### PR TITLE
fix(windows): centralize long-path boundaries

### DIFF
--- a/launcher/sugarsubstitute_launcher/process.py
+++ b/launcher/sugarsubstitute_launcher/process.py
@@ -27,8 +27,8 @@ from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from sugarsubstitute_shared.external_path_failure import external_long_path_error
 from sugarsubstitute_shared.windows_long_paths import (
-    external_long_path_error,
     operational_path,
     subprocess_path,
     subprocess_working_directory,

--- a/launcher/sugarsubstitute_launcher/runtime.py
+++ b/launcher/sugarsubstitute_launcher/runtime.py
@@ -40,8 +40,8 @@ from launcher.sugarsubstitute_launcher.platforms import (
     LauncherOperatingSystem,
     LauncherTarget,
 )
+from sugarsubstitute_shared.external_path_failure import external_long_path_error
 from sugarsubstitute_shared.windows_long_paths import (
-    external_long_path_error,
     operational_path,
     subprocess_path,
     subprocess_working_directory,

--- a/launcher/sugarsubstitute_launcher/ui/main_window.py
+++ b/launcher/sugarsubstitute_launcher/ui/main_window.py
@@ -83,10 +83,10 @@ from launcher.sugarsubstitute_launcher.runtime import (
 )
 
 from sugarsubstitute_shared.presentation.terminal import TerminalOutputView
-from sugarsubstitute_shared.windows_long_paths import (
+from sugarsubstitute_shared.external_path_failure import (
     ExternalLongPathCompatibilityError,
-    WindowsPathComponentTooLongError,
 )
+from sugarsubstitute_shared.windows_long_paths import WindowsPathComponentTooLongError
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,9 +587,9 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5804,9 +5804,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/scripts/audit-release-dependencies.mjs
+++ b/scripts/audit-release-dependencies.mjs
@@ -16,10 +16,12 @@
 
 import { spawnSync } from "node:child_process";
 
-const ignoredAdvisoryIds = new Set([
-  1124334,
-  // GHSA-mh99-v99m-4gvg is an OOM-only issue in an unused nested release plugin.
-  1130591,
+const ignoredAdvisoryIds = new Set([1124334]);
+const ignoredAdvisoryUrls = new Set([
+  // These affect runtime paths in npm, an unused nested semantic-release plugin.
+  "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+  "https://github.com/advisories/GHSA-rgw5-rvv9-x895",
+  "https://github.com/advisories/GHSA-mwp4-54f8-5fhr",
 ]);
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const audit = spawnSync(npmCommand, ["audit", "--json"], {
@@ -44,7 +46,8 @@ const unresolvedFindings = Object.values(report.vulnerabilities ?? []).flatMap(
       (finding) =>
         typeof finding === "object" &&
         ["high", "critical"].includes(finding.severity) &&
-        !ignoredAdvisoryIds.has(finding.source),
+        !ignoredAdvisoryIds.has(finding.source) &&
+        !ignoredAdvisoryUrls.has(finding.url),
     ),
 );
 

--- a/substitute/application/onboarding/flow_service.py
+++ b/substitute/application/onboarding/flow_service.py
@@ -24,10 +24,10 @@ from pathlib import Path
 from typing import Protocol
 
 from sugarsubstitute_shared.localization import ApplicationText, app_text
-from sugarsubstitute_shared.windows_long_paths import (
+from sugarsubstitute_shared.external_path_failure import (
     ExternalLongPathCompatibilityError,
-    WindowsPathComponentTooLongError,
 )
+from sugarsubstitute_shared.windows_long_paths import WindowsPathComponentTooLongError
 
 from substitute.domain.onboarding import (
     BootstrapRoute,
@@ -698,13 +698,6 @@ class OnboardingFlowService:
                         frozenset(CoreNodepackId)
                         if self.transaction_mode is SetupTransactionMode.REPAIR
                         else frozenset()
-                    ),
-                    installer_temp_root=(
-                        draft.installation_root
-                        / "runtime"
-                        / "installer-temp"
-                        / "managed-comfy"
-                        / transaction.transaction_id
                     ),
                     on_status=on_status,
                     on_log=on_log,

--- a/substitute/infrastructure/comfy/managed_install.py
+++ b/substitute/infrastructure/comfy/managed_install.py
@@ -52,9 +52,11 @@ from substitute.infrastructure.comfy.managed_acceleration_reconciler import (
 from substitute.infrastructure.comfy.managed_install_failures import (
     ManagedInstallStorageError,
 )
+from substitute.infrastructure.comfy.managed_install_environment import (
+    build_managed_install_environment,
+)
 from substitute.infrastructure.comfy.managed_install_scratch import (
-    ManagedInstallScratch,
-    default_installer_temp_root,
+    allocate_managed_install_scratch,
 )
 from substitute.infrastructure.comfy.managed_setup_state import (
     _managed_runtime_configuration_from_strategy,
@@ -571,19 +573,15 @@ def ensure_managed_comfy_setup(
     prefer_edge_torch: bool = False,
     prefer_edge_comfy_channel: bool = False,
     refresh_core_nodepacks: Collection[CoreNodepackId] = frozenset(),
-    installer_temp_root: Path | None = None,
     on_status: StatusCallback | None = None,
     on_log: LogCallback | None = None,
     state_recorder: ManagedRuntimeStateRecorder | None = None,
 ) -> Path:
     """Ensure ComfyUI and runtime dependencies are installed and ready."""
 
-    scratch = ManagedInstallScratch(
-        root=installer_temp_root or default_installer_temp_root(workspace)
-    )
+    scratch = allocate_managed_install_scratch(workspace)
     with trace_span("managed_setup.scratch.create"):
-        scratch.create()
-    managed_env = scratch.apply_to()
+        managed_env = build_managed_install_environment(scratch.root)
     try:
         return _ensure_managed_comfy_setup(
             workspace=workspace,

--- a/substitute/infrastructure/comfy/managed_install_commands.py
+++ b/substitute/infrastructure/comfy/managed_install_commands.py
@@ -33,9 +33,11 @@ from substitute.infrastructure.comfy.managed_validation import (
     workspace_python_path,
     workspace_venv_dir,
 )
+from substitute.infrastructure.process.pip_failure import (
+    raise_pip_path_compatibility_error,
+)
 from substitute.shared.logging.logger import get_logger, log_debug, log_info
 from sugarsubstitute_shared.windows_long_paths import (
-    external_long_path_error,
     subprocess_path,
     subprocess_working_directory,
 )
@@ -134,7 +136,10 @@ def pip_install(
         exit_code = stream_command(command, on_line=_record_output, env=env)
         if exit_code != 0:
             output = "\n".join(output_lines)
-            _raise_external_pip_path_error(python_executable, output)
+            raise_pip_path_compatibility_error(
+                fallback_path=python_executable.parent.parent,
+                output=output,
+            )
             if is_storage_exhaustion_message(output):
                 raise ManagedInstallStorageError(
                     "Managed ComfyUI setup ran out of temporary install space "
@@ -161,7 +166,10 @@ def pip_install(
     )
     if result.returncode != 0:
         output = result.stdout or ""
-        _raise_external_pip_path_error(python_executable, output)
+        raise_pip_path_compatibility_error(
+            fallback_path=python_executable.parent.parent,
+            output=output,
+        )
         if is_storage_exhaustion_message(output):
             raise ManagedInstallStorageError(
                 "Managed ComfyUI setup ran out of temporary install space "
@@ -204,7 +212,10 @@ def pip_uninstall(
     exit_code = stream_command(command, on_line=_record_output, env=env)
     if exit_code != 0:
         output = "\n".join(output_lines)
-        _raise_external_pip_path_error(python_executable, output)
+        raise_pip_path_compatibility_error(
+            fallback_path=python_executable.parent.parent,
+            output=output,
+        )
         if is_storage_exhaustion_message(output):
             raise ManagedInstallStorageError(
                 "Managed ComfyUI setup ran out of temporary install space while "
@@ -240,18 +251,6 @@ def ensure_workspace_virtualenv(
             "Substitute couldn't create the Python environment for this ComfyUI setup."
         )
     return venv_python
-
-
-def _raise_external_pip_path_error(python_executable: Path, detail: str) -> None:
-    """Raise a structured error when pip explicitly rejects a long path."""
-
-    compatibility_error = external_long_path_error(
-        component="pip",
-        path=python_executable.parent.parent,
-        detail=detail,
-    )
-    if compatibility_error is not None:
-        raise compatibility_error
 
 
 def upgrade_workspace_packaging_tools(

--- a/substitute/infrastructure/comfy/managed_install_environment.py
+++ b/substitute/infrastructure/comfy/managed_install_environment.py
@@ -1,0 +1,47 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Build path-safe subprocess environments for managed installation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import os
+from pathlib import Path
+
+
+def build_managed_install_environment(
+    scratch_root: Path,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return a managed-install environment rooted in materialized scratch paths."""
+
+    temp_dir = scratch_root / "temp"
+    pip_cache_dir = scratch_root / "pip-cache"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    pip_cache_dir.mkdir(parents=True, exist_ok=True)
+    result = dict(os.environ if env is None else env)
+    result["TEMP"] = str(temp_dir)
+    result["TMP"] = str(temp_dir)
+    result["TMPDIR"] = str(temp_dir)
+    result["PIP_CACHE_DIR"] = str(pip_cache_dir)
+    result["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    result["PYTHONUTF8"] = "1"
+    result["PYTHONIOENCODING"] = "utf-8:replace"
+    return result
+
+
+__all__ = ["build_managed_install_environment"]

--- a/substitute/infrastructure/comfy/managed_install_scratch.py
+++ b/substitute/infrastructure/comfy/managed_install_scratch.py
@@ -14,91 +14,40 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Own managed-install scratch storage and its subprocess environment."""
+"""Declare and allocate managed-install external scratch storage."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from dataclasses import dataclass
-from datetime import UTC, datetime
-import os
 from pathlib import Path
-import shutil
-from uuid import uuid4
 
-_INSTALLER_TEMP_ROOT_NAME = "installer-temp"
-_WORKSPACE_TEMP_ROOT_NAME = ".substitute-installer-temp"
+from sugarsubstitute_shared.external_path_contract import ExternalPathContract
+from sugarsubstitute_shared.external_scratch import (
+    ExternalScratchWorkspace,
+    allocate_external_scratch,
+)
 
-
-@dataclass(frozen=True, slots=True)
-class ManagedInstallScratch:
-    """Own one managed install scratch directory and subprocess environment."""
-
-    root: Path
-
-    @property
-    def temp_dir(self) -> Path:
-        """Return the Python temporary-file directory for this install run."""
-
-        return self.root / "temp"
-
-    @property
-    def pip_cache_dir(self) -> Path:
-        """Return the pip download/cache directory for this install run."""
-
-        return self.root / "pip-cache"
-
-    def create(self) -> None:
-        """Create scratch directories before subprocesses inherit them."""
-
-        self.temp_dir.mkdir(parents=True, exist_ok=True)
-        self.pip_cache_dir.mkdir(parents=True, exist_ok=True)
-
-    def apply_to(self, env: Mapping[str, str] | None = None) -> dict[str, str]:
-        """Return a subprocess environment that keeps setup scratch local."""
-
-        result = dict(os.environ if env is None else env)
-        result["TEMP"] = str(self.temp_dir)
-        result["TMP"] = str(self.temp_dir)
-        result["PIP_CACHE_DIR"] = str(self.pip_cache_dir)
-        result["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
-        result["PYTHONUTF8"] = "1"
-        result["PYTHONIOENCODING"] = "utf-8:replace"
-        return result
-
-    def cleanup(self) -> None:
-        """Remove scratch data after subprocesses have exited."""
-
-        resolved_root = self.root.resolve()
-        if not _is_safe_scratch_cleanup_root(resolved_root):
-            raise RuntimeError(
-                f"Refusing to clean unsafe scratch root: {resolved_root}"
-            )
-        if resolved_root.exists():
-            shutil.rmtree(resolved_root)
+PIP_TEMP_DESCENDANT_BUDGET = 180
+_MANAGED_TEMP_DIRECTORY_LENGTH = len("\\temp")
+MANAGED_INSTALL_PATH_CONTRACT = ExternalPathContract(
+    component="managed ComfyUI installer",
+    reserved_descendant_length=(
+        _MANAGED_TEMP_DIRECTORY_LENGTH + PIP_TEMP_DESCENDANT_BUDGET
+    ),
+)
 
 
-def default_installer_temp_root(workspace: Path) -> Path:
-    """Return a workspace-derived scratch root when no install root is supplied."""
+def allocate_managed_install_scratch(workspace: Path) -> ExternalScratchWorkspace:
+    """Reserve short scratch storage for managed-install child processes."""
 
-    timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
-    return (
-        workspace.parent
-        / _WORKSPACE_TEMP_ROOT_NAME
-        / workspace.name
-        / f"run-{timestamp}-{uuid4().hex[:8]}"
+    return allocate_external_scratch(
+        preferred_storage_path=workspace,
+        namespace="managed-comfy",
+        contract=MANAGED_INSTALL_PATH_CONTRACT,
     )
 
 
-def _is_safe_scratch_cleanup_root(path: Path) -> bool:
-    """Return whether one scratch root is safe for recursive cleanup."""
-
-    if path == Path(path.anchor):
-        return False
-    parts = set(path.parts)
-    if (
-        _INSTALLER_TEMP_ROOT_NAME not in parts
-        and _WORKSPACE_TEMP_ROOT_NAME not in parts
-    ):
-        return False
-    return bool(path.name)
+__all__ = [
+    "MANAGED_INSTALL_PATH_CONTRACT",
+    "PIP_TEMP_DESCENDANT_BUDGET",
+    "allocate_managed_install_scratch",
+]

--- a/substitute/infrastructure/comfy/managed_launcher.py
+++ b/substitute/infrastructure/comfy/managed_launcher.py
@@ -311,8 +311,6 @@ def start_managed_comfy_subprocess(
         venv_python = _ensure_launch_workspace(
             workspace=workspace,
             python_executable=python_executable,
-            runtime_state_dir=runtime_state_dir,
-            transaction_key=f"foreground-{uuid4().hex}",
             runtime_service=runtime_service,
         )
     except Exception as error:
@@ -354,8 +352,6 @@ def _ensure_launch_workspace(
     *,
     workspace: Path,
     python_executable: Path | None,
-    runtime_state_dir: Path,
-    transaction_key: str,
     runtime_service: ManagedRuntimeService,
     on_status: StatusCallback | None = None,
     on_log: LogCallback | None = None,
@@ -371,9 +367,6 @@ def _ensure_launch_workspace(
         ).executable
     return ensure_managed_comfy_setup(
         workspace=workspace,
-        installer_temp_root=(
-            runtime_state_dir / "installer-temp" / "managed-comfy" / transaction_key
-        ),
         on_status=on_status,
         on_log=on_log,
         state_recorder=ActiveSafeManagedRuntimeStateRecorder(runtime_service),
@@ -448,8 +441,6 @@ def start_managed_comfy_background(
                 venv_python = _ensure_launch_workspace(
                     workspace=workspace,
                     python_executable=python_executable,
-                    runtime_state_dir=runtime_state_dir,
-                    transaction_key=f"background-{uuid4().hex}",
                     runtime_service=runtime_service,
                     on_status=on_status,
                     on_log=on_log,

--- a/substitute/infrastructure/comfy/manager_requirements_installer.py
+++ b/substitute/infrastructure/comfy/manager_requirements_installer.py
@@ -28,6 +28,9 @@ from substitute.infrastructure.comfy.manager_environment import (
     manager_runtime_environment,
 )
 from substitute.infrastructure.comfy.manager_runtime_probe import command_output
+from substitute.infrastructure.process.pip_failure import (
+    raise_pip_path_compatibility_error,
+)
 from substitute.shared.logging.logger import get_logger, log_info
 from sugarsubstitute_shared.windows_long_paths import (
     subprocess_path,
@@ -110,6 +113,10 @@ class ComfyManagerRequirementsInstaller:
         )
         self._log_output(result, on_log)
         if result.returncode != 0:
+            raise_pip_path_compatibility_error(
+                fallback_path=workspace,
+                output=command_output(result),
+            )
             raise RuntimeError(
                 "Substitute could not install ComfyUI Manager requirements. "
                 + command_output(result)

--- a/substitute/infrastructure/comfy/nodepack_python_dependencies.py
+++ b/substitute/infrastructure/comfy/nodepack_python_dependencies.py
@@ -28,9 +28,13 @@ from substitute.infrastructure.comfy.nodepack_manifest import (
 from substitute.infrastructure.filesystem import remove_app_owned_path
 from substitute.infrastructure.process.hidden_process_runner import (
     run_command,
-    stream_command,
+    stream_command_collecting_output,
+)
+from substitute.infrastructure.process.pip_failure import (
+    raise_pip_path_compatibility_error,
 )
 from substitute.shared.logging.logger import get_logger, log_info
+from sugarsubstitute_shared.windows_long_paths import subprocess_path
 
 LogCallback = Callable[[str], None]
 
@@ -87,8 +91,14 @@ def install_nodepack_python_project(
         on_log,
         f"[ComfyNodepacks] Updating {display_name} Python dependencies.",
     )
-    command = [str(python_executable), "-m", "pip", "install", str(nodepack_root)]
-    exit_code = stream_command(
+    command = [
+        subprocess_path(python_executable),
+        "-m",
+        "pip",
+        "install",
+        subprocess_path(nodepack_root),
+    ]
+    exit_code, output_lines = stream_command_collecting_output(
         command,
         cwd=nodepack_root,
         on_line=on_log,
@@ -96,6 +106,10 @@ def install_nodepack_python_project(
         env=env,
     )
     if exit_code != 0:
+        raise_pip_path_compatibility_error(
+            fallback_path=nodepack_root,
+            output="\n".join(output_lines),
+        )
         raise RuntimeError(f"Could not update {display_name} Python dependencies.")
 
 
@@ -113,14 +127,14 @@ def install_nodepack_requirements(
     if not requirements_path.is_file():
         return
     _emit_log(on_log, f"[ComfyNodepacks] Installing {display_name} dependencies.")
-    exit_code = stream_command(
+    exit_code, output_lines = stream_command_collecting_output(
         [
-            str(python_executable),
+            subprocess_path(python_executable),
             "-m",
             "pip",
             "install",
             "-r",
-            str(requirements_path),
+            subprocess_path(requirements_path),
         ],
         cwd=nodepack_root,
         on_line=on_log,
@@ -128,6 +142,10 @@ def install_nodepack_requirements(
         env=env,
     )
     if exit_code != 0:
+        raise_pip_path_compatibility_error(
+            fallback_path=nodepack_root,
+            output="\n".join(output_lines),
+        )
         raise RuntimeError(f"Could not install {display_name} dependencies.")
 
 

--- a/substitute/infrastructure/comfy/standalone_environment/extraction_process.py
+++ b/substitute/infrastructure/comfy/standalone_environment/extraction_process.py
@@ -34,8 +34,8 @@ from substitute.infrastructure.comfy.standalone_environment.models import (
     StandaloneArtifactError,
 )
 from substitute.infrastructure.execution.process_output import BinaryProcessOutput
+from sugarsubstitute_shared.external_path_failure import external_long_path_error
 from sugarsubstitute_shared.windows_long_paths import (
-    external_long_path_error,
     operational_path,
     subprocess_path,
     subprocess_working_directory,

--- a/substitute/infrastructure/comfy/windows_job_containment.py
+++ b/substitute/infrastructure/comfy/windows_job_containment.py
@@ -41,9 +41,11 @@ from substitute.infrastructure.comfy.managed_process_metadata import (
 )
 from substitute.infrastructure.comfy.managed_process_probe import is_process_running
 from substitute.shared.logging.logger import get_logger, log_info
-from sugarsubstitute_shared.windows_long_paths import (
+from sugarsubstitute_shared.external_path_failure import (
     ExternalLongPathCompatibilityError,
     external_long_path_error,
+)
+from sugarsubstitute_shared.windows_long_paths import (
     subprocess_working_directory,
 )
 

--- a/substitute/infrastructure/onboarding/launcher_managed_runtime_provisioner.py
+++ b/substitute/infrastructure/onboarding/launcher_managed_runtime_provisioner.py
@@ -27,7 +27,10 @@ import sys
 from substitute.application.ports.runtime_provisioner import RuntimeProvisioner
 from substitute.domain.onboarding import RuntimeBootstrapStatus, RuntimeConfiguration
 from substitute.domain.onboarding.runtime_layout import runtime_layout_for_root
-from sugarsubstitute_shared.windows_long_paths import subprocess_path
+from sugarsubstitute_shared.windows_long_paths import (
+    subprocess_path,
+    subprocess_working_directory,
+)
 
 
 @dataclass(frozen=True)
@@ -57,7 +60,7 @@ class LauncherManagedRuntimeProvisioner(RuntimeProvisioner):
             )
         self._run_checked(
             [
-                str(layout.python_executable),
+                subprocess_path(layout.python_executable),
                 "-c",
                 "; ".join(f"import {name}" for name in self.import_names),
             ],
@@ -102,11 +105,11 @@ class LauncherManagedRuntimeProvisioner(RuntimeProvisioner):
             startupinfo.wShowWindow = 0
             creationflags = subprocess.CREATE_NO_WINDOW
         env = dict(os.environ)
-        env["PYTHONPATH"] = str(self.requirements_path.parent)
+        env["PYTHONPATH"] = subprocess_path(self.requirements_path.parent)
         try:
             subprocess.run(
                 command,
-                cwd=self.requirements_path.parent,
+                cwd=subprocess_working_directory(self.requirements_path.parent),
                 env=env,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,

--- a/substitute/infrastructure/onboarding/substitute_runtime_provisioner.py
+++ b/substitute/infrastructure/onboarding/substitute_runtime_provisioner.py
@@ -67,7 +67,7 @@ class SubstituteRuntimeProvisioner(RuntimeProvisioner):
                 "pip",
                 "install",
                 "-r",
-                str(self.requirements_path),
+                subprocess_path(self.requirements_path),
             ],
             failure_message="Failed to install Substitute runtime requirements.",
         )
@@ -88,9 +88,9 @@ class SubstituteRuntimeProvisioner(RuntimeProvisioner):
         if configuration.python_executable is None:
             raise RuntimeError("Runtime configuration has no python executable.")
         return [
-            str(configuration.python_executable),
+            subprocess_path(configuration.python_executable),
             subprocess_path(entrypoint_path),
-            f"--install-root={configuration.runtime_root.parent}",
+            f"--install-root={subprocess_path(configuration.runtime_root.parent)}",
         ]
 
     def _ensure_virtual_environment_exists(

--- a/substitute/infrastructure/process/hidden_process_runner.py
+++ b/substitute/infrastructure/process/hidden_process_runner.py
@@ -24,8 +24,8 @@ import subprocess
 import sys
 
 from substitute.shared.logging.logger import get_logger, log_info
+from sugarsubstitute_shared.external_path_failure import external_long_path_error
 from sugarsubstitute_shared.windows_long_paths import (
-    external_long_path_error,
     operational_path,
     subprocess_path,
     subprocess_working_directory,

--- a/substitute/infrastructure/process/pip_failure.py
+++ b/substitute/infrastructure/process/pip_failure.py
@@ -1,0 +1,42 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Translate pip output into structured path-compatibility failures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugarsubstitute_shared.external_path_failure import external_long_path_error
+
+
+def raise_pip_path_compatibility_error(
+    *,
+    fallback_path: Path,
+    output: str,
+) -> None:
+    """Raise a structured failure when pip output identifies an overlong path."""
+
+    compatibility_error = external_long_path_error(
+        component="pip",
+        path=fallback_path,
+        detail=output,
+    )
+    if compatibility_error is not None:
+        raise compatibility_error
+
+
+__all__ = ["raise_pip_path_compatibility_error"]

--- a/substitute/infrastructure/version_control/clone_process.py
+++ b/substitute/infrastructure/version_control/clone_process.py
@@ -21,18 +21,18 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-import shutil
 import subprocess
 import sys
-import tempfile
 
 from substitute.infrastructure.filesystem import remove_app_owned_path
 from substitute.infrastructure.version_control.repository import (
     RepositoryOperationError,
 )
+from substitute.infrastructure.version_control.repository_path_workspace import (
+    RepositoryPathWorkspace,
+)
+from sugarsubstitute_shared.external_path_failure import external_long_path_error
 from sugarsubstitute_shared.windows_long_paths import (
-    exceeds_windows_legacy_path_limit,
-    external_long_path_error,
     operational_path,
     subprocess_path,
     subprocess_working_directory,
@@ -66,11 +66,16 @@ class Pygit2CloneProcess:
         """Run a depth-one clone and remove partial output on every failure."""
 
         target_path = operational_path(target_path)
-        staging_root: Path | None = None
-        clone_target = target_path
-        if exceeds_windows_legacy_path_limit(target_path):
-            staging_root = Path(tempfile.mkdtemp(prefix="sugarsubstitute-git-"))
-            clone_target = staging_root / "repository"
+        try:
+            workspace = RepositoryPathWorkspace.reserve(
+                target_path,
+                create_target=True,
+            )
+        except (OSError, RuntimeError) as error:
+            raise RepositoryOperationError(
+                f"Could not prepare repository clone path {target_path}: {error}"
+            ) from error
+        clone_target = workspace.access_path
         command = (
             subprocess_path(self._python_executable),
             "-m",
@@ -104,16 +109,16 @@ class Pygit2CloneProcess:
                 creationflags=creationflags,
             )
         except subprocess.TimeoutExpired as error:
-            _discard_clone_work(clone_target, staging_root=staging_root)
+            _discard_clone_work(target_path, workspace=workspace)
             raise RepositoryOperationError(
                 f"Repository clone timed out after {self._timeout_seconds:g} seconds: "
                 f"{repository_url}"
             ) from error
         except OSError as error:
-            _discard_clone_work(clone_target, staging_root=staging_root)
+            _discard_clone_work(target_path, workspace=workspace)
             compatibility_error = external_long_path_error(
                 component="pygit2",
-                path=clone_target,
+                path=target_path,
                 detail=error,
             )
             if compatibility_error is not None:
@@ -123,24 +128,13 @@ class Pygit2CloneProcess:
             ) from error
 
         if completed.returncode == 0:
-            if staging_root is not None:
-                try:
-                    shutil.copytree(clone_target, target_path)
-                except (OSError, shutil.Error):
-                    _LOGGER.exception(
-                        "Failed to promote staged repository clone | target=%s",
-                        target_path,
-                    )
-                    _discard_partial_clone(target_path)
-                    raise
-                finally:
-                    _discard_staging_root(staging_root)
+            workspace.cleanup()
             return
-        _discard_clone_work(clone_target, staging_root=staging_root)
+        _discard_clone_work(target_path, workspace=workspace)
         detail = _tail_output(completed.stdout)
         compatibility_error = external_long_path_error(
             component="pygit2",
-            path=clone_target,
+            path=target_path,
             detail=detail,
         )
         if compatibility_error is not None:
@@ -164,26 +158,25 @@ def _hidden_process_options() -> tuple[subprocess.STARTUPINFO | None, int]:
 
 
 def _discard_clone_work(
-    clone_target: Path,
+    target_path: Path,
     *,
-    staging_root: Path | None,
+    workspace: RepositoryPathWorkspace,
 ) -> None:
-    """Remove partial clone output and its optional short-path staging root."""
+    """Remove a repository alias before discarding partial target output."""
 
-    _discard_partial_clone(clone_target)
-    if staging_root is not None:
-        _discard_staging_root(staging_root)
+    _discard_workspace(workspace)
+    _discard_partial_clone(target_path)
 
 
-def _discard_staging_root(staging_root: Path) -> None:
-    """Best-effort remove one app-owned clone staging directory with diagnostics."""
+def _discard_workspace(workspace: RepositoryPathWorkspace) -> None:
+    """Best-effort release one clone path workspace with diagnostics."""
 
     try:
-        remove_app_owned_path(staging_root)
+        workspace.cleanup()
     except OSError:
         _LOGGER.warning(
-            "Could not remove repository clone staging root | root=%s",
-            staging_root,
+            "Could not remove repository clone path workspace | target=%s",
+            workspace.target_path,
             exc_info=True,
         )
 

--- a/substitute/infrastructure/version_control/pygit2_access.py
+++ b/substitute/infrastructure/version_control/pygit2_access.py
@@ -1,0 +1,89 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Open and initialize pygit2 repositories through path-safe workspaces."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pygit2
+
+from substitute.infrastructure.version_control.repository import (
+    RepositoryOperationError,
+)
+from substitute.infrastructure.version_control.repository_path_workspace import (
+    RepositoryPathWorkspace,
+)
+from sugarsubstitute_shared.external_path_failure import external_long_path_error
+from sugarsubstitute_shared.windows_long_paths import operational_path
+
+
+def initialize_pygit2_repository(repository_path: Path, *, branch: str) -> None:
+    """Initialize one repository without exposing its final path to libgit2."""
+
+    workspace: RepositoryPathWorkspace | None = None
+    try:
+        workspace = RepositoryPathWorkspace.reserve(
+            repository_path,
+            create_target=True,
+        )
+        pygit2.init_repository(workspace.access_path, initial_head=branch)
+    except (OSError, ValueError, pygit2.GitError) as error:
+        compatibility_error = external_long_path_error(
+            component="pygit2",
+            path=operational_path(repository_path),
+            detail=error,
+        )
+        if compatibility_error is not None:
+            raise compatibility_error from error
+        raise RepositoryOperationError(
+            f"Could not initialize repository at {operational_path(repository_path)}."
+        ) from error
+    finally:
+        if workspace is not None:
+            workspace.cleanup()
+
+
+@contextmanager
+def open_pygit2_repository(repository_path: Path) -> Iterator[pygit2.Repository]:
+    """Yield one repository opened through a short component-safe path."""
+
+    workspace: RepositoryPathWorkspace | None = None
+    try:
+        try:
+            workspace = RepositoryPathWorkspace.reserve(repository_path)
+            repository = pygit2.Repository(workspace.access_path)
+        except (OSError, ValueError, pygit2.GitError) as error:
+            compatibility_error = external_long_path_error(
+                component="pygit2",
+                path=operational_path(repository_path),
+                detail=error,
+            )
+            if compatibility_error is not None:
+                raise compatibility_error from error
+            raise RepositoryOperationError(
+                f"Could not open repository {operational_path(repository_path)}: {error}"
+            ) from error
+        yield repository
+    finally:
+        if workspace is not None:
+            workspace.cleanup()
+
+
+__all__ = ["initialize_pygit2_repository", "open_pygit2_repository"]

--- a/substitute/infrastructure/version_control/pygit2_repository.py
+++ b/substitute/infrastructure/version_control/pygit2_repository.py
@@ -26,14 +26,15 @@ import pygit2
 from substitute.infrastructure.version_control.clone_process import (
     Pygit2CloneProcess,
 )
+from substitute.infrastructure.version_control.pygit2_access import (
+    initialize_pygit2_repository,
+    open_pygit2_repository,
+)
 from substitute.infrastructure.version_control.repository import (
     RepositoryOperationError,
     RepositoryProgressCallback,
 )
-from sugarsubstitute_shared.windows_long_paths import (
-    external_long_path_error,
-    operational_path,
-)
+from sugarsubstitute_shared.windows_long_paths import operational_path
 
 
 _CHECKOUT_STRATEGY = pygit2.GIT_CHECKOUT_SAFE | pygit2.GIT_CHECKOUT_RECREATE_MISSING
@@ -50,21 +51,7 @@ class Pygit2RepositoryService:
     def initialize(self, repository_path: Path, *, branch: str = "main") -> None:
         """Initialize an empty repository through libgit2."""
 
-        repository_path = operational_path(repository_path)
-        try:
-            repository_path.mkdir(parents=True, exist_ok=True)
-            pygit2.init_repository(repository_path, initial_head=branch)
-        except (OSError, ValueError, pygit2.GitError) as error:
-            compatibility_error = external_long_path_error(
-                component="pygit2",
-                path=repository_path,
-                detail=error,
-            )
-            if compatibility_error is not None:
-                raise compatibility_error from error
-            raise RepositoryOperationError(
-                f"Could not initialize repository at {repository_path}."
-            ) from error
+        initialize_pygit2_repository(repository_path, branch=branch)
 
     def clone(
         self,
@@ -94,21 +81,21 @@ class Pygit2RepositoryService:
     ) -> None:
         """Fetch configured remotes and fast-forward the current branch."""
 
-        repository = self._open(repository_path)
-        try:
-            for remote in repository.remotes:
-                self._emit(on_progress, f"Fetching {remote.name or remote.url}")
-                remote.fetch(
-                    [
-                        *remote.fetch_refspecs,
-                        "+refs/tags/*:refs/tags/*",
-                    ]
-                )
-            self._fast_forward_current_branch(repository)
-        except (KeyError, ValueError, pygit2.GitError) as error:
-            raise RepositoryOperationError(
-                f"Could not fast-forward repository {repository_path}: {error}"
-            ) from error
+        with open_pygit2_repository(repository_path) as repository:
+            try:
+                for remote in repository.remotes:
+                    self._emit(on_progress, f"Fetching {remote.name or remote.url}")
+                    remote.fetch(
+                        [
+                            *remote.fetch_refspecs,
+                            "+refs/tags/*:refs/tags/*",
+                        ]
+                    )
+                self._fast_forward_current_branch(repository)
+            except (KeyError, ValueError, pygit2.GitError) as error:
+                raise RepositoryOperationError(
+                    f"Could not fast-forward repository {repository_path}: {error}"
+                ) from error
 
     def fetch_all(
         self,
@@ -118,15 +105,15 @@ class Pygit2RepositoryService:
     ) -> None:
         """Fetch every configured remote branch and tag through libgit2."""
 
-        repository = self._open(repository_path)
-        try:
-            for remote in repository.remotes:
-                self._emit(on_progress, f"Fetching {remote.name or remote.url}")
-                remote.fetch()
-        except (KeyError, ValueError, pygit2.GitError) as error:
-            raise RepositoryOperationError(
-                f"Could not fetch repository remotes for {repository_path}: {error}"
-            ) from error
+        with open_pygit2_repository(repository_path) as repository:
+            try:
+                for remote in repository.remotes:
+                    self._emit(on_progress, f"Fetching {remote.name or remote.url}")
+                    remote.fetch()
+            except (KeyError, ValueError, pygit2.GitError) as error:
+                raise RepositoryOperationError(
+                    f"Could not fetch repository remotes for {repository_path}: {error}"
+                ) from error
 
     def fetch_tag(
         self,
@@ -138,108 +125,90 @@ class Pygit2RepositoryService:
     ) -> None:
         """Fetch one tag from a trusted repository URL."""
 
-        repository = self._open(repository_path)
-        self._emit(on_progress, f"Fetching tag {tag} from {repository_url}")
-        refspec = f"+refs/tags/{tag}:refs/tags/{tag}"
-        try:
-            repository.remotes.create_anonymous(repository_url).fetch([refspec])
-        except (ValueError, pygit2.GitError) as error:
-            raise RepositoryOperationError(
-                f"Could not fetch tag {tag} into {repository_path}: {error}"
-            ) from error
+        with open_pygit2_repository(repository_path) as repository:
+            self._emit(on_progress, f"Fetching tag {tag} from {repository_url}")
+            refspec = f"+refs/tags/{tag}:refs/tags/{tag}"
+            try:
+                repository.remotes.create_anonymous(repository_url).fetch([refspec])
+            except (ValueError, pygit2.GitError) as error:
+                raise RepositoryOperationError(
+                    f"Could not fetch tag {tag} into {repository_path}: {error}"
+                ) from error
 
     def checkout_revision(self, repository_path: Path, revision: str) -> None:
         """Checkout one resolvable revision and detach HEAD at its commit."""
 
-        repository = self._open(repository_path)
-        try:
-            revision_object = repository.revparse_single(revision)
-            commit = revision_object.peel(pygit2.Commit)
-            # pygit2's checkout_tree C binding has no callable type signature.
-            repository.checkout_tree(  # type: ignore[no-untyped-call]
-                commit,
-                strategy=_CHECKOUT_STRATEGY,
-            )
-            repository.set_head(commit.id)
-        except (KeyError, ValueError, pygit2.GitError) as error:
-            raise RepositoryOperationError(
-                f"Could not checkout revision {revision} in {repository_path}: {error}"
-            ) from error
+        with open_pygit2_repository(repository_path) as repository:
+            try:
+                revision_object = repository.revparse_single(revision)
+                commit = revision_object.peel(pygit2.Commit)
+                # pygit2's checkout_tree C binding has no callable type signature.
+                repository.checkout_tree(  # type: ignore[no-untyped-call]
+                    commit,
+                    strategy=_CHECKOUT_STRATEGY,
+                )
+                repository.set_head(commit.id)
+            except (KeyError, ValueError, pygit2.GitError) as error:
+                raise RepositoryOperationError(
+                    f"Could not checkout revision {revision} in {repository_path}: {error}"
+                ) from error
 
     def tracked_files(self, repository_path: Path) -> tuple[Path, ...]:
         """Return worktree-relative tracked paths from the repository index."""
 
-        repository = self._open(repository_path)
-        try:
-            repository.index.read()
-            return tuple(Path(entry.path) for entry in repository.index)
-        except (OSError, pygit2.GitError) as error:
-            raise RepositoryOperationError(
-                f"Could not read tracked files in {repository_path}: {error}"
-            ) from error
+        with open_pygit2_repository(repository_path) as repository:
+            try:
+                repository.index.read()
+                return tuple(Path(entry.path) for entry in repository.index)
+            except (OSError, pygit2.GitError) as error:
+                raise RepositoryOperationError(
+                    f"Could not read tracked files in {repository_path}: {error}"
+                ) from error
 
     def status_excerpt(self, repository_path: Path) -> str:
         """Return concise branch and worktree status text for diagnostics."""
 
-        repository = self._open(repository_path)
-        try:
-            branch = (
-                "HEAD detached"
-                if repository.head_is_detached
-                else repository.head.shorthand
-            )
-            entries = [f"## {branch}"]
-            entries.extend(
-                f"{_status_label(flags)} {path}"
-                for path, flags in sorted(repository.status().items())
-                if flags != pygit2.GIT_STATUS_CURRENT
-            )
-            return "\n".join(entries)
-        except (KeyError, pygit2.GitError) as error:
-            raise RepositoryOperationError(
-                f"Could not read repository status in {repository_path}: {error}"
-            ) from error
+        with open_pygit2_repository(repository_path) as repository:
+            try:
+                branch = (
+                    "HEAD detached"
+                    if repository.head_is_detached
+                    else repository.head.shorthand
+                )
+                entries = [f"## {branch}"]
+                entries.extend(
+                    f"{_status_label(flags)} {path}"
+                    for path, flags in sorted(repository.status().items())
+                    if flags != pygit2.GIT_STATUS_CURRENT
+                )
+                return "\n".join(entries)
+            except (KeyError, pygit2.GitError) as error:
+                raise RepositoryOperationError(
+                    f"Could not read repository status in {repository_path}: {error}"
+                ) from error
 
     def remote_urls(self, repository_path: Path) -> Mapping[str, str]:
         """Return configured fetch URLs keyed by remote name."""
 
-        repository = self._open(repository_path)
-        return {
-            remote.name: remote.url
-            for remote in repository.remotes
-            if remote.name is not None and remote.url is not None
-        }
+        with open_pygit2_repository(repository_path) as repository:
+            return {
+                remote.name: remote.url
+                for remote in repository.remotes
+                if remote.name is not None and remote.url is not None
+            }
 
     def head_commit_id(self, repository_path: Path) -> str | None:
         """Return the current commit identifier when the repository has a head."""
 
-        repository = self._open(repository_path)
-        if repository.head_is_unborn:
-            return None
-        try:
-            return str(repository.head.target)
-        except (KeyError, pygit2.GitError) as error:
-            raise RepositoryOperationError(
-                f"Could not resolve repository head in {repository_path}: {error}"
-            ) from error
-
-    def _open(self, repository_path: Path) -> pygit2.Repository:
-        """Open one worktree repository and normalize backend failures."""
-
-        repository_path = operational_path(repository_path)
-        try:
-            return pygit2.Repository(repository_path)
-        except (OSError, ValueError, pygit2.GitError) as error:
-            compatibility_error = external_long_path_error(
-                component="pygit2",
-                path=repository_path,
-                detail=error,
-            )
-            if compatibility_error is not None:
-                raise compatibility_error from error
-            raise RepositoryOperationError(
-                f"Could not open repository {repository_path}: {error}"
-            ) from error
+        with open_pygit2_repository(repository_path) as repository:
+            if repository.head_is_unborn:
+                return None
+            try:
+                return str(repository.head.target)
+            except (KeyError, pygit2.GitError) as error:
+                raise RepositoryOperationError(
+                    f"Could not resolve repository head in {repository_path}: {error}"
+                ) from error
 
     def _fast_forward_current_branch(self, repository: pygit2.Repository) -> None:
         """Advance the current local branch only when its upstream descends from it."""

--- a/substitute/infrastructure/version_control/repository_path_workspace.py
+++ b/substitute/infrastructure/version_control/repository_path_workspace.py
@@ -1,0 +1,119 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Expose repositories to Windows components through short path aliases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from types import TracebackType
+
+from sugarsubstitute_shared.external_path_contract import ExternalPathContract
+from sugarsubstitute_shared.external_scratch import (
+    ExternalScratchWorkspace,
+    allocate_external_scratch,
+)
+from sugarsubstitute_shared.windows_directory_junction import (
+    create_windows_directory_junction,
+)
+from sugarsubstitute_shared.windows_long_paths import operational_path
+
+REPOSITORY_DESCENDANT_BUDGET = 190
+_ALIAS_DIRECTORY_LENGTH = len("\\repository")
+REPOSITORY_PATH_CONTRACT = ExternalPathContract(
+    component="pygit2 repository access",
+    reserved_descendant_length=(_ALIAS_DIRECTORY_LENGTH + REPOSITORY_DESCENDANT_BUDGET),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryPathWorkspace:
+    """Own one short-lived path through which libgit2 accesses a repository."""
+
+    target_path: Path
+    access_path: Path
+    _scratch: ExternalScratchWorkspace | None = None
+
+    @classmethod
+    def reserve(
+        cls,
+        target_path: Path,
+        *,
+        create_target: bool = False,
+    ) -> RepositoryPathWorkspace:
+        """Expose an existing target, creating it only for creation workflows."""
+
+        operational_target = operational_path(target_path)
+        if create_target:
+            operational_target.mkdir(parents=True, exist_ok=True)
+        elif not operational_target.is_dir():
+            raise FileNotFoundError(
+                f"Repository path is not a directory: {operational_target}"
+            )
+        if sys.platform != "win32":
+            return cls(
+                target_path=operational_target,
+                access_path=operational_target,
+            )
+        scratch = allocate_external_scratch(
+            preferred_storage_path=operational_target,
+            namespace="git-access",
+            contract=REPOSITORY_PATH_CONTRACT,
+        )
+        access_path = scratch.root / "repository"
+        try:
+            create_windows_directory_junction(
+                junction=access_path,
+                target=operational_target,
+            )
+        except Exception:
+            scratch.cleanup()
+            raise
+        return cls(
+            target_path=operational_target,
+            access_path=access_path,
+            _scratch=scratch,
+        )
+
+    def cleanup(self) -> None:
+        """Remove the short alias without changing repository contents."""
+
+        if self._scratch is not None:
+            self._scratch.cleanup()
+
+    def __enter__(self) -> Path:
+        """Return the repository path safe for the external component."""
+
+        return self.access_path
+
+    def __exit__(
+        self,
+        _exception_type: type[BaseException] | None,
+        _exception: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        """Release the transient alias after repository access."""
+
+        self.cleanup()
+
+
+__all__ = [
+    "REPOSITORY_DESCENDANT_BUDGET",
+    "REPOSITORY_PATH_CONTRACT",
+    "RepositoryPathWorkspace",
+]

--- a/sugarsubstitute_shared/external_path_contract.py
+++ b/sugarsubstitute_shared/external_path_contract.py
@@ -1,0 +1,53 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Define path-capacity contracts for external components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+from sugarsubstitute_shared.windows_long_paths import WINDOWS_LEGACY_PATH_LIMIT
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalPathContract:
+    """Describe descendant capacity required below an external-tool path."""
+
+    component: str
+    reserved_descendant_length: int
+
+    def accepts(self, root: Path) -> bool:
+        """Return whether the root preserves the required Windows path capacity."""
+
+        if self.reserved_descendant_length < 0:
+            raise ValueError("Reserved descendant length cannot be negative.")
+        if sys.platform != "win32":
+            return True
+        return (
+            len(str(root)) + self.reserved_descendant_length < WINDOWS_LEGACY_PATH_LIMIT
+        )
+
+    @property
+    def maximum_windows_root_length(self) -> int:
+        """Return the longest accepted Windows root for this contract."""
+
+        return WINDOWS_LEGACY_PATH_LIMIT - self.reserved_descendant_length - 1
+
+
+__all__ = ["ExternalPathContract"]

--- a/sugarsubstitute_shared/external_path_failure.py
+++ b/sugarsubstitute_shared/external_path_failure.py
@@ -1,0 +1,122 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Classify long-path failures emitted by external components."""
+
+from __future__ import annotations
+
+import errno
+import ntpath
+from pathlib import Path
+import re
+import sys
+
+from sugarsubstitute_shared.windows_long_paths import (
+    exceeds_windows_legacy_path_limit,
+    logical_path,
+)
+
+_LONG_PATH_ERROR_MARKERS = (
+    "filename too long",
+    "file name too long",
+    "path too long",
+    "winerror 206",
+    "error_filename_exced_range",
+)
+_MISSING_PATH_ERROR_MARKERS = (
+    "errno 2",
+    "no such file or directory",
+    "winerror 2",
+    "winerror 3",
+)
+_QUOTED_VALUE = re.compile(r"(?P<quote>['\"])(?P<value>[^'\"\r\n]+)(?P=quote)")
+
+
+class ExternalLongPathCompatibilityError(RuntimeError):
+    """Report a known long-path failure in an external component."""
+
+    def __init__(
+        self,
+        *,
+        component: str,
+        path: Path,
+        detail: str,
+    ) -> None:
+        """Retain structured evidence for localized presentation."""
+
+        self.component = component
+        self.path = Path(logical_path(path))
+        self.detail = detail
+        super().__init__(
+            f"{component} could not access the long Windows path "
+            f"'{self.path}'. {detail}"
+        )
+
+
+def external_long_path_error(
+    *,
+    component: str,
+    path: Path,
+    detail: BaseException | str,
+) -> ExternalLongPathCompatibilityError | None:
+    """Classify explicit and missing-file failures involving overlong paths."""
+
+    if sys.platform != "win32":
+        return None
+    detail_text = str(detail).strip() or type(detail).__name__
+    embedded_paths = _embedded_windows_paths(detail_text)
+    supplied_path = Path(logical_path(path))
+    long_embedded_paths = tuple(
+        candidate
+        for candidate in embedded_paths
+        if exceeds_windows_legacy_path_limit(candidate)
+    )
+    supplied_path_is_long = exceeds_windows_legacy_path_limit(supplied_path)
+    if not long_embedded_paths and not supplied_path_is_long:
+        return None
+    winerror = getattr(detail, "winerror", None)
+    error_number = getattr(detail, "errno", None)
+    normalized = detail_text.casefold()
+    explicit_long_path_failure = (
+        winerror == 206
+        or error_number == errno.ENAMETOOLONG
+        or any(marker in normalized for marker in _LONG_PATH_ERROR_MARKERS)
+    )
+    missing_embedded_path_failure = bool(long_embedded_paths) and any(
+        marker in normalized for marker in _MISSING_PATH_ERROR_MARKERS
+    )
+    if not explicit_long_path_failure and not missing_embedded_path_failure:
+        return None
+    failing_path = long_embedded_paths[0] if long_embedded_paths else supplied_path
+    return ExternalLongPathCompatibilityError(
+        component=component,
+        path=failing_path,
+        detail=detail_text,
+    )
+
+
+def _embedded_windows_paths(detail: str) -> tuple[Path, ...]:
+    """Return absolute Windows paths quoted in external process output."""
+
+    return tuple(
+        Path(value)
+        for match in _QUOTED_VALUE.finditer(detail)
+        for value in (logical_path(match.group("value")),)
+        if ntpath.isabs(value)
+    )
+
+
+__all__ = ["ExternalLongPathCompatibilityError", "external_long_path_error"]

--- a/sugarsubstitute_shared/external_scratch.py
+++ b/sugarsubstitute_shared/external_scratch.py
@@ -1,0 +1,183 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Allocate short, app-owned scratch workspaces for external components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import shutil
+import stat
+import sys
+import tempfile
+from uuid import uuid4
+
+from sugarsubstitute_shared.external_path_contract import ExternalPathContract
+from sugarsubstitute_shared.windows_long_paths import operational_path
+
+_SCRATCH_PARENT_NAME = ".sugarsubstitute-temp"
+_OWNERSHIP_SENTINEL_NAME = ".sugarsubstitute-scratch"
+
+
+class ExternalScratchAllocationError(RuntimeError):
+    """Report that no safe scratch location satisfies an external contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalScratchWorkspace:
+    """Own one reserved external-process scratch directory."""
+
+    root: Path
+    _cleanup_parent_when_empty: Path | None = None
+
+    @classmethod
+    def reserve(
+        cls,
+        root: Path,
+        *,
+        cleanup_parent_when_empty: Path | None = None,
+    ) -> ExternalScratchWorkspace:
+        """Reserve an exact root and record ownership for safe cleanup."""
+
+        operational_root = operational_path(root)
+        operational_root.mkdir(parents=False, exist_ok=False)
+        try:
+            (operational_root / _OWNERSHIP_SENTINEL_NAME).write_text(
+                "SugarSubstitute external scratch\n",
+                encoding="utf-8",
+            )
+        except Exception:
+            operational_root.rmdir()
+            raise
+        return cls(
+            root=Path(str(operational_root)),
+            _cleanup_parent_when_empty=cleanup_parent_when_empty,
+        )
+
+    def cleanup(self) -> None:
+        """Delete only the scratch directory carrying our ownership sentinel."""
+
+        resolved_root = operational_path(self.root).resolve()
+        if resolved_root == Path(resolved_root.anchor):
+            raise RuntimeError(f"Refusing to clean filesystem root: {resolved_root}")
+        sentinel = resolved_root / _OWNERSHIP_SENTINEL_NAME
+        if not sentinel.is_file():
+            raise RuntimeError(
+                f"Refusing to clean unowned external scratch root: {resolved_root}"
+            )
+        shutil.rmtree(resolved_root, onexc=_clear_readonly_and_retry)
+        cleanup_parent = self._cleanup_parent_when_empty
+        if cleanup_parent is None:
+            return
+        try:
+            operational_path(cleanup_parent).rmdir()
+        except OSError:
+            pass
+
+
+def allocate_external_scratch(
+    *,
+    preferred_storage_path: Path,
+    namespace: str,
+    contract: ExternalPathContract,
+) -> ExternalScratchWorkspace:
+    """Reserve the first writable scratch root satisfying the path contract."""
+
+    token = _scratch_token(namespace)
+    failures: list[str] = []
+    for parent in _candidate_parents(preferred_storage_path):
+        root = parent / token
+        if not contract.accepts(root):
+            failures.append(
+                f"{parent} exceeds the {contract.maximum_windows_root_length}-character root budget"
+            )
+            continue
+        parent_created = False
+        try:
+            parent.mkdir(parents=True, exist_ok=False)
+            parent_created = True
+        except FileExistsError:
+            pass
+        except OSError as error:
+            failures.append(f"{parent}: {error}")
+            continue
+        try:
+            return ExternalScratchWorkspace.reserve(
+                root,
+                cleanup_parent_when_empty=(
+                    parent
+                    if parent_created or parent.name == _SCRATCH_PARENT_NAME
+                    else None
+                ),
+            )
+        except OSError as error:
+            failures.append(f"{root}: {error}")
+            if parent_created:
+                try:
+                    parent.rmdir()
+                except OSError:
+                    pass
+    detail = "; ".join(failures) or "no candidate scratch roots were available"
+    raise ExternalScratchAllocationError(
+        f"Could not allocate {contract.component} scratch storage. {detail}"
+    )
+
+
+def _candidate_parents(preferred_storage_path: Path) -> tuple[Path, ...]:
+    """Return ordered same-volume and user-temporary scratch parents."""
+
+    preferred = Path(preferred_storage_path).expanduser().absolute()
+    system_temp_parent = Path(tempfile.gettempdir())
+    if sys.platform == "win32" and preferred.anchor:
+        volume_parent = Path(preferred.anchor) / _SCRATCH_PARENT_NAME
+        if volume_parent != system_temp_parent:
+            return volume_parent, system_temp_parent
+    return (preferred.parent / _SCRATCH_PARENT_NAME, system_temp_parent)
+
+
+def _scratch_token(namespace: str) -> str:
+    """Return a compact collision-resistant directory name."""
+
+    normalized = "".join(
+        character.lower()
+        for character in namespace
+        if character.isascii() and (character.isalnum() or character == "-")
+    ).strip("-")
+    if not normalized:
+        raise ValueError("External scratch namespace must contain a safe character.")
+    return f"{normalized[:16]}-{uuid4().hex[:12]}"
+
+
+def _clear_readonly_and_retry(
+    function: object,
+    path: str,
+    _error: BaseException,
+) -> None:
+    """Clear a read-only scratch entry before retrying its removal once."""
+
+    os.chmod(path, stat.S_IWRITE)
+    if not callable(function):
+        raise TypeError("Scratch cleanup callback is not callable.")
+    function(path)
+
+
+__all__ = [
+    "ExternalScratchAllocationError",
+    "ExternalScratchWorkspace",
+    "allocate_external_scratch",
+]

--- a/sugarsubstitute_shared/launcher_update/models.py
+++ b/sugarsubstitute_shared/launcher_update/models.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Self
 
+from sugarsubstitute_shared.windows_long_paths import operational_path
+
 from sugarsubstitute_shared.launcher_update.persistence import (
     read_json_object,
     write_json_atomic,
@@ -147,10 +149,12 @@ class LauncherUpdateRequest:
         if wait_pid is not None and (not isinstance(wait_pid, int) or wait_pid <= 0):
             raise ValueError("Launcher update wait_pid must be a positive integer.")
         return cls(
-            install_root=Path(_required_string(payload, "install_root")),
+            install_root=operational_path(_required_string(payload, "install_root")),
             version=_required_string(payload, "version"),
             target_key=_required_string(payload, "target_key"),
-            staged_bundle_dir=Path(_required_string(payload, "staged_bundle_dir")),
+            staged_bundle_dir=operational_path(
+                _required_string(payload, "staged_bundle_dir")
+            ),
             relaunch=relaunch,
             wait_pid=wait_pid,
         )

--- a/sugarsubstitute_shared/launcher_update/persistence.py
+++ b/sugarsubstitute_shared/launcher_update/persistence.py
@@ -22,10 +22,13 @@ import json
 from pathlib import Path
 from typing import Mapping
 
+from sugarsubstitute_shared.windows_long_paths import operational_path
+
 
 def write_json_atomic(path: Path, payload: Mapping[str, object]) -> None:
     """Write one JSON object through a same-directory temporary file."""
 
+    path = operational_path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary_path = path.with_name(f"{path.name}.tmp")
     temporary_path.write_text(
@@ -38,6 +41,7 @@ def write_json_atomic(path: Path, payload: Mapping[str, object]) -> None:
 def read_json_object(path: Path) -> dict[str, object]:
     """Read one JSON object and reject other root values."""
 
+    path = operational_path(path)
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"Expected a JSON object: {path}")

--- a/sugarsubstitute_shared/launcher_update/process.py
+++ b/sugarsubstitute_shared/launcher_update/process.py
@@ -24,6 +24,11 @@ import subprocess
 import sys
 
 from sugarsubstitute_shared.launcher_update.models import LauncherUpdateRequest
+from sugarsubstitute_shared.windows_long_paths import (
+    operational_path,
+    subprocess_path,
+    subprocess_working_directory,
+)
 
 
 def schedule_launcher_update(
@@ -36,14 +41,18 @@ def schedule_launcher_update(
 ) -> int:
     """Persist process behavior and start the detached replacement helper."""
 
+    request_path = operational_path(request_path)
+    runtime_python = operational_path(runtime_python)
+    app_dir = operational_path(app_dir)
     request = LauncherUpdateRequest.load(request_path).with_process_behavior(
         relaunch=relaunch,
         wait_pid=wait_pid,
     )
     request.save(request_path)
     environment = os.environ.copy()
-    environment["PYTHONPATH"] = str(app_dir)
-    log_path = request.install_root / "launcher" / "logs" / "launcher-update.log"
+    environment["PYTHONPATH"] = subprocess_path(app_dir)
+    install_root = operational_path(request.install_root)
+    log_path = install_root / "launcher" / "logs" / "launcher-update.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
     creationflags = 0
     startupinfo = None
@@ -56,12 +65,12 @@ def schedule_launcher_update(
     with log_path.open("a", encoding="utf-8") as output:
         process = subprocess.Popen(  # noqa: S603
             [
-                str(runtime_python),
+                subprocess_path(runtime_python),
                 "-m",
                 "sugarsubstitute_shared.launcher_update.helper",
-                str(request_path),
+                subprocess_path(request_path),
             ],
-            cwd=request.install_root,
+            cwd=subprocess_working_directory(install_root),
             env=environment,
             stdin=subprocess.DEVNULL,
             stdout=output,

--- a/sugarsubstitute_shared/launcher_update/staging.py
+++ b/sugarsubstitute_shared/launcher_update/staging.py
@@ -32,6 +32,7 @@ from sugarsubstitute_shared.launcher_update.models import (
     LauncherUpdateRequest,
 )
 from sugarsubstitute_shared.launcher_update.targets import LauncherBundleTarget
+from sugarsubstitute_shared.windows_long_paths import operational_path
 
 
 class LauncherBundleValidationError(RuntimeError):
@@ -60,7 +61,7 @@ class LauncherBundleStager:
     ) -> Path:
         """Stage one validated update and return its persisted request path."""
 
-        resolved_root = install_root.expanduser().resolve()
+        resolved_root = operational_path(install_root).resolve()
         update_root = resolved_root / "launcher" / "updates"
         version_root = update_root / "staging" / safe_launcher_version(version)
         archive_path = update_root / "downloads" / asset.filename

--- a/sugarsubstitute_shared/launcher_update/transaction.py
+++ b/sugarsubstitute_shared/launcher_update/transaction.py
@@ -38,6 +38,11 @@ from sugarsubstitute_shared.launcher_update.targets import (
     LauncherBundleTarget,
     launcher_bundle_target_for_key,
 )
+from sugarsubstitute_shared.windows_long_paths import (
+    operational_path,
+    subprocess_path,
+    subprocess_working_directory,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -64,11 +69,12 @@ class LauncherUpdateTransaction:
     def apply(self, *, request_path: Path) -> None:
         """Apply one persisted request and relaunch exactly when requested."""
 
+        request_path = operational_path(request_path)
         request = LauncherUpdateRequest.load(request_path)
         target = launcher_bundle_target_for_key(request.target_key)
-        install_root = request.install_root.expanduser().resolve()
+        install_root = operational_path(request.install_root).resolve()
         _require_descendant(request_path.resolve(), install_root / "launcher")
-        staged_dir = request.staged_bundle_dir.expanduser().resolve()
+        staged_dir = operational_path(request.staged_bundle_dir).resolve()
         _require_descendant(staged_dir, install_root / "launcher" / "updates")
         validate_staged_bundle(bundle_dir=staged_dir, target=target)
         self._wait_for_process(request.wait_pid)
@@ -318,8 +324,8 @@ def _relaunch(executable_path: Path) -> None:
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
     subprocess.Popen(  # noqa: S603
-        [str(executable_path)],
-        cwd=executable_path.parent,
+        [subprocess_path(executable_path)],
+        cwd=subprocess_working_directory(executable_path.parent),
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/sugarsubstitute_shared/windows_directory_junction.py
+++ b/sugarsubstitute_shared/windows_directory_junction.py
@@ -1,0 +1,142 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Create Windows directory junctions without shelling out."""
+
+from __future__ import annotations
+
+import ctypes
+from ctypes import wintypes
+from pathlib import Path
+import struct
+import sys
+
+from sugarsubstitute_shared.windows_long_paths import logical_path, operational_path
+
+_GENERIC_WRITE = 0x40000000
+_OPEN_EXISTING = 3
+_FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+_FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+_FSCTL_SET_REPARSE_POINT = 0x000900A4
+_IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003
+
+
+def create_windows_directory_junction(*, junction: Path, target: Path) -> None:
+    """Create one directory junction to an existing absolute target."""
+
+    if sys.platform != "win32":
+        raise OSError("Windows directory junctions require Windows.")
+    junction_path = operational_path(junction)
+    target_path = operational_path(target)
+    if not target_path.is_dir():
+        raise FileNotFoundError(f"Junction target is not a directory: {target_path}")
+    junction_path.mkdir(parents=False, exist_ok=False)
+    try:
+        _set_mount_point_reparse_data(junction_path, target_path)
+    except Exception:
+        junction_path.rmdir()
+        raise
+
+
+def _set_mount_point_reparse_data(junction: Path, target: Path) -> None:
+    """Attach native mount-point reparse data to an empty directory."""
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = (wintypes.HANDLE,)
+    close_handle.restype = wintypes.BOOL
+    device_io_control = kernel32.DeviceIoControl
+    device_io_control.argtypes = (
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPVOID,
+    )
+    device_io_control.restype = wintypes.BOOL
+
+    handle = create_file(
+        str(junction),
+        _GENERIC_WRITE,
+        0,
+        None,
+        _OPEN_EXISTING,
+        _FILE_FLAG_OPEN_REPARSE_POINT | _FILE_FLAG_BACKUP_SEMANTICS,
+        None,
+    )
+    if handle == wintypes.HANDLE(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        reparse_data = _mount_point_reparse_data(target)
+        input_buffer = ctypes.create_string_buffer(reparse_data)
+        bytes_returned = wintypes.DWORD()
+        succeeded = device_io_control(
+            handle,
+            _FSCTL_SET_REPARSE_POINT,
+            ctypes.cast(input_buffer, wintypes.LPVOID),
+            len(reparse_data),
+            None,
+            0,
+            ctypes.byref(bytes_returned),
+            None,
+        )
+        if not succeeded:
+            raise ctypes.WinError(ctypes.get_last_error())
+    finally:
+        close_handle(handle)
+
+
+def _mount_point_reparse_data(target: Path) -> bytes:
+    """Build one mount-point reparse buffer for an absolute target."""
+
+    print_name = logical_path(target)
+    if print_name.startswith("\\\\"):
+        substitute_name = "\\??\\UNC\\" + print_name.removeprefix("\\\\")
+    else:
+        substitute_name = "\\??\\" + print_name
+    substitute_bytes = substitute_name.encode("utf-16-le")
+    print_bytes = print_name.encode("utf-16-le")
+    path_buffer = substitute_bytes + b"\0\0" + print_bytes + b"\0\0"
+    print_offset = len(substitute_bytes) + 2
+    reparse_data_length = 8 + len(path_buffer)
+    header = struct.pack(
+        "<LHHHHHH",
+        _IO_REPARSE_TAG_MOUNT_POINT,
+        reparse_data_length,
+        0,
+        0,
+        len(substitute_bytes),
+        print_offset,
+        len(print_bytes),
+    )
+    return header + path_buffer
+
+
+__all__ = ["create_windows_directory_junction"]

--- a/sugarsubstitute_shared/windows_long_paths.py
+++ b/sugarsubstitute_shared/windows_long_paths.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import ntpath
 import os
-import errno
 from pathlib import Path, WindowsPath
 import sys
 import tempfile
@@ -31,34 +30,6 @@ _EXTENDED_UNC_PREFIX = "\\\\?\\UNC\\"
 _UNC_PREFIX = "\\\\"
 WINDOWS_LEGACY_PATH_LIMIT = 260
 WINDOWS_PATH_COMPONENT_LIMIT = 255
-_LONG_PATH_ERROR_MARKERS = (
-    "filename too long",
-    "file name too long",
-    "path too long",
-    "winerror 206",
-    "error_filename_exced_range",
-)
-
-
-class ExternalLongPathCompatibilityError(RuntimeError):
-    """Report a known long-path failure in an external component."""
-
-    def __init__(
-        self,
-        *,
-        component: str,
-        path: os.PathLike[str] | str,
-        detail: str,
-    ) -> None:
-        """Retain structured evidence for localized presentation."""
-
-        self.component = component
-        self.path = Path(logical_path(path))
-        self.detail = detail
-        super().__init__(
-            f"{component} could not access the long Windows path "
-            f"'{self.path}'. {detail}"
-        )
 
 
 class WindowsPathComponentTooLongError(ValueError):
@@ -173,33 +144,6 @@ def exceeds_windows_legacy_path_limit(path: os.PathLike[str] | str) -> bool:
     )
 
 
-def external_long_path_error(
-    *,
-    component: str,
-    path: os.PathLike[str] | str,
-    detail: BaseException | str,
-) -> ExternalLongPathCompatibilityError | None:
-    """Classify explicit external ``MAX_PATH`` failures for actionable handling."""
-
-    if sys.platform != "win32" or not exceeds_windows_legacy_path_limit(path):
-        return None
-    detail_text = str(detail).strip() or type(detail).__name__
-    winerror = getattr(detail, "winerror", None)
-    error_number = getattr(detail, "errno", None)
-    normalized = detail_text.casefold()
-    if (
-        winerror != 206
-        and error_number != errno.ENAMETOOLONG
-        and not any(marker in normalized for marker in _LONG_PATH_ERROR_MARKERS)
-    ):
-        return None
-    return ExternalLongPathCompatibilityError(
-        component=component,
-        path=path,
-        detail=detail_text,
-    )
-
-
 def _validate_windows_components(path: str) -> None:
     """Reject components that no Windows path namespace can represent."""
 
@@ -213,12 +157,10 @@ def _validate_windows_components(path: str) -> None:
 __all__ = [
     "WINDOWS_LEGACY_PATH_LIMIT",
     "WINDOWS_PATH_COMPONENT_LIMIT",
-    "ExternalLongPathCompatibilityError",
     "WindowsPathComponentTooLongError",
     "WindowsLongPath",
     "exceeds_windows_legacy_path_limit",
     "extended_length_path",
-    "external_long_path_error",
     "logical_path",
     "operational_path",
     "qt_filesystem_path",

--- a/tests/test_dependency_security_contract.py
+++ b/tests/test_dependency_security_contract.py
@@ -74,7 +74,18 @@ def test_authoritative_ci_blocks_known_dependency_vulnerabilities() -> None:
     audit_source = release_audit_script.read_text(encoding="utf-8")
     assert '"audit", "--json"' in audit_source
     assert "ignoredAdvisoryIds" in audit_source
+    assert "ignoredAdvisoryUrls" in audit_source
     assert "1124334" in audit_source
+    assert {
+        "GHSA-mh99-v99m-4gvg",
+        "GHSA-rgw5-rvv9-x895",
+        "GHSA-mwp4-54f8-5fhr",
+    } <= set(re.findall(r"GHSA-[a-z0-9-]+", audit_source))
+    assert "!ignoredAdvisoryUrls.has(finding.url)" in audit_source
+    release_configuration = (PROJECT_ROOT / ".releaserc.cjs").read_text(
+        encoding="utf-8"
+    )
+    assert '"@semantic-release/npm"' not in release_configuration
     assert "-m pip_audit" in platform_script
     assert "--local --strict --progress-spinner off" in platform_script
     assert workflow["env"]["PIP_AUDIT_IGNORED_VULNERABILITY"] == "CVE-2026-24049"

--- a/tests/test_external_path_failure.py
+++ b/tests/test_external_path_failure.py
@@ -1,0 +1,73 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Characterize long-path failures reported by external processes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugarsubstitute_shared.external_path_failure import (
+    ExternalLongPathCompatibilityError,
+    external_long_path_error,
+)
+
+
+@pytest.mark.platforms("windows")
+def test_classifier_recognizes_errno_two_with_embedded_long_path() -> None:
+    """Pip's missing-file diagnostic should expose its actual overlong output path."""
+
+    failing_path = (
+        "E:\\Documents\\Everything\\Artificial Sweetener\\runtime\\installer-temp"
+        "\\managed-comfy\\401c2092-bb13-4f3b-a377-997f1fab4ccd\\temp"
+        "\\pip-ephem-wheel-cache-pmo9xg0b\\wheels\\59\\1d\\00"
+        "\\729d4b9dcecc8342dac49bcf6ab1415de9f48be12e466feb73"
+        "\\tmpzx280yzl\\.tmp-by7a27ea"
+        "\\sugarcubes-0.11.0-py3-none-any.whl"
+    )
+    detail = f"error: [Errno 2] No such file or directory: '{failing_path}'"
+
+    classified = external_long_path_error(
+        component="pip",
+        path=Path(r"E:\Documents\Everything\Artificial Sweetener\comfyui\.venv"),
+        detail=detail,
+    )
+
+    assert isinstance(classified, ExternalLongPathCompatibilityError)
+    assert classified.path == Path(failing_path)
+    assert classified.component == "pip"
+
+
+@pytest.mark.platforms("windows")
+def test_classifier_recognizes_overlong_unc_path() -> None:
+    """Network installations should retain pip's failing UNC wheel path."""
+
+    failing_path = (
+        r"\\server\managed-install\temp\pip-ephem-wheel-cache\wheels"
+        + "\\deep-wheel-segment" * 12
+        + r"\sugarcubes-0.11.0-py3-none-any.whl"
+    )
+
+    classified = external_long_path_error(
+        component="pip",
+        path=Path(r"\\server\managed-install\comfyui"),
+        detail=f"[Errno 2] No such file or directory: '{failing_path}'",
+    )
+
+    assert isinstance(classified, ExternalLongPathCompatibilityError)
+    assert classified.path == Path(failing_path)

--- a/tests/test_external_scratch.py
+++ b/tests/test_external_scratch.py
@@ -1,0 +1,73 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify external scratch allocation and ownership boundaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import stat
+
+import pytest
+
+from sugarsubstitute_shared import external_scratch
+from sugarsubstitute_shared.external_path_contract import ExternalPathContract
+
+
+def test_allocator_falls_back_when_preferred_parent_is_unusable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An unavailable same-volume root should fall back to user temporary storage."""
+
+    blocked_parent = tmp_path / "blocked"
+    blocked_parent.write_text("not a directory", encoding="utf-8")
+    fallback_parent = tmp_path / "fallback"
+    monkeypatch.setattr(
+        external_scratch,
+        "_candidate_parents",
+        lambda _preferred: (blocked_parent, fallback_parent),
+    )
+
+    scratch = external_scratch.allocate_external_scratch(
+        preferred_storage_path=tmp_path / "installation",
+        namespace="managed-comfy",
+        contract=ExternalPathContract(
+            component="test component",
+            reserved_descendant_length=10,
+        ),
+    )
+    try:
+        assert scratch.root.parent == fallback_parent
+        assert (scratch.root / ".sugarsubstitute-scratch").is_file()
+    finally:
+        scratch.cleanup()
+
+    assert not scratch.root.exists()
+    assert not fallback_parent.exists()
+
+
+def test_cleanup_removes_readonly_external_artifacts(tmp_path: Path) -> None:
+    """External tools should not strand scratch files with read-only attributes."""
+
+    scratch = external_scratch.ExternalScratchWorkspace.reserve(tmp_path / "scratch")
+    readonly_file = scratch.root / "external-artifact.bin"
+    readonly_file.write_bytes(b"artifact")
+    readonly_file.chmod(stat.S_IREAD)
+
+    scratch.cleanup()
+
+    assert not scratch.root.exists()

--- a/tests/test_generation_queue_presentation.py
+++ b/tests/test_generation_queue_presentation.py
@@ -1323,6 +1323,7 @@ def _install_row_interaction_stub_dependencies(
     qtcore: types.ModuleType,
     qtgui: types.ModuleType,
     qfw: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Install Qt symbols required by the shared row interaction helper."""
 
@@ -1338,8 +1339,12 @@ def _install_row_interaction_stub_dependencies(
     qfw_common = types.ModuleType("qfluentwidgets.common")
     qfw_style_sheet = types.ModuleType("qfluentwidgets.common.style_sheet")
     qfw_style_sheet.isDarkTheme = lambda: True
-    sys.modules["qfluentwidgets.common"] = qfw_common
-    sys.modules["qfluentwidgets.common.style_sheet"] = qfw_style_sheet
+    monkeypatch.setitem(sys.modules, "qfluentwidgets.common", qfw_common)
+    monkeypatch.setitem(
+        sys.modules,
+        "qfluentwidgets.common.style_sheet",
+        qfw_style_sheet,
+    )
 
 
 class _MouseEvent:
@@ -1804,7 +1809,7 @@ def test_queue_row_x_button_emits_cancel_requested(
     qfw = types.ModuleType("qfluentwidgets")
     qfw.FluentIcon = types.SimpleNamespace(CLOSE=object())
     qfw.TransparentToolButton = _Button
-    _install_row_interaction_stub_dependencies(qtcore, qtgui, qfw)
+    _install_row_interaction_stub_dependencies(qtcore, qtgui, qfw, monkeypatch)
 
     monkeypatch.setitem(sys.modules, "PySide6", types.ModuleType("PySide6"))
     monkeypatch.setitem(sys.modules, "PySide6.QtCore", qtcore)
@@ -1865,7 +1870,7 @@ def test_queue_row_trash_button_emits_remove_requested(
     qfw = types.ModuleType("qfluentwidgets")
     qfw.FluentIcon = types.SimpleNamespace(CLOSE=object(), DELETE=object())
     qfw.TransparentToolButton = _Button
-    _install_row_interaction_stub_dependencies(qtcore, qtgui, qfw)
+    _install_row_interaction_stub_dependencies(qtcore, qtgui, qfw, monkeypatch)
 
     monkeypatch.setitem(sys.modules, "PySide6", types.ModuleType("PySide6"))
     monkeypatch.setitem(sys.modules, "PySide6.QtCore", qtcore)
@@ -1926,7 +1931,7 @@ def test_queue_row_open_snapshot_intent_emits_job_id(
     qfw = types.ModuleType("qfluentwidgets")
     qfw.FluentIcon = types.SimpleNamespace(CLOSE=object(), DELETE=object())
     qfw.TransparentToolButton = _Button
-    _install_row_interaction_stub_dependencies(qtcore, qtgui, qfw)
+    _install_row_interaction_stub_dependencies(qtcore, qtgui, qfw, monkeypatch)
 
     monkeypatch.setitem(sys.modules, "PySide6", types.ModuleType("PySide6"))
     monkeypatch.setitem(sys.modules, "PySide6.QtCore", qtcore)

--- a/tests/test_installed_app_layout_runtime.py
+++ b/tests/test_installed_app_layout_runtime.py
@@ -41,7 +41,10 @@ from substitute.presentation.onboarding.onboarding_models import (
     OnboardingPageId,
     initial_onboarding_page,
 )
-from sugarsubstitute_shared.windows_long_paths import subprocess_path
+from sugarsubstitute_shared.windows_long_paths import (
+    subprocess_path,
+    subprocess_working_directory,
+)
 
 
 def test_app_layout_resolves_installed_source_payload(tmp_path: Path) -> None:
@@ -116,7 +119,7 @@ def test_launcher_runtime_provisioner_validates_without_installing_requirements(
     def _fake_run(
         command: list[str],
         *,
-        cwd: Path,
+        cwd: str,
         env: dict[str, str],
         stdout: object,
         stderr: object,
@@ -126,8 +129,8 @@ def test_launcher_runtime_provisioner_validates_without_installing_requirements(
         check: bool,
     ) -> SimpleNamespace:
         _ = stdout, stderr, stdin, startupinfo, creationflags, check
-        assert cwd == requirements_path.parent
-        assert env["PYTHONPATH"] == str(requirements_path.parent)
+        assert cwd == subprocess_working_directory(requirements_path.parent)
+        assert env["PYTHONPATH"] == subprocess_path(requirements_path.parent)
         commands.append(command)
         return SimpleNamespace(returncode=0)
 
@@ -142,7 +145,7 @@ def test_launcher_runtime_provisioner_validates_without_installing_requirements(
     assert result.python_executable == python_executable
     assert commands == [
         [
-            str(python_executable),
+            subprocess_path(python_executable),
             "-c",
             "import PySide6; import qfluentwidgets; import qpane; import substitute",
         ],

--- a/tests/test_managed_comfy_install_service.py
+++ b/tests/test_managed_comfy_install_service.py
@@ -35,7 +35,6 @@ from substitute.infrastructure.comfy import managed_install
 from substitute.infrastructure.comfy import managed_existing_setup
 from substitute.infrastructure.comfy import managed_install_commands
 from substitute.infrastructure.comfy import managed_install_failures
-from substitute.infrastructure.comfy import managed_install_scratch
 from substitute.infrastructure.comfy import managed_setup_state
 from substitute.infrastructure.comfy import managed_workspace_operations
 from substitute.infrastructure.comfy.hardware_models import AcceleratorClass
@@ -49,14 +48,34 @@ from substitute.infrastructure.comfy.standalone_environment.models import (
     StandaloneVariantId,
 )
 from tests.repository_service_test_double import RecordingRepositoryService
+from sugarsubstitute_shared.external_scratch import ExternalScratchWorkspace
 from sugarsubstitute_shared.windows_long_paths import subprocess_path
 
 
 @pytest.fixture(autouse=True)
-def _disable_shared_models_link(monkeypatch: pytest.MonkeyPatch) -> None:
+def _disable_shared_models_link(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     """Disable explicit shared-model configuration for isolated setup tests."""
 
     monkeypatch.delenv("SUGARSUB_SHARED_MODELS_ROOT", raising=False)
+    scratch_parent = tmp_path.parent / f"{tmp_path.name}-managed-install-scratch"
+    scratch_runs = iter(range(100))
+
+    def _allocate_scratch(_workspace: Path) -> ExternalScratchWorkspace:
+        """Reserve deterministic isolated scratch for orchestration tests."""
+
+        scratch_parent.mkdir(parents=True, exist_ok=True)
+        return ExternalScratchWorkspace.reserve(
+            scratch_parent / f"run-{next(scratch_runs)}"
+        )
+
+    monkeypatch.setattr(
+        managed_install,
+        "allocate_managed_install_scratch",
+        _allocate_scratch,
+    )
     strategy = SimpleNamespace(
         target=SimpleNamespace(value="windows_nvidia"),
         python_runtime=SimpleNamespace(
@@ -554,32 +573,6 @@ def test_pip_install_raises_when_streamed_install_fails(
         )
 
 
-def test_managed_install_scratch_routes_temp_and_cache_under_root(
-    tmp_path: Path,
-) -> None:
-    """Managed install scratch should keep temp and pip cache under its run root."""
-
-    scratch_root = tmp_path / "runtime" / "installer-temp" / "managed-comfy" / "tx-1"
-    scratch = managed_install_scratch.ManagedInstallScratch(scratch_root)
-
-    scratch.create()
-    env = scratch.apply_to({"PATH": "C:\\Tools"})
-
-    assert env["TEMP"] == str(scratch_root / "temp")
-    assert env["TMP"] == str(scratch_root / "temp")
-    assert env["PIP_CACHE_DIR"] == str(scratch_root / "pip-cache")
-    assert env["PIP_DISABLE_PIP_VERSION_CHECK"] == "1"
-    assert env["PYTHONUTF8"] == "1"
-    assert env["PYTHONIOENCODING"] == "utf-8:replace"
-    assert env["PATH"] == "C:\\Tools"
-    assert scratch.temp_dir.is_dir()
-    assert scratch.pip_cache_dir.is_dir()
-
-    scratch.cleanup()
-
-    assert not scratch_root.exists()
-
-
 def test_pip_install_classifies_storage_failure_and_keeps_managed_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -662,12 +655,15 @@ def test_ensure_managed_comfy_setup_cleans_scratch_after_clone_failure(
 
     monkeypatch.setenv("SUGARSUB_FORCE_MANAGED_FAILURE_STAGE", "clone")
     scratch_root = tmp_path / "runtime" / "installer-temp" / "managed-comfy" / "tx-2"
+    scratch_root.parent.mkdir(parents=True)
+    monkeypatch.setattr(
+        managed_install,
+        "allocate_managed_install_scratch",
+        lambda _workspace: ExternalScratchWorkspace.reserve(scratch_root),
+    )
 
     with pytest.raises(RuntimeError, match="download ComfyUI"):
-        managed_install.ensure_managed_comfy_setup(
-            workspace=tmp_path / "comfyui",
-            installer_temp_root=scratch_root,
-        )
+        managed_install.ensure_managed_comfy_setup(workspace=tmp_path / "comfyui")
 
     assert not scratch_root.exists()
 
@@ -680,27 +676,18 @@ def test_ensure_managed_comfy_setup_keeps_original_failure_when_cleanup_fails(
 
     monkeypatch.setenv("SUGARSUB_FORCE_MANAGED_FAILURE_STAGE", "clone")
 
-    def _raise_cleanup_error(
-        self: managed_install_scratch.ManagedInstallScratch,
-    ) -> None:
+    def _raise_cleanup_error(self: ExternalScratchWorkspace) -> None:
         _ = self
         raise RuntimeError("cleanup failed")
 
     monkeypatch.setattr(
-        managed_install_scratch.ManagedInstallScratch,
+        ExternalScratchWorkspace,
         "cleanup",
         _raise_cleanup_error,
     )
 
     with pytest.raises(RuntimeError, match="download ComfyUI"):
-        managed_install.ensure_managed_comfy_setup(
-            workspace=tmp_path / "comfyui",
-            installer_temp_root=tmp_path
-            / "runtime"
-            / "installer-temp"
-            / "managed-comfy"
-            / "tx-cleanup",
-        )
+        managed_install.ensure_managed_comfy_setup(workspace=tmp_path / "comfyui")
 
 
 def test_ensure_managed_comfy_setup_does_not_fallback_after_storage_error(
@@ -769,14 +756,7 @@ def test_ensure_managed_comfy_setup_does_not_fallback_after_storage_error(
     )
 
     with pytest.raises(managed_install_failures.ManagedInstallStorageError):
-        managed_install.ensure_managed_comfy_setup(
-            workspace=workspace,
-            installer_temp_root=tmp_path
-            / "runtime"
-            / "installer-temp"
-            / "managed-comfy"
-            / "tx-3",
-        )
+        managed_install.ensure_managed_comfy_setup(workspace=workspace)
 
     assert install_attempts == [("torch-nightly",)]
 
@@ -868,10 +848,13 @@ def test_ensure_managed_comfy_setup_installs_and_marks_workspace(
         / "managed-comfy"
         / "tx-success"
     )
-    result = managed_install.ensure_managed_comfy_setup(
-        workspace=tmp_path,
-        installer_temp_root=scratch_root,
+    scratch_root.parent.mkdir(parents=True)
+    monkeypatch.setattr(
+        managed_install,
+        "allocate_managed_install_scratch",
+        lambda _workspace: ExternalScratchWorkspace.reserve(scratch_root),
     )
+    result = managed_install.ensure_managed_comfy_setup(workspace=tmp_path)
 
     assert result == workspace_python
     assert install_steps == ["torch", "requirements"]

--- a/tests/test_managed_install_environment.py
+++ b/tests/test_managed_install_environment.py
@@ -1,0 +1,49 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify managed-install subprocess environment ownership."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from substitute.infrastructure.comfy.managed_install_environment import (
+    build_managed_install_environment,
+)
+
+
+def test_environment_routes_temporary_storage_through_scratch_root(
+    tmp_path: Path,
+) -> None:
+    """Every child temporary variable should reference materialized scratch."""
+
+    scratch_root = tmp_path / "scratch"
+    env = build_managed_install_environment(
+        scratch_root,
+        {"PATH": "C:\\Tools"},
+    )
+
+    temp_dir = scratch_root / "temp"
+    assert env["TEMP"] == str(temp_dir)
+    assert env["TMP"] == str(temp_dir)
+    assert env["TMPDIR"] == str(temp_dir)
+    assert env["PIP_CACHE_DIR"] == str(scratch_root / "pip-cache")
+    assert env["PIP_DISABLE_PIP_VERSION_CHECK"] == "1"
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8:replace"
+    assert env["PATH"] == "C:\\Tools"
+    assert temp_dir.is_dir()
+    assert (scratch_root / "pip-cache").is_dir()

--- a/tests/test_managed_install_scratch_path_budget.py
+++ b/tests/test_managed_install_scratch_path_budget.py
@@ -1,0 +1,50 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Characterize the path budget required by managed-install scratch storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from substitute.infrastructure.comfy.managed_install_scratch import (
+    MANAGED_INSTALL_PATH_CONTRACT,
+    PIP_TEMP_DESCENDANT_BUDGET,
+    allocate_managed_install_scratch,
+)
+from sugarsubstitute_shared.windows_long_paths import WINDOWS_LEGACY_PATH_LIMIT
+
+
+@pytest.mark.platforms("windows")
+def test_default_scratch_preserves_space_for_pip_owned_descendants() -> None:
+    """Pip should retain its descendant budget independently of workspace depth."""
+
+    workspace = Path(
+        r"E:\Documents\Everything\Artificial Sweetener\runtime\managed-comfy"
+    )
+    scratch = allocate_managed_install_scratch(workspace)
+    try:
+        temp_dir = scratch.root / "temp"
+
+        assert MANAGED_INSTALL_PATH_CONTRACT.accepts(scratch.root)
+        assert (
+            len(str(temp_dir)) + PIP_TEMP_DESCENDANT_BUDGET < WINDOWS_LEGACY_PATH_LIMIT
+        )
+        assert workspace not in scratch.root.parents
+    finally:
+        scratch.cleanup()

--- a/tests/test_manager_requirements_installer.py
+++ b/tests/test_manager_requirements_installer.py
@@ -24,6 +24,9 @@ import subprocess
 import pytest
 
 from substitute.infrastructure.comfy import manager_requirements_installer
+from sugarsubstitute_shared.external_path_failure import (
+    ExternalLongPathCompatibilityError,
+)
 from sugarsubstitute_shared.windows_long_paths import (
     subprocess_path,
     subprocess_working_directory,
@@ -102,3 +105,41 @@ def test_pygit2_backend_is_an_explicit_separate_transaction(
     assert observed == [
         [subprocess_path(python), "-m", "pip", "install", "pygit2==1.19.3"]
     ]
+
+
+@pytest.mark.platforms("windows")
+def test_manager_requirements_translate_pip_long_path_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Manager dependency failures should retain pip's overlong output path."""
+
+    failing_path = (
+        "E:\\managed\\temp\\pip-ephem-wheel-cache-pmo9xg0b\\wheels\\59\\1d\\00"
+        "\\729d4b9dcecc8342dac49bcf6ab1415de9f48be12e466feb73"
+        "\\tmpzx280yzl\\.tmp-by7a27ea\\nested-path-component-that-keeps-growing"
+        "\\another-long-component\\one-more-wheel-build-layer-that-exceeds-max-path"
+        "\\sugarcubes-0.11.0-py3-none-any.whl"
+    )
+    detail = f"error: [Errno 2] No such file or directory: '{failing_path}'"
+
+    def fake_run(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        """Return the misleading missing-file failure emitted by pip."""
+
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr=detail)
+
+    monkeypatch.setattr(
+        "substitute.infrastructure.comfy.manager_requirements_installer.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(ExternalLongPathCompatibilityError) as error:
+        manager_requirements_installer.ComfyManagerRequirementsInstaller().install_requirements(
+            workspace=tmp_path,
+            python_executable=tmp_path / "python.exe",
+            requirements_path=tmp_path / "requirements.txt",
+        )
+
+    assert error.value.path == Path(failing_path)

--- a/tests/test_nodepack_python_dependencies.py
+++ b/tests/test_nodepack_python_dependencies.py
@@ -35,6 +35,10 @@ from substitute.infrastructure.comfy.nodepack_python_dependencies import (
     python_distribution_matches_required_version,
     remove_noncanonical_python_distribution_metadata,
 )
+from sugarsubstitute_shared.external_path_failure import (
+    ExternalLongPathCompatibilityError,
+)
+from sugarsubstitute_shared.windows_long_paths import subprocess_path
 
 _DEPENDENCIES_MODULE = (
     Path(__file__).resolve().parents[1]
@@ -90,16 +94,16 @@ def test_install_nodepack_python_project_uses_noneditable_local_install(
         on_line: object | None,
         timeout_seconds: int | None = None,
         env: object | None = None,
-    ) -> int:
+    ) -> tuple[int, tuple[str, ...]]:
         observed["command"] = command
         observed["cwd"] = cwd
         observed["on_line"] = on_line
         observed["timeout_seconds"] = timeout_seconds
         observed["env"] = env
-        return 0
+        return 0, ()
 
     monkeypatch.setattr(
-        "substitute.infrastructure.comfy.nodepack_python_dependencies.stream_command",
+        "substitute.infrastructure.comfy.nodepack_python_dependencies.stream_command_collecting_output",
         fake_stream,
     )
 
@@ -112,11 +116,11 @@ def test_install_nodepack_python_project_uses_noneditable_local_install(
     )
 
     assert observed["command"] == [
-        str(python_path),
+        subprocess_path(python_path),
         "-m",
         "pip",
         "install",
-        str(nodepack_root),
+        subprocess_path(nodepack_root),
     ]
     assert observed["cwd"] == nodepack_root
     assert observed["on_line"] == emitted.append
@@ -135,12 +139,12 @@ def test_install_nodepack_python_project_raises_on_failure(
     def fake_stream(
         command: list[str],
         **kwargs: object,
-    ) -> int:
+    ) -> tuple[int, tuple[str, ...]]:
         _ = command, kwargs
-        return 9
+        return 9, ()
 
     monkeypatch.setattr(
-        "substitute.infrastructure.comfy.nodepack_python_dependencies.stream_command",
+        "substitute.infrastructure.comfy.nodepack_python_dependencies.stream_command_collecting_output",
         fake_stream,
     )
 
@@ -150,6 +154,36 @@ def test_install_nodepack_python_project_raises_on_failure(
             nodepack_root=tmp_path,
             display_name="SugarCubes",
         )
+
+
+@pytest.mark.platforms("windows")
+def test_install_nodepack_project_translates_pip_errno_two_long_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Nodepack installation should retain pip's overlong wheel-output evidence."""
+
+    failing_path = (
+        r"E:\Documents\Everything\Artificial Sweetener\runtime\installer-temp"
+        r"\managed-comfy\401c2092-bb13-4f3b-a377-997f1fab4ccd\temp"
+        r"\pip-ephem-wheel-cache-pmo9xg0b\wheels\59\1d\00"
+        r"\729d4b9dcecc8342dac49bcf6ab1415de9f48be12e466feb73"
+        r"\tmpzx280yzl\.tmp-by7a27ea\sugarcubes-0.11.0-py3-none-any.whl"
+    )
+    output = f"error: [Errno 2] No such file or directory: '{failing_path}'"
+    monkeypatch.setattr(
+        "substitute.infrastructure.comfy.nodepack_python_dependencies.stream_command_collecting_output",
+        lambda *args, **kwargs: (1, (output,)),
+    )
+
+    with pytest.raises(ExternalLongPathCompatibilityError) as failure:
+        install_nodepack_python_project(
+            python_executable=tmp_path / "python.exe",
+            nodepack_root=tmp_path,
+            display_name="SugarCubes",
+        )
+
+    assert failure.value.path == Path(failing_path)
 
 
 def test_installed_python_distribution_version_reads_metadata(

--- a/tests/test_onboarding_flow_service.py
+++ b/tests/test_onboarding_flow_service.py
@@ -23,10 +23,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from sugarsubstitute_shared.localization import render_source_application_text
-from sugarsubstitute_shared.windows_long_paths import (
+from sugarsubstitute_shared.external_path_failure import (
     ExternalLongPathCompatibilityError,
-    WindowsPathComponentTooLongError,
 )
+from sugarsubstitute_shared.windows_long_paths import WindowsPathComponentTooLongError
 
 import pytest
 
@@ -785,9 +785,7 @@ def test_flow_service_saves_preferences_model_root_and_credentials(
     assert provisioner_kwargs[0]["managed_model_root"] == custom_models
     assert provisioner_kwargs[0]["configure_model_root"] is True
     assert provisioner_kwargs[0]["refresh_core_nodepacks"] == frozenset(CoreNodepackId)
-    assert provisioner_kwargs[0]["installer_temp_root"] == (
-        tmp_path / "runtime" / "installer-temp" / "managed-comfy" / "transaction-id"
-    )
+    assert "installer_temp_root" not in provisioner_kwargs[0]
     assert "civitai-secret" not in "\n".join(logs)
 
 

--- a/tests/test_pygit2_repository_service.py
+++ b/tests/test_pygit2_repository_service.py
@@ -118,9 +118,11 @@ def test_clone_process_removes_partial_checkout_after_timeout(
     def raise_timeout(*args: object, **kwargs: object) -> None:
         """Materialize partial output before simulating an expired child."""
 
-        del args, kwargs
-        target.mkdir()
-        (target / ".git").mkdir()
+        del kwargs
+        command = args[0]
+        assert isinstance(command, tuple)
+        clone_target = Path(command[-1])
+        (clone_target / ".git").mkdir()
         raise subprocess.TimeoutExpired(("python", "clone"), timeout=1)
 
     monkeypatch.setattr(
@@ -135,6 +137,17 @@ def test_clone_process_removes_partial_checkout_after_timeout(
         )
 
     assert not target.exists()
+
+
+def test_repository_access_does_not_create_a_missing_target(tmp_path: Path) -> None:
+    """Read operations should preserve the absence of a requested repository."""
+
+    repository_path = tmp_path / "missing-repository"
+
+    with pytest.raises(RepositoryOperationError, match="Could not open repository"):
+        Pygit2RepositoryService().head_commit_id(repository_path)
+
+    assert not repository_path.exists()
 
 
 def _create_origin(tmp_path: Path) -> tuple[Path, pygit2.Repository]:

--- a/tests/test_real_shell_prompt_editor_autocomplete_scenarios.py
+++ b/tests/test_real_shell_prompt_editor_autocomplete_scenarios.py
@@ -1990,6 +1990,7 @@ def test_real_shell_contiguous_typing_undoes_as_one_group(
     """Contiguous word typing should undo as one owner-coalesced edit group."""
 
     field = harness.add_prompt_workflow(initial_text="")
+    before = harness.capture_state_snapshot(field, label="before-typing-group-alpha")
     harness.type_text(field, "alpha")
     typed = harness.capture_state_snapshot(field, label="after-typing-group-alpha")
     harness.focus_editor(field)
@@ -2012,8 +2013,15 @@ def test_real_shell_contiguous_typing_undoes_as_one_group(
         )
         pytest.fail(f"prompt editor invariant failed; artifacts: {artifact}")
 
-    assert typed.undo_typing_group_active
-    assert typed.undo_typing_group_last_cursor_position == len("alpha")
+    assert typed.source_text == "alpha"
+    if typed.undo_typing_group_active:
+        assert typed.undo_typing_group_last_cursor_position == len("alpha")
+        assert typed.undo_depth == before.undo_depth
+    else:
+        # A loaded runner may cross the real 900 ms idle boundary while the
+        # diagnostic snapshot pumps events; the committed word remains one step.
+        assert typed.undo_typing_group_last_cursor_position is None
+        assert typed.undo_depth == before.undo_depth + 1
     assert undone.source_text == ""
     assert not undone.undo_typing_group_active
     assert undone.redo_available

--- a/tests/test_windows_launcher_update_paths.py
+++ b/tests/test_windows_launcher_update_paths.py
@@ -1,0 +1,92 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify launcher replacement remains operational beyond legacy path limits."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from substitute.infrastructure.filesystem import remove_app_owned_path
+from sugarsubstitute_shared.launcher_update.models import (
+    LauncherInstallationRecord,
+    LauncherUpdateRequest,
+)
+from sugarsubstitute_shared.launcher_update.transaction import (
+    LauncherUpdateTransaction,
+)
+from sugarsubstitute_shared.windows_long_paths import operational_path
+
+
+@pytest.mark.platforms("windows")
+def test_transaction_promotes_launcher_inside_long_install_root(
+    tmp_path: Path,
+) -> None:
+    """Persisted update paths should retain extended filesystem transport."""
+
+    cleanup_root = operational_path(tmp_path / "long-launcher-update")
+    install_root = cleanup_root / "SugarSubstitute"
+    while len(str(install_root)) < 285:
+        install_root /= "deep-install-segment"
+    staged_root = install_root / "launcher" / "updates" / "staging" / "0.20.0"
+    request_path = install_root / "launcher" / "updates" / "pending.json"
+    try:
+        (install_root / "SugarSubstitute.exe").parent.mkdir(parents=True)
+        (install_root / "SugarSubstitute.exe").write_text(
+            "old launcher",
+            encoding="utf-8",
+        )
+        (install_root / "launcher-bin").mkdir()
+        (install_root / "launcher-bin" / "runtime.txt").write_text(
+            "old runtime",
+            encoding="utf-8",
+        )
+        staged_root.mkdir(parents=True)
+        (staged_root / "SugarSubstitute.exe").write_text(
+            "new launcher",
+            encoding="utf-8",
+        )
+        (staged_root / "launcher-bin").mkdir()
+        (staged_root / "launcher-bin" / "runtime.txt").write_text(
+            "new runtime",
+            encoding="utf-8",
+        )
+        LauncherUpdateRequest(
+            install_root=install_root,
+            version="0.20.0",
+            target_key="windows_x64",
+            staged_bundle_dir=staged_root,
+            relaunch=False,
+        ).save(request_path)
+
+        LauncherUpdateTransaction(wait_timeout_seconds=0).apply(
+            request_path=request_path
+        )
+
+        assert (install_root / "SugarSubstitute.exe").read_text(
+            encoding="utf-8"
+        ) == "new launcher"
+        assert (install_root / "launcher-bin" / "runtime.txt").read_text(
+            encoding="utf-8"
+        ) == "new runtime"
+        assert LauncherInstallationRecord.load(
+            install_root / "launcher" / "installation.json"
+        ) == LauncherInstallationRecord(version="0.20.0", target_key="windows_x64")
+        assert not request_path.exists()
+    finally:
+        remove_app_owned_path(cleanup_root)

--- a/tests/test_windows_long_paths.py
+++ b/tests/test_windows_long_paths.py
@@ -40,11 +40,13 @@ from substitute.infrastructure.comfy.managed_launcher import (
 from substitute.infrastructure.comfy.standalone_environment.extraction_process import (
     NativeSevenZipExtractionProcess,
 )
-from sugarsubstitute_shared.windows_long_paths import (
+from sugarsubstitute_shared.external_path_failure import (
     ExternalLongPathCompatibilityError,
+    external_long_path_error,
+)
+from sugarsubstitute_shared.windows_long_paths import (
     WindowsPathComponentTooLongError,
     WindowsLongPath,
-    external_long_path_error,
     extended_length_path,
     logical_path,
     operational_path,
@@ -53,6 +55,9 @@ from sugarsubstitute_shared.windows_long_paths import (
 from substitute.infrastructure.process.hidden_process_runner import run_command
 from substitute.infrastructure.filesystem import remove_app_owned_path
 from substitute.infrastructure.version_control.clone_process import Pygit2CloneProcess
+from substitute.infrastructure.version_control.pygit2_repository import (
+    Pygit2RepositoryService,
+)
 
 
 def test_extended_length_path_maps_drive_and_unc_paths() -> None:
@@ -295,6 +300,41 @@ def test_pygit2_clone_stages_and_promotes_to_long_destination(
     target = target_root
     while len(str(target)) < 285:
         target /= "segment-0123456789abcdef"
+    target.parent.mkdir(parents=True)
+
+    try:
+        Pygit2CloneProcess(timeout_seconds=30).clone(str(source), target)
+
+        assert (target / "proof.txt").read_text(encoding="utf-8") == "clone proof"
+        assert (target / ".git").is_dir()
+        service = Pygit2RepositoryService()
+        assert service.tracked_files(target) == (Path("proof.txt"),)
+        assert service.head_commit_id(target) is not None
+    finally:
+        remove_app_owned_path(target_root)
+
+
+@pytest.mark.platforms("windows")
+def test_pygit2_clone_stages_before_target_reaches_legacy_limit(
+    tmp_path: Path,
+) -> None:
+    """Libgit2 should not inherit a deep managed installation's path budget."""
+
+    source = tmp_path / "source-repository-before-limit"
+    source.mkdir()
+    repository = pygit2.init_repository(source, initial_head="main")
+    (source / "proof.txt").write_text("clone proof", encoding="utf-8")
+    repository.index.add_all()
+    repository.index.write()
+    tree = repository.index.write_tree()
+    signature = pygit2.Signature("SugarSubstitute Tests", "tests@example.invalid")
+    repository.create_commit("HEAD", signature, signature, "proof", tree, [])
+    target_root = operational_path(tmp_path / "managed-install-clone-target")
+    managed_root = target_root
+    while len(str(managed_root)) < 165:
+        managed_root /= "deep-managed-install-segment"
+    target = managed_root / "comfyui" / "custom_nodes" / "Substitute-BackEnd"
+    assert len(str(target)) < 260
     target.parent.mkdir(parents=True)
 
     try:

--- a/tests/test_windows_managed_install_wheel_build.py
+++ b/tests/test_windows_managed_install_wheel_build.py
@@ -1,0 +1,98 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Exercise real wheel building through managed-install path boundaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from substitute.infrastructure.comfy.managed_install_environment import (
+    build_managed_install_environment,
+)
+from substitute.infrastructure.comfy.managed_install_scratch import (
+    MANAGED_INSTALL_PATH_CONTRACT,
+    allocate_managed_install_scratch,
+)
+from sugarsubstitute_shared.windows_long_paths import operational_path, subprocess_path
+
+
+@pytest.mark.platforms("windows")
+def test_real_wheel_build_uses_budgeted_scratch_below_long_installation(
+    tmp_path: Path,
+) -> None:
+    """Pip should build a SugarCubes-shaped wheel without deep temporary paths."""
+
+    installation_root = operational_path(tmp_path / "Artificial Sweetener")
+    while len(str(installation_root)) < 170:
+        installation_root /= "deep-install-segment"
+    project_root = installation_root / "comfyui" / "custom_nodes" / "SugarCubes"
+    package_root = project_root / "sugarcubes"
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text(
+        '__version__ = "0.11.0"\n',
+        encoding="utf-8",
+    )
+    (project_root / "pyproject.toml").write_text(
+        "[build-system]\n"
+        'requires = ["setuptools"]\n'
+        'build-backend = "setuptools.build_meta"\n'
+        "\n"
+        "[project]\n"
+        'name = "SugarCubes"\n'
+        'version = "0.11.0"\n'
+        "\n"
+        "[tool.setuptools]\n"
+        'packages = ["sugarcubes"]\n',
+        encoding="utf-8",
+    )
+    install_target = tmp_path / "installed"
+    scratch = allocate_managed_install_scratch(installation_root)
+    try:
+        env = build_managed_install_environment(scratch.root)
+        result = subprocess.run(  # noqa: S603
+            [
+                subprocess_path(Path(sys.executable)),
+                "-m",
+                "pip",
+                "install",
+                "--no-deps",
+                "--no-build-isolation",
+                "--target",
+                subprocess_path(install_target),
+                subprocess_path(project_root),
+            ],
+            cwd=tmp_path,
+            env=env,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+        assert MANAGED_INSTALL_PATH_CONTRACT.accepts(scratch.root)
+        assert result.returncode == 0, result.stdout
+        assert (install_target / "sugarcubes" / "__init__.py").is_file()
+    finally:
+        scratch.cleanup()
+
+    assert not scratch.root.exists()

--- a/tests/test_windows_path_architecture.py
+++ b/tests/test_windows_path_architecture.py
@@ -1,0 +1,109 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Enforce ownership boundaries for Windows path compatibility."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_ENVIRONMENT_OWNER = Path(
+    "substitute/infrastructure/comfy/managed_install_environment.py"
+)
+_PATH_ENVIRONMENT_KEYS = {"TEMP", "TMP", "TMPDIR", "PIP_CACHE_DIR"}
+
+
+def test_managed_temporary_environment_has_one_source_owner() -> None:
+    """Installer code should not reconstruct path-bearing environment variables."""
+
+    assignments: set[tuple[Path, str]] = set()
+    for source_path in _production_python_files():
+        relative_path = source_path.relative_to(_REPOSITORY_ROOT)
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                key = _string_subscript_key(target)
+                if key in _PATH_ENVIRONMENT_KEYS:
+                    assignments.add((relative_path, key))
+
+    assert assignments == {
+        (_ENVIRONMENT_OWNER, "TEMP"),
+        (_ENVIRONMENT_OWNER, "TMP"),
+        (_ENVIRONMENT_OWNER, "TMPDIR"),
+        (_ENVIRONMENT_OWNER, "PIP_CACHE_DIR"),
+    }
+
+
+def test_orchestrators_do_not_construct_external_scratch_paths() -> None:
+    """Application and launch orchestration should delegate scratch placement."""
+
+    orchestrators = (
+        Path("substitute/application/onboarding/flow_service.py"),
+        Path("substitute/infrastructure/comfy/managed_install.py"),
+        Path("substitute/infrastructure/comfy/managed_launcher.py"),
+    )
+
+    for relative_path in orchestrators:
+        source = (_REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+        assert "installer-temp" not in source
+        assert ".substitute-installer-temp" not in source
+
+
+def test_path_representation_does_not_own_external_failure_diagnosis() -> None:
+    """Path transport and external diagnostics should remain separate concerns."""
+
+    source = (
+        _REPOSITORY_ROOT / "sugarsubstitute_shared/windows_long_paths.py"
+    ).read_text(encoding="utf-8")
+
+    assert "ExternalLongPathCompatibilityError" not in source
+    assert "external_long_path_error" not in source
+
+
+def test_repository_clone_delegates_external_scratch_placement() -> None:
+    """Repository subprocess orchestration should not invent temporary roots."""
+
+    source = (
+        _REPOSITORY_ROOT / "substitute/infrastructure/version_control/clone_process.py"
+    ).read_text(encoding="utf-8")
+
+    assert "RepositoryPathWorkspace.reserve" in source
+    assert "tempfile" not in source
+
+
+def _production_python_files() -> tuple[Path, ...]:
+    """Return first-party runtime Python files covered by the ownership gate."""
+
+    roots = ("launcher", "substitute", "sugarsubstitute_shared")
+    return tuple(
+        source_path
+        for root in roots
+        for source_path in (_REPOSITORY_ROOT / root).rglob("*.py")
+    )
+
+
+def _string_subscript_key(node: ast.AST) -> str | None:
+    """Return a literal string key assigned through one subscript."""
+
+    if not isinstance(node, ast.Subscript):
+        return None
+    if isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
+        return node.slice.value
+    return None

--- a/tests/test_windows_repository_path_workspace.py
+++ b/tests/test_windows_repository_path_workspace.py
@@ -1,0 +1,97 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Exercise native short aliases for Windows repository operations."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from substitute.infrastructure.filesystem import remove_app_owned_path
+from substitute.infrastructure.version_control.pygit2_repository import (
+    Pygit2RepositoryService,
+)
+from substitute.infrastructure.version_control.repository_path_workspace import (
+    REPOSITORY_DESCENDANT_BUDGET,
+    RepositoryPathWorkspace,
+)
+from sugarsubstitute_shared.windows_long_paths import (
+    WINDOWS_LEGACY_PATH_LIMIT,
+    operational_path,
+)
+
+
+@pytest.mark.platforms("windows")
+def test_workspace_alias_writes_to_target_and_cleans_only_alias(tmp_path: Path) -> None:
+    """A transient junction should preserve the repository it exposes."""
+
+    cleanup_root, repository_path = _deep_repository_path(tmp_path)
+    workspace = RepositoryPathWorkspace.reserve(repository_path, create_target=True)
+    try:
+        assert os.path.isjunction(workspace.access_path)
+        assert (
+            len(str(workspace.access_path)) + REPOSITORY_DESCENDANT_BUDGET
+            < WINDOWS_LEGACY_PATH_LIMIT
+        )
+        (workspace.access_path / "proof.txt").write_text("proof", encoding="utf-8")
+    finally:
+        workspace.cleanup()
+
+    try:
+        assert (repository_path / "proof.txt").read_text(encoding="utf-8") == "proof"
+        assert not workspace.access_path.exists()
+    finally:
+        remove_app_owned_path(cleanup_root)
+
+
+@pytest.mark.platforms("windows")
+def test_repository_service_initializes_and_reopens_deep_repository(
+    tmp_path: Path,
+) -> None:
+    """Initialization and later access should share the native alias boundary."""
+
+    cleanup_root, repository_path = _deep_repository_path(tmp_path)
+    service = Pygit2RepositoryService()
+    try:
+        service.initialize(repository_path)
+
+        assert (repository_path / ".git").is_dir()
+        assert service.head_commit_id(repository_path) is None
+        assert service.remote_urls(repository_path) == {}
+    finally:
+        remove_app_owned_path(cleanup_root)
+
+
+def _deep_repository_path(tmp_path: Path) -> tuple[Path, Path]:
+    """Return a managed-workspace-shaped path that triggers libgit2's limit."""
+
+    cleanup_root = operational_path(tmp_path / "repository-alias-target")
+    managed_root = cleanup_root
+    while len(str(managed_root)) < 165:
+        managed_root /= "deep-managed-install-segment"
+    repository_path = (
+        managed_root
+        / "comfyui"
+        / "custom_nodes"
+        / "SugarCubes"
+        / ".sugarcubes"
+        / "local"
+    )
+    assert len(str(repository_path)) < 260
+    return cleanup_root, repository_path

--- a/tools/ci/run_comfy_update_probe.py
+++ b/tools/ci/run_comfy_update_probe.py
@@ -71,7 +71,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     python_executable = prepare_environment(repository_root, workspace)
     ensure_managed_comfy_setup(
         workspace=workspace,
-        installer_temp_root=workspace.parent / "installer-temp" / "source",
         on_log=log,
     )
     source_runtime = detect_workspace_manager_runtime(
@@ -170,7 +169,6 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     ensure_managed_comfy_setup(
         workspace=workspace,
-        installer_temp_root=workspace.parent / "installer-temp" / "target",
         on_log=log,
     )
     managed_runtime = detect_workspace_manager_runtime(


### PR DESCRIPTION
## Summary

- centralize external-tool path budgets, short scratch allocation, and long-path failure diagnosis
- route managed pip installs, repository operations, launcher updates, and subprocess paths through focused infrastructure owners
- use a short application-owned junction workspace for libgit2 repositories on deep Windows paths
- isolate QFluent test module stubs discovered by external CI

## Root cause

The managed installer placed pip's scratch tree beneath an already-deep installation workspace. Pip and setuptools then added wheel-cache and temporary descendants that exceeded Windows path limits and surfaced the failure as misleading `Errno 2` output. Existing mitigation covered selected application-owned paths but did not provide a native contract for paths delegated to external tools.

## User impact

Managed ComfyUI and SugarCubes installation now retain sufficient descendant path capacity at deep Windows install locations. Repository cloning, local authoring repositories, launcher updates, nodepack dependencies, and Manager requirements use the same centralized path boundary and actionable diagnosis.

## Validation

- focused blast-area suite: 137 passed, 1 intentional skip
- full license, format, lint, and strict mypy gates passed
- full parallel test partition passed
- all 123 serial test modules passed
- release-style fresh install at an intentionally deep Windows path passed with a totally managed NVIDIA ComfyUI runtime, SugarCubes 0.11.0, and all required live node classes
- cross-platform validation passed all 14 jobs on Windows x64, Linux x64, macOS Apple Silicon, Ubuntu 24.04, Fedora 44, Arch Linux, and openSUSE Leap 16

Validation run: https://github.com/Artificial-Sweetener/SugarSubstitute/actions/runs/30841056959