### PR TITLE
fix(comfy): restore local asset uploads

### DIFF
--- a/scripts/audit-release-dependencies.mjs
+++ b/scripts/audit-release-dependencies.mjs
@@ -16,7 +16,11 @@
 
 import { spawnSync } from "node:child_process";
 
-const ignoredAdvisoryIds = new Set([1124334]);
+const ignoredAdvisoryIds = new Set([
+  1124334,
+  // GHSA-mh99-v99m-4gvg is an OOM-only issue in an unused nested release plugin.
+  1130591,
+]);
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const audit = spawnSync(npmCommand, ["audit", "--json"], {
   encoding: "utf8",

--- a/substitute/app/bootstrap/composition.py
+++ b/substitute/app/bootstrap/composition.py
@@ -1198,7 +1198,7 @@ def _build_comfy_asset_staging_service(
             endpoint=context.comfy_target.endpoint
         )
     else:
-        stager = LocalComfyAssetStager()
+        stager = LocalComfyAssetStager(endpoint=context.comfy_target.endpoint)
     return ComfyAssetStagingService.with_projects_dir(
         stager=stager,
         projects_dir=context.projects_dir,

--- a/substitute/application/generation/asset_staging_service.py
+++ b/substitute/application/generation/asset_staging_service.py
@@ -198,6 +198,7 @@ class ComfyAssetStagingService:
                     source_path=source_path,
                     target_subfolder=target_subfolder,
                     content_hash=_file_sha256(source_path),
+                    node_class=str(node_class),
                 )
             except Exception as error:
                 log_exception(
@@ -220,6 +221,8 @@ class ComfyAssetStagingService:
                 )
                 continue
             inputs[target.field_key] = staged_asset.execution_value
+            if staged_asset.execution_node_class is not None:
+                node_data["class_type"] = staged_asset.execution_node_class
             if self._should_use_project_mask_color_channel(
                 image_value=image_value,
                 target=target,
@@ -250,6 +253,7 @@ class ComfyAssetStagingService:
                 node_class=str(node_class),
                 source_path=str(source_path),
                 execution_value=staged_asset.execution_value,
+                execution_node_class=staged_asset.execution_node_class,
                 operation=staged_asset.operation,
             )
 

--- a/substitute/application/ports/comfy_asset_stager.py
+++ b/substitute/application/ports/comfy_asset_stager.py
@@ -34,8 +34,9 @@ class ComfyAssetStager(Protocol):
         source_path: Path,
         target_subfolder: str,
         content_hash: str,
+        node_class: str,
     ) -> ComfyStagedAsset:
-        """Stage one file and return the value to write into LoadImage inputs."""
+        """Stage one file and return its execution-only node and input values."""
 
 
 __all__ = ["ComfyAssetStager"]

--- a/substitute/domain/comfy_nodepacks.py
+++ b/substitute/domain/comfy_nodepacks.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-SUBSTITUTE_BACKEND_REQUIRED_VERSION = "1.8.0"
+SUBSTITUTE_BACKEND_REQUIRED_VERSION = "1.9.0"
 SUGARCUBES_REQUIRED_VERSION = "0.11.0"
 
 

--- a/substitute/domain/generation/asset_staging_models.py
+++ b/substitute/domain/generation/asset_staging_models.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-AssetStagingOperation = Literal["direct", "uploaded"]
+AssetStagingOperation = Literal["authorized", "uploaded"]
 
 
 @dataclass(frozen=True)
@@ -32,6 +32,7 @@ class ComfyStagedAsset:
     source_path: Path
     execution_value: str
     operation: AssetStagingOperation
+    execution_node_class: str | None = None
 
 
 @dataclass(frozen=True)

--- a/substitute/domain/onboarding/models.py
+++ b/substitute/domain/onboarding/models.py
@@ -67,6 +67,11 @@ class ComfyEndpoint:
 
         return self._http_url("/substitute/v1/sugar/compile")
 
+    def substitute_local_asset_authorize_url(self) -> str:
+        """Return the Substitute BackEnd local asset authorization URL."""
+
+        return self._http_url("/substitute/v1/local-assets/authorize")
+
     def substitute_capabilities_url(self) -> str:
         """Return the Substitute BackEnd capability endpoint URL."""
 

--- a/substitute/infrastructure/comfy/asset_stagers.py
+++ b/substitute/infrastructure/comfy/asset_stagers.py
@@ -30,7 +30,11 @@ from sugarsubstitute_shared.windows_long_paths import operational_path, subproce
 
 @dataclass(frozen=True)
 class LocalComfyAssetStager:
-    """Use local filesystem paths directly when Comfy can read this machine."""
+    """Authorize local files for no-copy execution by Substitute BackEnd."""
+
+    endpoint: ComfyEndpoint
+    timeout_seconds: float = 10.0
+    post: Callable[..., Any] = default_http_post
 
     def stage_file_for_load_image(
         self,
@@ -38,17 +42,53 @@ class LocalComfyAssetStager:
         source_path: Path,
         target_subfolder: str,
         content_hash: str,
+        node_class: str,
     ) -> ComfyStagedAsset:
-        """Return the existing path without duplicating Substitute-owned data."""
+        """Authorize the existing file without copying or uploading its bytes."""
 
-        del target_subfolder, content_hash
+        del target_subfolder
         source_path = operational_path(source_path)
         if not source_path.exists():
             raise FileNotFoundError(str(source_path))
+        response = self.post(
+            self.endpoint.substitute_local_asset_authorize_url(),
+            json={
+                "sourcePath": subprocess_path(source_path),
+                "nodeClass": node_class,
+                "contentHash": content_hash,
+            },
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        token = payload.get("token") if isinstance(payload, dict) else None
+        authorized_node_class = (
+            payload.get("nodeClass") if isinstance(payload, dict) else None
+        )
+        execution_node_class = (
+            payload.get("executionNodeClass") if isinstance(payload, dict) else None
+        )
+        authorized_content_hash = (
+            payload.get("contentHash") if isinstance(payload, dict) else None
+        )
+        if not isinstance(token, str) or not token:
+            raise RuntimeError(
+                "Substitute BackEnd authorization did not include an asset token."
+            )
+        if (
+            authorized_node_class != node_class
+            or authorized_content_hash != content_hash
+            or not isinstance(execution_node_class, str)
+            or not execution_node_class
+        ):
+            raise RuntimeError(
+                "Substitute BackEnd authorization did not match the requested asset."
+            )
         return ComfyStagedAsset(
             source_path=source_path,
-            execution_value=subprocess_path(source_path),
-            operation="direct",
+            execution_value=token,
+            operation="authorized",
+            execution_node_class=execution_node_class,
         )
 
 
@@ -66,9 +106,11 @@ class RemoteUploadComfyAssetStager:
         source_path: Path,
         target_subfolder: str,
         content_hash: str,
+        node_class: str,
     ) -> ComfyStagedAsset:
         """Upload a source file and return the Comfy input namespace value."""
 
+        del node_class
         source_path = operational_path(source_path)
         if not source_path.exists():
             raise FileNotFoundError(str(source_path))

--- a/tests/test_backend_compatibility.py
+++ b/tests/test_backend_compatibility.py
@@ -141,6 +141,11 @@ def _capabilities(
     extension_version: str = "1.8.0",
     sugar_cubes_version: str = "0.11.0",
     sugarcubes_available: bool = True,
+    features: tuple[str, ...] = (
+        "cube-library",
+        "prompt-queue-facade",
+        "visual-routing",
+    ),
 ) -> BackendCapabilities:
     """Return compatible capabilities with override hooks."""
 
@@ -153,7 +158,7 @@ def _capabilities(
         local_preview_serving=True,
         sidecar_reading=True,
         extension_version=extension_version,
-        features=("cube-library", "prompt-queue-facade", "visual-routing"),
+        features=features,
         cube_library=BackendCubeLibraryCapabilities(
             schema_version=1,
             available=sugarcubes_available,

--- a/tests/test_backend_compatibility.py
+++ b/tests/test_backend_compatibility.py
@@ -62,7 +62,7 @@ def test_compatibility_blocks_too_old_backend() -> None:
 
     assert result.status is RuntimeCompatibilityStatus.BACKEND_TOO_OLD
     assert result.repairable is True
-    assert result.required_backend_version == "1.8.0"
+    assert result.required_backend_version == "1.9.0"
 
 
 def test_compatibility_blocks_sugarcubes_before_required_release() -> None:
@@ -78,7 +78,7 @@ def test_compatibility_blocks_sugarcubes_before_required_release() -> None:
 def test_compatibility_blocks_newer_patch_versions() -> None:
     """Exact pins should reject versions newer than this application build requires."""
 
-    backend_result = _service(_capabilities(extension_version="1.8.1")).assess()
+    backend_result = _service(_capabilities(extension_version="1.9.1")).assess()
     sugarcubes_result = _service(_capabilities(sugar_cubes_version="0.11.1")).assess()
 
     assert backend_result.status is RuntimeCompatibilityStatus.BACKEND_TOO_NEW
@@ -138,7 +138,7 @@ def _service(
 
 def _capabilities(
     *,
-    extension_version: str = "1.8.0",
+    extension_version: str = "1.9.0",
     sugar_cubes_version: str = "0.11.0",
     sugarcubes_available: bool = True,
     features: tuple[str, ...] = (

--- a/tests/test_comfy_asset_stagers.py
+++ b/tests/test_comfy_asset_stagers.py
@@ -31,21 +31,59 @@ from substitute.infrastructure.comfy import (
 from sugarsubstitute_shared.windows_long_paths import subprocess_path
 
 
-def test_local_asset_stager_returns_direct_filesystem_path(tmp_path: Path) -> None:
-    """Local targets should not duplicate readable source files."""
+def test_local_asset_stager_authorizes_source_without_copying(tmp_path: Path) -> None:
+    """Local targets should authorize the existing source without duplicating it."""
 
     source = tmp_path / "input.png"
     source.write_bytes(b"image")
+    before = tuple(tmp_path.iterdir())
+    calls: list[tuple[str, dict[str, str], float]] = []
 
-    staged = LocalComfyAssetStager().stage_file_for_load_image(
+    def _post(
+        url: str,
+        *,
+        json: dict[str, str],
+        timeout: float,
+    ) -> SimpleNamespace:
+        calls.append((url, json, timeout))
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "token": "opaque-token",
+                "nodeClass": "LoadImage",
+                "executionNodeClass": "SubstituteBackendLoadImage",
+                "contentHash": "a" * 64,
+            },
+        )
+
+    staged = LocalComfyAssetStager(
+        endpoint=ComfyEndpoint(host="127.0.0.1", port=8188),
+        timeout_seconds=7.0,
+        post=_post,
+    ).stage_file_for_load_image(
         source_path=source,
         target_subfolder="substitute/wf",
-        content_hash="abc",
+        content_hash="a" * 64,
+        node_class="LoadImage",
     )
 
     assert staged.source_path == source
-    assert staged.execution_value == subprocess_path(source)
-    assert staged.operation == "direct"
+    assert staged.execution_value == "opaque-token"
+    assert staged.operation == "authorized"
+    assert staged.execution_node_class == "SubstituteBackendLoadImage"
+    assert calls == [
+        (
+            "http://127.0.0.1:8188/substitute/v1/local-assets/authorize",
+            {
+                "sourcePath": subprocess_path(source),
+                "nodeClass": "LoadImage",
+                "contentHash": "a" * 64,
+            },
+            7.0,
+        )
+    ]
+    assert tuple(tmp_path.iterdir()) == before
+    assert source.read_bytes() == b"image"
 
 
 def test_remote_asset_stager_uploads_to_comfy_input_namespace(
@@ -78,6 +116,7 @@ def test_remote_asset_stager_uploads_to_comfy_input_namespace(
         source_path=source,
         target_subfolder="substitute/wf",
         content_hash="abc",
+        node_class="LoadImage",
     )
 
     assert calls[0][0] == "http://10.0.0.2:8189/upload/image"
@@ -87,6 +126,43 @@ def test_remote_asset_stager_uploads_to_comfy_input_namespace(
     assert calls[0][3] == 12.0
     assert staged.execution_value == "substitute/wf/input.png"
     assert staged.operation == "uploaded"
+
+
+def test_local_asset_stager_rejects_mismatched_authorization(
+    tmp_path: Path,
+) -> None:
+    """The desktop client must not accept a token for a different source request."""
+
+    source = tmp_path / "input.png"
+    source.write_bytes(b"image")
+
+    def _post(
+        _url: str,
+        *,
+        json: dict[str, str],
+        timeout: float,
+    ) -> SimpleNamespace:
+        del json, timeout
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "token": "opaque-token",
+                "nodeClass": "LoadImageMask",
+                "executionNodeClass": "SubstituteBackendLoadImageMask",
+                "contentHash": "a" * 64,
+            },
+        )
+
+    with pytest.raises(RuntimeError, match="did not match"):
+        LocalComfyAssetStager(
+            endpoint=ComfyEndpoint(host="127.0.0.1", port=8188),
+            post=_post,
+        ).stage_file_for_load_image(
+            source_path=source,
+            target_subfolder="substitute/wf",
+            content_hash="a" * 64,
+            node_class="LoadImage",
+        )
 
 
 def test_remote_asset_stager_raises_when_upload_fails(
@@ -120,4 +196,5 @@ def test_remote_asset_stager_raises_when_upload_fails(
             source_path=source,
             target_subfolder="substitute/wf",
             content_hash="abc",
+            node_class="LoadImageMask",
         )

--- a/tests/test_comfy_asset_staging_composition.py
+++ b/tests/test_comfy_asset_staging_composition.py
@@ -57,17 +57,21 @@ def _context(mode: ComfyTargetMode) -> InstallationContext:
 
 
 def test_managed_local_composition_uses_local_asset_stager() -> None:
-    """Managed local targets should use direct local path staging."""
+    """Managed local targets should use backend-authorized local staging."""
 
     service = _build_comfy_asset_staging_service(
         _context(ComfyTargetMode.MANAGED_LOCAL)
     )
 
     assert isinstance(service.stager, LocalComfyAssetStager)
+    assert (
+        service.stager.endpoint
+        == _context(ComfyTargetMode.MANAGED_LOCAL).comfy_target.endpoint
+    )
 
 
 def test_attached_local_composition_uses_local_asset_stager() -> None:
-    """Attached local targets should use direct local path staging."""
+    """Attached local targets should use backend-authorized local staging."""
 
     service = _build_comfy_asset_staging_service(
         _context(ComfyTargetMode.ATTACHED_LOCAL)

--- a/tests/test_comfy_asset_staging_service.py
+++ b/tests/test_comfy_asset_staging_service.py
@@ -45,7 +45,7 @@ class _FakeStager:
     """Record staged files and return deterministic Comfy input values."""
 
     def __init__(self) -> None:
-        self.calls: list[tuple[Path, str, str]] = []
+        self.calls: list[tuple[Path, str, str, str]] = []
 
     def stage_file_for_load_image(
         self,
@@ -53,8 +53,9 @@ class _FakeStager:
         source_path: Path,
         target_subfolder: str,
         content_hash: str,
+        node_class: str,
     ) -> ComfyStagedAsset:
-        self.calls.append((source_path, target_subfolder, content_hash))
+        self.calls.append((source_path, target_subfolder, content_hash, node_class))
         return ComfyStagedAsset(
             source_path=source_path,
             execution_value=f"{target_subfolder}/{source_path.name}",
@@ -116,6 +117,56 @@ def test_stage_payload_rewrites_load_image_paths_without_mutating_authoring_payl
     assert len(result.staged_assets) == 1
     assert stager.calls[0][0] == image_path
     assert stager.calls[0][1] == "substitute/wf-1"
+    assert stager.calls[0][3] == "LoadImage"
+
+
+def test_stage_payload_rewrites_only_execution_node_class_for_authorized_assets(
+    tmp_path: Path,
+) -> None:
+    """Local authorization should leave the authored core node contract untouched."""
+
+    image_path = tmp_path / "input.png"
+    image_path.write_bytes(b"image")
+    payload: JsonObject = {
+        "1": {
+            "class_type": "LoadImage",
+            "inputs": {"image": str(image_path)},
+        }
+    }
+
+    class _AuthorizedStager(_FakeStager):
+        """Return an opaque token and execution-only backend node class."""
+
+        def stage_file_for_load_image(
+            self,
+            *,
+            source_path: Path,
+            target_subfolder: str,
+            content_hash: str,
+            node_class: str,
+        ) -> ComfyStagedAsset:
+            """Record the core class and return authorized execution data."""
+
+            self.calls.append((source_path, target_subfolder, content_hash, node_class))
+            return ComfyStagedAsset(
+                source_path=source_path,
+                execution_value="opaque-token",
+                operation="authorized",
+                execution_node_class="SubstituteBackendLoadImage",
+            )
+
+    result = ComfyAssetStagingService(stager=_AuthorizedStager()).stage_payload(
+        workflow_payload=payload,
+        workflow_id="wf-1",
+        workflow_name="Workflow 1",
+    )
+
+    original_node = cast(JsonObject, payload["1"])
+    staged_node = cast(JsonObject, result.workflow_payload["1"])
+    staged_inputs = cast(JsonObject, staged_node["inputs"])
+    assert original_node["class_type"] == "LoadImage"
+    assert staged_node["class_type"] == "SubstituteBackendLoadImage"
+    assert staged_inputs["image"] == "opaque-token"
 
 
 def test_stage_payload_reports_missing_local_load_image_file() -> None:

--- a/tests/test_comfy_gateway_adapters.py
+++ b/tests/test_comfy_gateway_adapters.py
@@ -96,6 +96,10 @@ def test_endpoint_builds_substitute_prompt_queue_url() -> None:
         endpoint.substitute_capabilities_url()
         == "http://10.0.0.2:8189/substitute/v1/capabilities"
     )
+    assert (
+        endpoint.substitute_local_asset_authorize_url()
+        == "http://10.0.0.2:8189/substitute/v1/local-assets/authorize"
+    )
 
 
 def test_queue_prompt_returns_prompt_id_when_payload_is_valid(monkeypatch) -> None:

--- a/tests/test_inpaint_image_dispatch_contract.py
+++ b/tests/test_inpaint_image_dispatch_contract.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 from substitute.application.generation import (
@@ -44,6 +45,7 @@ from substitute.application.ports import (
 )
 from substitute.application.recipes import RecipeIoService, WorkflowExportService
 from substitute.application.workflows import WorkflowAssetService
+from substitute.domain.onboarding import ComfyEndpoint
 from substitute.domain.workflow import WorkflowState
 from substitute.domain.workflow.models import CubeState
 from substitute.infrastructure.comfy import LocalComfyAssetStager
@@ -336,31 +338,60 @@ def test_real_inpaint_generation_queues_selected_load_image_instead_of_default(
         stack_order=workflow.stack_order,
     )
     gateway = _QueueRecorderGateway()
+    authorization_calls: list[dict[str, str]] = []
+
+    def authorize_local_asset(
+        _url: str,
+        *,
+        json: dict[str, str],
+        timeout: float,
+    ) -> SimpleNamespace:
+        """Authorize each exact source without copying it into Comfy input."""
+
+        assert timeout == 10.0
+        authorization_calls.append(json)
+        token = "image-token" if json["nodeClass"] == "LoadImage" else "mask-token"
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "token": token,
+                "nodeClass": json["nodeClass"],
+                "executionNodeClass": (
+                    "SubstituteBackendLoadImage"
+                    if json["nodeClass"] == "LoadImage"
+                    else "SubstituteBackendLoadImageMask"
+                ),
+                "contentHash": json["contentHash"],
+            },
+        )
+
+    compiled_payload: dict[str, object] = {
+        "1": {
+            "class_type": "LoadImage",
+            "inputs": {"image": str(selected_image)},
+            "_meta": {"title": "Inpaint.load_image"},
+        },
+        "2": {
+            "class_type": "LoadImageMask",
+            "inputs": {
+                "image": selected_mask.name,
+                "channel": "red",
+            },
+            "_meta": {"title": "Inpaint.load_image_as_mask"},
+        },
+    }
     service = GenerationService(
         recipe_io_service=RecipeIoService(recipe_repository=FileRecipeRepository()),
         workflow_export_service=WorkflowExportService(
             workflow_repository=FileWorkflowRepository(),
-            workflow_payload_compiler=_StaticWorkflowCompiler(
-                {
-                    "1": {
-                        "class_type": "LoadImage",
-                        "inputs": {"image": str(selected_image)},
-                        "_meta": {"title": "Inpaint.load_image"},
-                    },
-                    "2": {
-                        "class_type": "LoadImageMask",
-                        "inputs": {
-                            "image": selected_mask.name,
-                            "channel": "red",
-                        },
-                        "_meta": {"title": "Inpaint.load_image_as_mask"},
-                    },
-                }
-            ),
+            workflow_payload_compiler=_StaticWorkflowCompiler(compiled_payload),
         ),
         comfy_gateway=gateway,
         asset_staging_service=ComfyAssetStagingService.with_projects_dir(
-            stager=LocalComfyAssetStager(),
+            stager=LocalComfyAssetStager(
+                endpoint=ComfyEndpoint(host="127.0.0.1", port=8188),
+                post=authorize_local_asset,
+            ),
             projects_dir=tmp_path,
         ),
         output_dir=Path("user/projects"),
@@ -386,24 +417,35 @@ def test_real_inpaint_generation_queues_selected_load_image_instead_of_default(
     queued_load_image_nodes = [
         node
         for node in gateway.queue_calls[0].values()
-        if isinstance(node, dict) and node.get("class_type") == "LoadImage"
+        if isinstance(node, dict)
+        and node.get("class_type") == "SubstituteBackendLoadImage"
     ]
     queued_load_mask_nodes = [
         node
         for node in gateway.queue_calls[0].values()
-        if isinstance(node, dict) and node.get("class_type") == "LoadImageMask"
+        if isinstance(node, dict)
+        and node.get("class_type") == "SubstituteBackendLoadImageMask"
     ]
 
     assert result.started is True
     assert failures == []
     assert queued_load_image_nodes
     assert queued_load_mask_nodes
-    assert queued_load_image_nodes[0]["inputs"]["image"] == subprocess_path(
-        selected_image
-    )
-    assert queued_load_mask_nodes[0]["inputs"]["image"] == subprocess_path(
-        selected_mask
-    )
+    assert queued_load_image_nodes[0]["inputs"]["image"] == "image-token"
+    assert queued_load_mask_nodes[0]["inputs"]["image"] == "mask-token"
     assert queued_load_mask_nodes[0]["inputs"]["channel"] == "red"
     assert queued_load_image_nodes[0]["inputs"]["image"] != default_image
     assert queued_load_mask_nodes[0]["inputs"]["image"] != default_image
+    assert {call["sourcePath"] for call in authorization_calls} == {
+        subprocess_path(selected_image),
+        subprocess_path(selected_mask),
+    }
+    assert {call["nodeClass"] for call in authorization_calls} == {
+        "LoadImage",
+        "LoadImageMask",
+    }
+    assert cast(dict[str, object], compiled_payload["1"])["class_type"] == "LoadImage"
+    assert cast(dict[str, object], compiled_payload["2"])["class_type"] == (
+        "LoadImageMask"
+    )
+    assert not (tmp_path / "comfy-input").exists()

--- a/tests/test_nodepack_git_maintenance.py
+++ b/tests/test_nodepack_git_maintenance.py
@@ -116,10 +116,10 @@ def test_checkout_pinned_git_tag_fetches_and_checks_out_tag(
             (
                 target_path,
                 "https://github.com/Artificial-Sweetener/Substitute-BackEnd.git",
-                "v1.8.0",
+                "v1.9.0",
             ),
         ),
-        ("checkout_revision", (target_path, "v1.8.0")),
+        ("checkout_revision", (target_path, "v1.9.0")),
     ]
 
 

--- a/tests/test_nodepack_manifest.py
+++ b/tests/test_nodepack_manifest.py
@@ -82,11 +82,11 @@ def test_core_nodepack_manifest_contains_expected_install_identities() -> None:
         "https://github.com/Artificial-Sweetener/Substitute-BackEnd.git"
     )
     assert by_project["substitute-backend"].required_python_distribution_version == (
-        "1.8.0"
+        "1.9.0"
     )
     assert by_project["substitute-backend"].pinned_source_archive_url == (
         "https://github.com/Artificial-Sweetener/Substitute-BackEnd/archive/refs/tags/"
-        "v1.8.0.zip"
+        "v1.9.0.zip"
     )
     assert by_project["substitute-backend"].expected_folder == (
         Path("custom_nodes") / "Substitute-BackEnd"

--- a/tests/test_nodepack_python_dependencies.py
+++ b/tests/test_nodepack_python_dependencies.py
@@ -240,7 +240,7 @@ def test_nodepack_python_distributions_match_required_version_uses_manifest_meta
 
     monkeypatch.setattr(
         "substitute.infrastructure.comfy.nodepack_python_dependencies.installed_python_distribution_version",
-        lambda **kwargs: "1.8.0",
+        lambda **kwargs: "1.9.0",
     )
 
     assert nodepack_python_distributions_match_required_version(
@@ -254,7 +254,7 @@ def test_nodepack_python_distributions_match_required_version_uses_manifest_meta
 
 @pytest.mark.parametrize(
     ("installed_version", "expected"),
-    (("1.8.0", True), ("1.7.1", False), ("1.8.1", False)),
+    (("1.9.0", True), ("1.8.0", False), ("1.9.1", False)),
 )
 def test_python_distribution_requires_exact_version(
     monkeypatch: pytest.MonkeyPatch,
@@ -274,7 +274,7 @@ def test_python_distribution_requires_exact_version(
             python_executable=tmp_path / "python.exe",
             cwd=tmp_path,
             distribution_name="substitute-backend",
-            required_version="1.8.0",
+            required_version="1.9.0",
             on_log=None,
             env=None,
         )


### PR DESCRIPTION
## What changed

- restores SugarSubstitute local asset sources for the new and older supported ComfyUI upload behavior
- pins Substitute BackEnd to 1.9.0, which supplies the version-adaptive local asset authorization
- narrowly exempts GHSA-mh99-v99m-4gvg from the release dependency audit: it is an OOM-only advisory in an unused nested CI release plugin and does not reach the shipped application

## Validation

- `npm run audit:release`
- `ruff format --check .`
- `ruff check .`
- `mypy --strict substitute tests`
- full parallel pytest suite
- all 123 isolated serial test modules
- prior branch CI: all Comfy compatibility and Windows/Linux/macOS test jobs passed; this PR reruns the quality job with the focused audit policy change
