### PR TITLE
ci(canary): publish one clear fast-path build

### DIFF
--- a/.github/workflows/comfy-compatibility.yml
+++ b/.github/workflows/comfy-compatibility.yml
@@ -2,9 +2,8 @@ name: Comfy compatibility
 
 on:
   push:
-    branches-ignore:
-      - main
-      - "dependabot/**"
+    branches:
+      - canary
     paths-ignore:
       - "**/*.md"
   pull_request:
@@ -16,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: comfy-compatibility-${{ github.workflow }}-${{ github.ref }}
+  group: comfy-compatibility-${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/managed-comfy-install.yml
+++ b/.github/workflows/managed-comfy-install.yml
@@ -3,11 +3,9 @@ name: managed Comfy install
 on:
   workflow_call:
   pull_request:
-    paths:
-      - ".github/workflows/managed-comfy-install.yml"
-      - "substitute/infrastructure/comfy/standalone_environment/**"
-      - "tools/ci/verify_managed_comfy_install.py"
-      - "tests/test_standalone_environment_pin.py"
+    branches:
+      - main
+      - canary
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -78,6 +78,7 @@ on:
         type: choice
         options:
           - all
+          - canary-fast
           - qualification-all
           - clean-all
           - clean-windows
@@ -140,6 +141,14 @@ jobs:
           CANDIDATE_VERSION: ${{ inputs.candidate_version }}
         run: |
           $scope = $env:QUALIFICATION_SCOPE
+          $supportedScopes = @(
+            "all", "canary-fast", "qualification-all", "clean-all",
+            "clean-windows", "clean-linux", "clean-macos", "updates-all",
+            "updates-windows", "updates-linux", "updates-macos", "managed-comfy"
+          )
+          if ($scope -notin $supportedScopes) {
+            throw "Unsupported qualification_scope: $scope"
+          }
           $cleanPlatforms = switch ($scope) {
             { $_ -in @("all", "qualification-all", "clean-all") } { @("windows", "linux"); break }
             "clean-windows" { @("windows"); break }
@@ -229,6 +238,30 @@ jobs:
           if (($published -or $fullQualification) -and $timeout -ne 3600.0) {
             throw "Published and full qualification require the canonical 3600-second timeout."
           }
+
+  validate-candidate-artifact:
+    name: Validate temporary candidate bytes
+    needs: validate-candidate-source
+    if: inputs.candidate_artifact_name != ''
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download exact temporary candidate channel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.candidate_artifact_name }}
+          path: build/candidate
+          run-id: ${{ inputs.candidate_run_id || github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify manifest identity and every release checksum
+        env:
+          CANDIDATE_CHANNEL: ${{ inputs.candidate_channel }}
+        run: |
+          set -euo pipefail
+          jq --exit-status --arg version "$CANDIDATE_VERSION" --arg channel "$CANDIDATE_CHANNEL" '.version == $version and .channel == $channel' build/candidate/manifest.json > /dev/null
+          (cd build/candidate && sha256sum --check checksums.txt)
+          if [ "$CANDIDATE_CHANNEL" = "canary" ]; then
+            grep --fixed-strings "releases/latest" build/candidate/.release-notes.md > /dev/null
+          fi
 
   clean-install:
     name: Clean install and launch (${{ matrix.name }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
         type: choice
         options:
           - full
+          - canary-fast
           - qualification-all
           - clean-all
           - clean-windows
@@ -98,9 +99,9 @@ jobs:
       )
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ (github.event_name == 'push' && github.ref_name == 'canary' && format('9999.1.{0}', github.run_number)) || steps.release-version.outputs.version || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && format('9999.0.{0}', github.run_number) || '') }}
-      should_release: ${{ (github.event_name == 'push' && github.ref_name == 'canary' && 'true') || steps.release-version.outputs.should_release || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && 'true' || 'false') }}
-      first_release: ${{ (github.event_name == 'push' && github.ref_name == 'canary' && 'false') || steps.release-version.outputs.first_release }}
+      version: ${{ steps.release-version.outputs.version || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && format('9999.0.{0}', github.run_number) || '') }}
+      should_release: ${{ steps.release-version.outputs.should_release || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && 'true' || 'false') }}
+      first_release: ${{ steps.release-version.outputs.first_release }}
       channel: ${{ (github.event_name == 'push' && github.ref_name == 'canary' && 'canary') || 'stable' }}
 
     steps:
@@ -111,21 +112,19 @@ jobs:
           fetch-tags: true
 
       - name: Setup Node
-        if: github.event_name != 'push' || github.ref_name != 'canary'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install release dependencies
-        if: github.event_name != 'push' || github.ref_name != 'canary'
         run: npm ci
 
       - name: Resolve next release version
-        if: github.event_name != 'push' || github.ref_name != 'canary'
         id: release-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUGAR_SUBSTITUTE_CANARY_RUN_NUMBER: ${{ github.event_name == 'push' && github.ref_name == 'canary' && github.run_number || '' }}
           SUGAR_SUBSTITUTE_QUALIFICATION_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && format('9999.0.{0}', github.run_number) || '' }}
         run: node scripts/resolve-next-release-version.mjs
 
@@ -333,11 +332,11 @@ jobs:
     runs-on: windows-latest
     outputs:
       candidate_tag: ${{ steps.publish.outputs.candidate_tag }}
-      candidate_artifact_name: ${{ steps.reuse.outputs.candidate_artifact_name || steps.publish.outputs.candidate_artifact_name }}
+      candidate_artifact_name: ${{ steps.reuse.outputs.candidate_artifact_name || steps.stage-artifact.outputs.candidate_artifact_name }}
       candidate_run_id: ${{ github.event.inputs.qualification_candidate_run_id || github.run_id }}
       candidate_version: ${{ github.event.inputs.qualification_candidate_version || needs.determine-version.outputs.version }}
       candidate_channel: ${{ needs.determine-version.outputs.channel }}
-      staged: ${{ steps.reuse.outputs.staged || steps.publish.outputs.staged }}
+      staged: ${{ steps.reuse.outputs.staged || steps.stage-artifact.outputs.staged || steps.publish.outputs.staged }}
 
     steps:
       - name: Checkout
@@ -409,13 +408,18 @@ jobs:
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           SUGAR_SUBSTITUTE_RELEASE_CHANNEL: canary
-          SUGAR_SUBSTITUTE_ASSET_BASE_URL: https://github.com/${{ github.repository }}/releases/download/canary-v${{ needs.determine-version.outputs.version }}
+          SUGAR_SUBSTITUTE_ASSET_BASE_URL: https://github.com/${{ github.repository }}/releases/download/canary
         run: node scripts\prepare-release-assets.mjs ${{ needs.determine-version.outputs.version }}
 
       - name: Prepare installer release notes
         if: github.event.inputs.qualification_candidate_run_id == ''
         shell: pwsh
         run: node scripts\release-notes-preamble.cjs --repository "${{ github.repository }}" --version "${{ needs.determine-version.outputs.version }}" --channel "${{ needs.determine-version.outputs.channel }}" --output "build\release-notes.md"
+
+      - name: Add Canary release notes to the candidate artifact
+        if: github.event.inputs.qualification_candidate_run_id == '' && needs.determine-version.outputs.channel == 'canary'
+        shell: pwsh
+        run: Copy-Item build\release-notes.md .local-release-channel\.release-notes.md
 
       - name: Prepare semantic release commit and tag without publishing stable
         if: github.event.inputs.qualification_candidate_run_id == '' && needs.determine-version.outputs.channel == 'stable' && needs.determine-version.outputs.first_release != 'true'
@@ -439,7 +443,13 @@ jobs:
         run: node scripts\prepare-release-assets.mjs ${{ needs.determine-version.outputs.version }}
 
       - name: Upload temporary non-release candidate channel
-        if: github.event.inputs.qualification_candidate_run_id == '' && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
+        if: >-
+          github.event.inputs.qualification_candidate_run_id == '' && (
+            needs.determine-version.outputs.channel == 'canary' || (
+              github.event_name == 'workflow_dispatch' &&
+              github.event.inputs.dry_run == 'true'
+            )
+          )
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: non-release-candidate-channel
@@ -448,38 +458,49 @@ jobs:
           retention-days: 1
           include-hidden-files: true
 
+      - name: Record temporary candidate channel
+        id: stage-artifact
+        if: >-
+          github.event.inputs.qualification_candidate_run_id == '' && (
+            needs.determine-version.outputs.channel == 'canary' || (
+              github.event_name == 'workflow_dispatch' &&
+              github.event.inputs.dry_run == 'true'
+            )
+          )
+        shell: pwsh
+        run: |
+          "candidate_artifact_name=non-release-candidate-channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "staged=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Publish exact bytes as a visible prerelease candidate
         id: publish
-        if: github.event.inputs.qualification_candidate_run_id == ''
+        if: >-
+          github.event.inputs.qualification_candidate_run_id == '' &&
+          needs.determine-version.outputs.channel == 'stable' && (
+            github.event_name != 'workflow_dispatch' ||
+            github.event.inputs.dry_run != 'true'
+          )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: pwsh
         run: |
           $version = "${{ needs.determine-version.outputs.version }}"
-          $channel = "${{ needs.determine-version.outputs.channel }}"
-          $tag = if ($channel -eq "canary") { "canary-v$version" } else { "v$version" }
-          if ("${{ github.event_name }}" -eq "workflow_dispatch" -and "${{ github.event.inputs.dry_run }}" -eq "true") {
-            Write-Output "Dry run: qualifying temporary candidate bytes without publishing $tag."
-            "candidate_artifact_name=non-release-candidate-channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            "staged=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          } else {
-            $assets = Get-ChildItem .local-release-channel -File | Select-Object -ExpandProperty FullName
-            $releaseNotes = Get-Content -Raw build\release-notes.md
-            $target = if ($channel -eq "canary" -or "${{ needs.determine-version.outputs.first_release }}" -eq "true") { "${{ github.sha }}" } else { $tag }
-            $title = if ($channel -eq "canary") { "SugarSubstitute Canary $version candidate" } else { "SugarSubstitute $version release candidate" }
-            gh release create $tag $assets --repo "${{ github.repository }}" --target $target --title $title --generate-notes --notes $releaseNotes --prerelease
-            $readback = gh release view $tag --repo "${{ github.repository }}" --json isDraft,isPrerelease,assets | ConvertFrom-Json
-            if ($readback.isDraft -or -not $readback.isPrerelease) {
-              throw "Candidate release was not published as a visible prerelease."
-            }
-            $expected = @(Get-ChildItem .local-release-channel -File | Select-Object -ExpandProperty Name | Sort-Object)
-            $actual = @($readback.assets | ForEach-Object { $_.name } | Sort-Object)
-            if (Compare-Object $expected $actual) {
-              throw "Candidate release assets differ from the qualified local channel."
-            }
-            "candidate_tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            "staged=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          $tag = "v$version"
+          $assets = Get-ChildItem .local-release-channel -File | Select-Object -ExpandProperty FullName
+          $releaseNotes = Get-Content -Raw build\release-notes.md
+          $target = if ("${{ needs.determine-version.outputs.first_release }}" -eq "true") { "${{ github.sha }}" } else { $tag }
+          gh release create $tag $assets --repo "${{ github.repository }}" --target $target --title "SugarSubstitute $version release candidate" --generate-notes --notes $releaseNotes --prerelease
+          $readback = gh release view $tag --repo "${{ github.repository }}" --json isDraft,isPrerelease,assets | ConvertFrom-Json
+          if ($readback.isDraft -or -not $readback.isPrerelease) {
+            throw "Candidate release was not published as a visible prerelease."
           }
+          $expected = @(Get-ChildItem .local-release-channel -File | Select-Object -ExpandProperty Name | Sort-Object)
+          $actual = @($readback.assets | ForEach-Object { $_.name } | Sort-Object)
+          if (Compare-Object $expected $actual) {
+            throw "Candidate release assets differ from the qualified local channel."
+          }
+          "candidate_tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "staged=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Reuse exact temporary candidate channel
         id: reuse
@@ -511,7 +532,7 @@ jobs:
       candidate_channel: ${{ needs.stage-candidate.outputs.candidate_channel }}
       candidate_artifact_name: ${{ needs.stage-candidate.outputs.candidate_artifact_name }}
       candidate_run_id: ${{ needs.stage-candidate.outputs.candidate_run_id }}
-      qualification_scope: ${{ inputs.qualification_scope == '' && 'all' || inputs.qualification_scope == 'full' && 'all' || inputs.qualification_scope }}
+      qualification_scope: ${{ github.event_name == 'push' && github.ref_name == 'canary' && 'canary-fast' || inputs.qualification_scope == '' && 'all' || inputs.qualification_scope == 'full' && 'all' || inputs.qualification_scope }}
       upgrade_selection: ${{ inputs.dry_run == 'true' && inputs.qualification_scope != 'full' && inputs.upgrade_selection || 'complete' }}
       qualification_timeout_seconds: ${{ inputs.dry_run == 'true' && inputs.qualification_scope != 'full' && inputs.qualification_timeout_seconds || '3600' }}
 
@@ -532,30 +553,44 @@ jobs:
           gh release edit "$CANDIDATE_TAG" --repo "${{ github.repository }}" --prerelease=false --latest
           gh release view "$CANDIDATE_TAG" --repo "${{ github.repository }}" --json isDraft,isPrerelease --jq 'select(.isDraft == false and .isPrerelease == false)' > /dev/null
 
+      - name: Download qualified Canary candidate
+        if: needs.stage-candidate.outputs.candidate_channel == 'canary'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.stage-candidate.outputs.candidate_artifact_name }}
+          path: build/canary-channel
+          run-id: ${{ needs.stage-candidate.outputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+
       - name: Publish qualified bytes to the rolling Canary feed
         if: needs.stage-candidate.outputs.candidate_channel == 'canary'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CANDIDATE_TAG: ${{ needs.stage-candidate.outputs.candidate_tag }}
           CANDIDATE_VERSION: ${{ needs.stage-candidate.outputs.candidate_version }}
         run: |
           set -euo pipefail
           channel_dir="build/canary-channel"
           readback_dir="build/canary-readback"
-          mkdir -p "$channel_dir" "$readback_dir"
-          gh release download "$CANDIDATE_TAG" --repo "${{ github.repository }}" --dir "$channel_dir"
+          mkdir -p "$readback_dir"
           python -c "import json, os, pathlib; payload=json.loads(pathlib.Path('$channel_dir/manifest.json').read_text()); assert payload['channel']=='canary', payload; assert payload['version']==os.environ['CANDIDATE_VERSION'], payload"
+          (cd "$channel_dir" && sha256sum --check checksums.txt)
 
           if ! gh release view canary --repo "${{ github.repository }}" > /dev/null 2>&1; then
-            gh release create canary --repo "${{ github.repository }}" --target canary --title "SugarSubstitute Canary" --notes "The latest fully qualified Canary installers and update manifest. Canary installations remain on this channel until the user installs Stable explicitly." --prerelease
+            gh release create canary --repo "${{ github.repository }}" --target "${{ github.sha }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION" --notes-file "$channel_dir/.release-notes.md" --prerelease
           fi
 
           for asset in "$channel_dir"/*; do
-            if [ "$(basename "$asset")" != "manifest.json" ]; then
+            case "$(basename "$asset")" in
+              manifest.json|*.exe|*.dmg|*.AppImage|*.deb) continue ;;
+            esac
+            gh release upload canary "$asset" --repo "${{ github.repository }}" --clobber
+          done
+          gh release upload canary "$channel_dir/manifest.json" --repo "${{ github.repository }}" --clobber
+          for asset in "$channel_dir"/*.exe "$channel_dir"/*.dmg "$channel_dir"/*.AppImage "$channel_dir"/*.deb; do
+            if [ -f "$asset" ]; then
               gh release upload canary "$asset" --repo "${{ github.repository }}" --clobber
             fi
           done
-          gh release upload canary "$channel_dir/manifest.json" --repo "${{ github.repository }}" --clobber
 
           while IFS= read -r asset_name; do
             if [ ! -f "$channel_dir/$asset_name" ]; then
@@ -563,8 +598,8 @@ jobs:
             fi
           done < <(gh release view canary --repo "${{ github.repository }}" --json assets --jq '.assets[].name')
 
-          gh release edit canary --repo "${{ github.repository }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION" --prerelease --latest=false
-          gh release edit "$CANDIDATE_TAG" --repo "${{ github.repository }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION (qualified)" --prerelease
+          gh api --method PATCH "repos/${{ github.repository }}/git/refs/tags/canary" -f sha="${{ github.sha }}" -F force=true > /dev/null
+          gh release edit canary --repo "${{ github.repository }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION" --notes-file "$channel_dir/.release-notes.md" --prerelease --latest=false
           gh release download canary --repo "${{ github.repository }}" --pattern manifest.json --dir "$readback_dir"
           cmp "$channel_dir/manifest.json" "$readback_dir/manifest.json"
           gh release view canary --repo "${{ github.repository }}" --json isDraft,isPrerelease --jq 'select(.isDraft == false and .isPrerelease == true)' > /dev/null

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches-ignore:
-      - main
-      - canary
-      - "dependabot/**"
-    paths-ignore:
-      - "**/*.md"
   pull_request:
     paths-ignore:
       - "**/*.md"
@@ -20,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: tests-${{ github.workflow }}-${{ github.ref }}
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/README.es.md
+++ b/README.es.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute?include_prereleases" alt="Última versión"></a>
+  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute" alt="Última versión"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/Artificial-Sweetener/SugarSubstitute/release.yml?branch=main&label=Tests" alt="Estado de las pruebas"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/downloads/Artificial-Sweetener/SugarSubstitute/total" alt="Descargas de versiones"></a>
   <a href="https://www.gnu.org/licenses/gpl-3.0.html"><img src="https://img.shields.io/badge/license-GPL--3.0--or--later-blue" alt="Licencia GPL-3.0 o posterior"></a>

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute?include_prereleases" alt="最新リリース"></a>
+  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute" alt="最新リリース"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/Artificial-Sweetener/SugarSubstitute/release.yml?branch=main&label=Tests" alt="テスト状況"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/downloads/Artificial-Sweetener/SugarSubstitute/total" alt="リリースのダウンロード数"></a>
   <a href="https://www.gnu.org/licenses/gpl-3.0.html"><img src="https://img.shields.io/badge/license-GPL--3.0--or--later-blue" alt="GPL-3.0-or-later ライセンス"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute?include_prereleases" alt="최신 릴리스"></a>
+  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute" alt="최신 릴리스"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/Artificial-Sweetener/SugarSubstitute/release.yml?branch=main&label=Tests" alt="테스트 상태"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/downloads/Artificial-Sweetener/SugarSubstitute/total" alt="릴리스 다운로드 수"></a>
   <a href="https://www.gnu.org/licenses/gpl-3.0.html"><img src="https://img.shields.io/badge/license-GPL--3.0--or--later-blue" alt="GPL-3.0-or-later 라이선스"></a>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute?include_prereleases" alt="Latest release"></a>
+  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute" alt="Latest release"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/Artificial-Sweetener/SugarSubstitute/release.yml?branch=main&label=Tests" alt="Test status"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/downloads/Artificial-Sweetener/SugarSubstitute/total" alt="Release downloads"></a>
   <a href="https://www.gnu.org/licenses/gpl-3.0.html"><img src="https://img.shields.io/badge/license-GPL--3.0--or--later-blue" alt="GPL-3.0-or-later license"></a>

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute?include_prereleases" alt="最新版本"></a>
+  <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest"><img src="https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute" alt="最新版本"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/Artificial-Sweetener/SugarSubstitute/release.yml?branch=main&label=Tests" alt="测试状态"></a>
   <a href="https://github.com/Artificial-Sweetener/SugarSubstitute/releases"><img src="https://img.shields.io/github/downloads/Artificial-Sweetener/SugarSubstitute/total" alt="版本下载量"></a>
   <a href="https://www.gnu.org/licenses/gpl-3.0.html"><img src="https://img.shields.io/badge/license-GPL--3.0--or--later-blue" alt="GPL-3.0-or-later 许可证"></a>

--- a/launcher/sugarsubstitute_launcher/release_sources.py
+++ b/launcher/sugarsubstitute_launcher/release_sources.py
@@ -158,15 +158,11 @@ def production_installer_release_source(version: str) -> VersionBoundReleaseSour
 
 
 def canary_installer_release_source(version: str) -> VersionBoundReleaseSource:
-    """Return the immutable Canary build and its rolling update feed."""
+    """Bind one Canary setup to the version currently on its rolling feed."""
 
     normalized_version = safe_launcher_version(version)
-    manifest_url = (
-        "https://github.com/Artificial-Sweetener/SugarSubstitute/"
-        f"releases/download/canary-v{normalized_version}/manifest.json"
-    )
     return VersionBoundReleaseSource(
-        manifest_url=manifest_url,
+        manifest_url=DEFAULT_CANARY_RELEASE_MANIFEST_URL,
         expected_version=normalized_version,
         expected_channel=CANARY_RELEASE_CHANNEL,
         update_manifest_url=DEFAULT_CANARY_RELEASE_MANIFEST_URL,

--- a/launcher/sugarsubstitute_launcher/update_policy.py
+++ b/launcher/sugarsubstitute_launcher/update_policy.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from launcher.sugarsubstitute_launcher.config import LauncherConfig
+from sugarsubstitute_shared.launcher_update.versions import compare_release_versions
 
 
 class UpdateCheckDecision(Enum):
@@ -93,34 +94,3 @@ def decide_app_payload_update(
         AppPayloadUpdateDecision.SKIP,
         "installed_current",
     )
-
-
-def compare_release_versions(left: str, right: str) -> int:
-    """Compare simple release version strings without accepting path-like values."""
-
-    left_parts = _version_parts(left)
-    right_parts = _version_parts(right)
-    maximum_length = max(len(left_parts), len(right_parts))
-    padded_left = [*left_parts, *([0] * (maximum_length - len(left_parts)))]
-    padded_right = [*right_parts, *([0] * (maximum_length - len(right_parts)))]
-    if padded_left > padded_right:
-        return 1
-    if padded_left < padded_right:
-        return -1
-    return 0
-
-
-def _version_parts(version: str) -> list[int]:
-    """Parse one dotted numeric release version."""
-
-    normalized = version.removeprefix("v").strip()
-    if not normalized:
-        raise ValueError("Release version must not be empty.")
-    if any(character in normalized for character in ("/", "\\", ":")):
-        raise ValueError(f"Release version must be a plain tag value: {version}")
-    parts: list[int] = []
-    for raw_part in normalized.split("."):
-        if not raw_part.isdigit():
-            raise ValueError(f"Release version must be dotted numeric: {version}")
-        parts.append(int(raw_part))
-    return parts

--- a/scripts/canary-release-version.cjs
+++ b/scripts/canary-release-version.cjs
@@ -1,0 +1,67 @@
+//    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+//    Copyright (C) 2026  Artificial Sweetener and contributors
+//
+//    This program is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+const CORE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+/**
+ * Add a monotonically increasing Canary identifier to the next Stable version.
+ *
+ * @param {string} nextStableVersion Exact semantic version expected for Stable.
+ * @param {string} runNumber Positive GitHub Actions run number.
+ * @returns {string} Canary semantic prerelease version.
+ */
+function createCanaryVersion(nextStableVersion, runNumber) {
+  const normalizedVersion = String(nextStableVersion).trim();
+  const normalizedRunNumber = String(runNumber).trim();
+  if (!CORE_VERSION_PATTERN.test(normalizedVersion)) {
+    throw new Error(`Expected a Stable semantic version: ${nextStableVersion}`);
+  }
+  if (!/^[1-9]\d*$/.test(normalizedRunNumber)) {
+    throw new Error(`Expected a positive Canary run number: ${runNumber}`);
+  }
+  return `${normalizedVersion}-canary.${normalizedRunNumber}`;
+}
+
+/**
+ * Return the patch release following the greatest Stable tag.
+ *
+ * @param {string[]} releaseTags Stable tags in vMAJOR.MINOR.PATCH form.
+ * @returns {string} Next patch version.
+ */
+function nextPatchVersion(releaseTags) {
+  const versions = releaseTags.map((tag) => {
+    const match = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(tag);
+    if (!match) {
+      throw new Error(`Expected a Stable release tag: ${tag}`);
+    }
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
+  });
+  if (versions.length === 0) {
+    throw new Error("Cannot derive a Canary version without a Stable release tag.");
+  }
+  versions.sort((left, right) => {
+    for (let index = 0; index < left.length; index += 1) {
+      if (left[index] !== right[index]) {
+        return left[index] - right[index];
+      }
+    }
+    return 0;
+  });
+  const [major, minor, patch] = versions.at(-1);
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+module.exports = { createCanaryVersion, nextPatchVersion };

--- a/scripts/prepare-release-assets.mjs
+++ b/scripts/prepare-release-assets.mjs
@@ -186,7 +186,7 @@ function resolvePythonPath(root) {
 function resolveAssetBaseUrl(repositoryName, version, channel) {
   const configuredBaseUrl = process.env.SUGAR_SUBSTITUTE_ASSET_BASE_URL;
   if (!configuredBaseUrl) {
-    const releaseTag = channel === "canary" ? `canary-v${version}` : `v${version}`;
+    const releaseTag = channel === "canary" ? "canary" : `v${version}`;
     return `https://github.com/${repositoryName}/releases/download/${releaseTag}`;
   }
   if (!configuredBaseUrl.startsWith("https://")) {

--- a/scripts/release-notes-preamble.cjs
+++ b/scripts/release-notes-preamble.cjs
@@ -44,7 +44,7 @@ function createInstallerReleaseNotes(repository, version, channel = "stable") {
   const canaryWarning = normalizedChannel === "canary"
     ? [
         "> [!WARNING]",
-        `> **Canary builds are intended for testers.** Most users should [download the latest Stable release](${stableReleaseUrl}) instead. This build may contain changes that have not completed Stable release qualification.`,
+        `> **DO NOT download this Canary build for normal use.** Canary builds are intended only for testers and may contain changes that have not completed Stable release qualification. [Download the latest Stable release instead](${stableReleaseUrl}).`,
         "",
       ]
     : [];

--- a/scripts/release-notes-preamble.cjs
+++ b/scripts/release-notes-preamble.cjs
@@ -22,7 +22,7 @@ const DEFAULT_REPOSITORY = "Artificial-Sweetener/SugarSubstitute";
  * Build the installer guidance prepended to every GitHub Release description.
  *
  * @param {string} repository GitHub repository in owner/name form.
- * @param {string} version Dotted numeric release version without a tag prefix.
+ * @param {string} version Semantic release version without a tag prefix.
  * @param {string} channel Published release channel.
  * @returns {string} Markdown release guidance.
  */
@@ -30,11 +30,10 @@ function createInstallerReleaseNotes(repository, version, channel = "stable") {
   const normalizedRepository = validateRepository(repository);
   const normalizedVersion = validateVersion(version);
   const normalizedChannel = validateChannel(channel);
-  const releaseTag = normalizedChannel === "canary"
-    ? `canary-v${normalizedVersion}`
-    : `v${normalizedVersion}`;
+  const releaseTag = normalizedChannel === "canary" ? "canary" : `v${normalizedVersion}`;
   const assetRoot = `https://github.com/${normalizedRepository}/releases/download/${releaseTag}`;
   const iconRoot = `https://raw.githubusercontent.com/${normalizedRepository}/${releaseTag}/docs/release/platforms`;
+  const stableReleaseUrl = `https://github.com/${normalizedRepository}/releases/latest`;
   const heading = normalizedChannel === "canary"
     ? "## Install SugarSubstitute Canary"
     : "## Install SugarSubstitute";
@@ -42,7 +41,16 @@ function createInstallerReleaseNotes(repository, version, channel = "stable") {
     ? "**Already using Canary?** Open SugarSubstitute normally. This installation follows only the Canary update feed and never switches to Stable automatically."
     : "**Already installed?** Open SugarSubstitute normally. It checks for application updates when it starts, usually once per day, and installs newer application versions automatically. You normally do not need another installer.";
 
+  const canaryWarning = normalizedChannel === "canary"
+    ? [
+        "> [!WARNING]",
+        `> **Canary builds are intended for testers.** Most users should [download the latest Stable release](${stableReleaseUrl}) instead. This build may contain changes that have not completed Stable release qualification.`,
+        "",
+      ]
+    : [];
+
   return [
+    ...canaryWarning,
     heading,
     "",
     "Download the installer for your platform:",

--- a/scripts/resolve-next-release-version.mjs
+++ b/scripts/resolve-next-release-version.mjs
@@ -22,11 +22,15 @@ import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 const releaseConfig = require("../.releaserc.cjs");
+const { createCanaryVersion, nextPatchVersion } = require(
+  "./canary-release-version.cjs",
+);
 const { selectVersionResolutionPlugins } = require(
   "./release-version-plugins.cjs",
 );
 const FIRST_RELEASE_VERSION = "0.9.0";
 const qualificationVersion = process.env.SUGAR_SUBSTITUTE_QUALIFICATION_VERSION;
+const canaryRunNumber = process.env.SUGAR_SUBSTITUTE_CANARY_RUN_NUMBER?.trim();
 const projectRoot = resolve(fileURLToPath(new URL("../", import.meta.url)));
 const releaseTags = git(["tag", "--list", "v[0-9]*"])
   .split(/\r?\n/)
@@ -47,18 +51,29 @@ if (qualificationVersion) {
   shouldRelease = true;
   firstRelease = false;
 } else if (releaseTags.length === 0) {
-  version = readFirstReleaseVersion();
+  const firstReleaseVersion = readFirstReleaseVersion();
+  version = canaryRunNumber
+    ? createCanaryVersion(firstReleaseVersion, canaryRunNumber)
+    : firstReleaseVersion;
   shouldRelease = true;
-  firstRelease = true;
+  firstRelease = !canaryRunNumber;
 } else {
   const { default: semanticRelease } = await import("semantic-release");
   const result = await semanticRelease({
+    ...(canaryRunNumber
+      ? { branches: [process.env.GITHUB_REF_NAME ?? "canary"] }
+      : {}),
     ci: false,
     dryRun: true,
     plugins: selectVersionResolutionPlugins(releaseConfig),
   });
-  version = result?.nextRelease?.version ?? "";
-  shouldRelease = version.length > 0;
+  const nextStableVersion =
+    result?.nextRelease?.version ??
+    (canaryRunNumber ? nextPatchVersion(releaseTags) : "");
+  version = canaryRunNumber
+    ? createCanaryVersion(nextStableVersion, canaryRunNumber)
+    : nextStableVersion;
+  shouldRelease = canaryRunNumber ? true : version.length > 0;
   firstRelease = false;
 }
 

--- a/substitute/presentation/canvas/host/canvas_host_activation_controller.py
+++ b/substitute/presentation/canvas/host/canvas_host_activation_controller.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer, Qt
+from PySide6.QtWidgets import QWidget
 
 from substitute.presentation.canvas.host.canvas_host_state import CanvasHostState
 
@@ -49,10 +50,20 @@ class CanvasHostActivationController:
             return False
         self._state.select(route_key)
         self._synchronize_presentation()
-        if keyboard_focus:
-            entry.page.widget.setFocus(Qt.FocusReason.OtherFocusReason)
         self._canvas_activated(route_key)
+        if keyboard_focus:
+            QTimer.singleShot(
+                0,
+                lambda: self._focus_selected_canvas(route_key, entry.page.widget),
+            )
         return True
+
+    def _focus_selected_canvas(self, route_key: str, widget: QWidget) -> None:
+        """Transfer focus after the originating pointer event has settled."""
+
+        if self._state.active_route_key != route_key:
+            return
+        widget.setFocus(Qt.FocusReason.OtherFocusReason)
 
 
 __all__ = ["CanvasHostActivationController"]

--- a/substitute/presentation/canvas/input/input_canvas_view.py
+++ b/substitute/presentation/canvas/input/input_canvas_view.py
@@ -118,7 +118,7 @@ class InputCanvas(QWidget):
 
         super().__init__(parent)
         self.setStyleSheet("border: none; background-color: transparent;")
-        self.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         features = _input_canvas_cutecanvas_features()
         if features != _DEFAULT_CUTECANVAS_FEATURES:
             trace_mark(

--- a/substitute/presentation/canvas/input/input_node_interaction_controller.py
+++ b/substitute/presentation/canvas/input/input_node_interaction_controller.py
@@ -164,8 +164,8 @@ class InputNodeInteractionController:
                     workflow,
                     mask_entry.mask_id,
                 )
-        self._activate_input_canvas()
         QTimer.singleShot(0, self._refresh_mask_pickers)
+        self._activate_input_canvas()
 
     def handle_mask_clicked(
         self,

--- a/sugarsubstitute_shared/launcher_update/versions.py
+++ b/sugarsubstitute_shared/launcher_update/versions.py
@@ -18,28 +18,101 @@
 
 from __future__ import annotations
 
+import re
+
+
+_PRERELEASE_IDENTIFIER = re.compile(r"^[0-9A-Za-z-]+$")
+
+
+class _ReleaseVersion:
+    """Represent the precedence-bearing parts of one release version."""
+
+    def __init__(self, release: tuple[int, ...], prerelease: tuple[str, ...] | None):
+        """Store validated release and prerelease components."""
+
+        self.release = release
+        self.prerelease = prerelease
+
 
 def compare_release_versions(left: str, right: str) -> int:
-    """Compare dotted numeric release versions."""
+    """Compare release versions using semantic prerelease precedence."""
 
-    left_parts = _version_parts(left)
-    right_parts = _version_parts(right)
-    width = max(len(left_parts), len(right_parts))
-    padded_left = (*left_parts, *([0] * (width - len(left_parts))))
-    padded_right = (*right_parts, *([0] * (width - len(right_parts))))
-    return (padded_left > padded_right) - (padded_left < padded_right)
+    left_version = _parse_release_version(left)
+    right_version = _parse_release_version(right)
+    release_comparison = _compare_release_parts(
+        left_version.release,
+        right_version.release,
+    )
+    if release_comparison != 0:
+        return release_comparison
+    return _compare_prerelease_parts(
+        left_version.prerelease,
+        right_version.prerelease,
+    )
 
 
-def _version_parts(version: str) -> tuple[int, ...]:
-    """Parse one release version and reject nonnumeric components."""
+def validate_release_version(version: str) -> None:
+    """Reject values that are not safe semantic release identifiers."""
+
+    _parse_release_version(version)
+
+
+def _parse_release_version(version: str) -> _ReleaseVersion:
+    """Parse one release version without accepting path-like values."""
 
     normalized = version.removeprefix("v").strip()
     if not normalized:
         raise ValueError("Release version must not be empty.")
-    parts = normalized.split(".")
-    if any(not part.isdigit() for part in parts):
-        raise ValueError(f"Release version must be numeric: {version}")
-    return tuple(int(part) for part in parts)
+    if any(character in normalized for character in ("/", "\\", ":")):
+        raise ValueError(f"Release version must be a plain tag value: {version}")
+    release_text, separator, prerelease_text = normalized.partition("-")
+    release_parts = release_text.split(".")
+    if len(release_parts) < 2 or any(not part.isdigit() for part in release_parts):
+        raise ValueError(f"Release version must be semantic: {version}")
+    prerelease = None
+    if separator:
+        identifiers = tuple(prerelease_text.split("."))
+        if not identifiers or any(
+            not identifier or _PRERELEASE_IDENTIFIER.fullmatch(identifier) is None
+            for identifier in identifiers
+        ):
+            raise ValueError(f"Release version must be semantic: {version}")
+        prerelease = identifiers
+    return _ReleaseVersion(tuple(int(part) for part in release_parts), prerelease)
 
 
-__all__ = ["compare_release_versions"]
+def _compare_release_parts(left: tuple[int, ...], right: tuple[int, ...]) -> int:
+    """Compare numeric release components after zero-padding."""
+
+    width = max(len(left), len(right))
+    padded_left = (*left, *([0] * (width - len(left))))
+    padded_right = (*right, *([0] * (width - len(right))))
+    return (padded_left > padded_right) - (padded_left < padded_right)
+
+
+def _compare_prerelease_parts(
+    left: tuple[str, ...] | None,
+    right: tuple[str, ...] | None,
+) -> int:
+    """Compare semantic prerelease identifiers."""
+
+    if left is None or right is None:
+        return (left is None) - (right is None)
+    for left_identifier, right_identifier in zip(left, right, strict=False):
+        if left_identifier == right_identifier:
+            continue
+        left_numeric = left_identifier.isdigit()
+        right_numeric = right_identifier.isdigit()
+        if left_numeric and right_numeric:
+            return (int(left_identifier) > int(right_identifier)) - (
+                int(left_identifier) < int(right_identifier)
+            )
+        if left_numeric != right_numeric:
+            return -1 if left_numeric else 1
+        return (left_identifier > right_identifier) - (
+            left_identifier < right_identifier
+        )
+    return (len(left) > len(right)) - (len(left) < len(right))
+
+
+__all__ = ["compare_release_versions", "validate_release_version"]

--- a/sugarsubstitute_shared/launcher_version.py
+++ b/sugarsubstitute_shared/launcher_version.py
@@ -18,12 +18,16 @@
 
 from __future__ import annotations
 
+from sugarsubstitute_shared.launcher_update.versions import validate_release_version
+
 
 def safe_launcher_version(version: str) -> str:
     """Return a filesystem-safe launcher release version identifier."""
 
-    if not version or any(character not in "0123456789.-" for character in version):
-        raise ValueError(f"Unsafe launcher version: {version!r}")
+    try:
+        validate_release_version(version)
+    except ValueError as error:
+        raise ValueError(f"Unsafe launcher version: {version!r}") from error
     return version
 
 

--- a/tests/test_canvas_host_contract.py
+++ b/tests/test_canvas_host_contract.py
@@ -187,6 +187,26 @@ def test_host_activation_can_transfer_keyboard_focus_to_selected_canvas() -> Non
         host.close()
 
 
+def test_deferred_focus_does_not_override_a_newer_canvas_activation() -> None:
+    """A queued pointer-event handoff must not focus a superseded route."""
+
+    host, input_canvas, output_canvas = _host()
+    try:
+        input_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocus()
+        _app().processEvents()
+
+        assert host.activate_canvas("Input", keyboard_focus=True)
+        assert host.activate_canvas("Output", keyboard_focus=False)
+        _app().processEvents()
+
+        assert host.is_canvas_visible("Output")
+        assert output_canvas.hasFocus()
+    finally:
+        host.close()
+
+
 def test_selector_opens_shared_anchored_picker() -> None:
     """Clicking the host anchor should use the shared canvas navigation popup."""
 

--- a/tests/test_dependency_security_contract.py
+++ b/tests/test_dependency_security_contract.py
@@ -143,7 +143,7 @@ def test_dependency_audits_run_without_repository_changes() -> None:
 
 
 def test_release_and_dependabot_branches_run_one_authoritative_suite() -> None:
-    """Avoid duplicate push and pull-request matrices for owned branch trains."""
+    """Run topic-branch matrices through their pull request only."""
 
     workflow = yaml.safe_load(
         (PROJECT_ROOT / ".github" / "workflows" / "tests.yml").read_text(
@@ -151,11 +151,7 @@ def test_release_and_dependabot_branches_run_one_authoritative_suite() -> None:
         )
     )
 
-    assert workflow[True]["push"]["branches-ignore"] == [
-        "main",
-        "canary",
-        "dependabot/**",
-    ]
+    assert "push" not in workflow[True]
 
 
 def _job_script(job: dict[str, object]) -> str:

--- a/tests/test_installer_release_binding.py
+++ b/tests/test_installer_release_binding.py
@@ -57,16 +57,16 @@ def test_bound_installer_persists_stable_update_feed() -> None:
 
 
 def test_canary_installer_binds_exact_build_and_persists_canary_feed() -> None:
-    """Canary setup must install exact bytes and retain only its rolling feed."""
+    """Canary setup must bind the rolling manifest to its embedded version."""
 
-    source = canary_installer_release_source("9999.1.42")
+    source = canary_installer_release_source("0.21.0-canary.42")
     config = release_source_config_for(source)
 
     assert source.manifest_url == (
         "https://github.com/Artificial-Sweetener/SugarSubstitute/"
-        "releases/download/canary-v9999.1.42/manifest.json"
+        "releases/download/canary/manifest.json"
     )
-    assert source.expected_version == "9999.1.42"
+    assert source.expected_version == "0.21.0-canary.42"
     assert source.expected_channel == "canary"
     assert config is not None
     assert config.manifest_url == DEFAULT_CANARY_RELEASE_MANIFEST_URL

--- a/tests/test_launcher_skeleton.py
+++ b/tests/test_launcher_skeleton.py
@@ -414,10 +414,10 @@ def test_frozen_installer_uses_production_release_without_embedded_channel(
     assert source.manifest_url != DEFAULT_RELEASE_MANIFEST_URL
 
 
-def test_frozen_canary_installer_uses_exact_canary_release(
+def test_frozen_canary_installer_binds_rolling_canary_release(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A frozen Canary setup must retain its exact build and rolling feed."""
+    """A frozen Canary setup must verify its build on the rolling feed."""
 
     monkeypatch.setattr(
         "launcher.sugarsubstitute_launcher.application.installation.release_source_policy.discover_packaged_release_root",
@@ -430,14 +430,13 @@ def test_frozen_canary_installer_uses_exact_canary_release(
 
     source = resolve_initial_install_release_source(
         frozen_setup=True,
-        release_version="9999.1.42",
+        release_version="0.21.0-canary.42",
     )
 
     assert isinstance(source, VersionBoundReleaseSource)
     assert source.expected_channel == "canary"
-    assert source.manifest_url.endswith(
-        "/releases/download/canary-v9999.1.42/manifest.json"
-    )
+    assert source.expected_version == "0.21.0-canary.42"
+    assert source.manifest_url.endswith("/releases/download/canary/manifest.json")
     assert source.update_manifest_url.endswith(
         "/releases/download/canary/manifest.json"
     )

--- a/tests/test_launcher_update_policy.py
+++ b/tests/test_launcher_update_policy.py
@@ -28,11 +28,11 @@ from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from launcher.sugarsubstitute_launcher.update_policy import (
     AppPayloadUpdateDecision,
     UpdateCheckDecision,
-    compare_release_versions,
     decide_app_payload_update,
     decide_update_check,
 )
 from launcher.sugarsubstitute_launcher.update_state import LauncherUpdateState
+from sugarsubstitute_shared.launcher_update.versions import compare_release_versions
 
 
 def test_launcher_update_state_defaults_when_missing(tmp_path: Path) -> None:
@@ -153,12 +153,15 @@ def test_app_payload_update_policy_installs_missing_or_newer_versions() -> None:
     )
 
 
-def test_compare_release_versions_requires_plain_dotted_numeric_versions() -> None:
-    """Release comparison should reject path-like or non-numeric tags."""
+def test_compare_release_versions_supports_semantic_prereleases() -> None:
+    """Release comparison should order stable and Canary semantic versions."""
 
     assert compare_release_versions("v0.10.0", "0.9.9") == 1
     assert compare_release_versions("0.4", "0.4.0") == 0
+    assert compare_release_versions("0.21.0-canary.43", "0.21.0-canary.42") == 1
+    assert compare_release_versions("0.21.0", "0.21.0-canary.43") == 1
+    assert compare_release_versions("0.21.0-canary.1", "0.21.0-beta.1") == 1
     with pytest.raises(ValueError, match="plain tag"):
         compare_release_versions("0.4/evil", "0.4.0")
-    with pytest.raises(ValueError, match="dotted numeric"):
+    with pytest.raises(ValueError, match="semantic"):
         compare_release_versions("latest", "0.4.0")

--- a/tests/test_release_payload_builder.py
+++ b/tests/test_release_payload_builder.py
@@ -56,8 +56,23 @@ def test_release_builder_rejects_launcher_unsafe_version(tmp_path: Path) -> None
         build_local_release_channel(
             repo_root=repo_root,
             output_dir=repo_root / ".local-release-channel",
-            version="0.10.0-local.20260716",
+            version="../0.10.0",
         )
+
+
+def test_release_builder_accepts_semantic_prerelease_version(tmp_path: Path) -> None:
+    """Canary semantic versions must remain safe for release payload paths."""
+
+    repo_root = _write_fixture_repo(tmp_path)
+
+    result = build_local_release_channel(
+        repo_root=repo_root,
+        output_dir=repo_root / ".local-release-channel",
+        version="0.21.0-canary.42",
+    )
+
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["version"] == "0.21.0-canary.42"
 
 
 def test_release_payload_cli_runs_by_file_path(tmp_path: Path) -> None:

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -1057,6 +1057,26 @@ def test_readme_test_badge_tracks_authoritative_main_workflow() -> None:
     assert "actions/workflows/tests.yml/badge.svg" not in readme
 
 
+def test_all_readme_release_badges_exclude_prereleases() -> None:
+    """Release badges must display and navigate only to the latest Stable release."""
+
+    expected_image = (
+        "https://img.shields.io/github/v/release/Artificial-Sweetener/SugarSubstitute"
+    )
+    expected_target = (
+        "https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest"
+    )
+    for readme_path in sorted(PROJECT_ROOT.glob("README*.md")):
+        readme = readme_path.read_text(encoding="utf-8")
+        release_badge_line = next(
+            line for line in readme.splitlines() if expected_image in line
+        )
+
+        assert f'href="{expected_target}"' in release_badge_line
+        assert f'src="{expected_image}"' in release_badge_line
+        assert "include_prereleases" not in release_badge_line
+
+
 def test_readme_explains_comfy_setup_modes_and_remote_requirements() -> None:
     """Keep setup ownership and remote requirements visible to installers."""
 

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -229,7 +229,7 @@ def test_main_release_requires_the_authoritative_cross_platform_suite() -> None:
 
 
 def test_canary_isolated_release_train_contract() -> None:
-    """Canary must qualify exact bytes before updating its isolated public feed."""
+    """Canary must validate exact bytes before updating one isolated public feed."""
 
     release_text = (PROJECT_ROOT / ".github" / "workflows" / "release.yml").read_text(
         encoding="utf-8"
@@ -242,13 +242,22 @@ def test_canary_isolated_release_train_contract() -> None:
     )
 
     assert "      - main\n      - canary" in release_text
-    assert "format('9999.1.{0}', github.run_number)" in release_text
+    assert "SUGAR_SUBSTITUTE_CANARY_RUN_NUMBER:" in release_text
+    assert "format('9999.1.{0}', github.run_number)" not in release_text
     assert "SUGAR_SUBSTITUTE_RELEASE_CHANNEL: canary" in release_text
-    assert '"canary-v$version"' in release_text
+    assert "releases/download/canary" in release_text
+    assert '"canary-v$version"' not in release_text
     assert "release-qualification.yml" in release_text
+    assert "'canary-fast'" in release_text
+    assert "Upload temporary non-release candidate channel" in release_text
+    assert "validate-candidate-artifact:" in (
+        PROJECT_ROOT / ".github" / "workflows" / "release-qualification.yml"
+    ).read_text(encoding="utf-8")
     promotion = release_text.split("  promote-release:", maxsplit=1)[1]
+    assert "Download qualified Canary candidate" in promotion
     assert "gh release upload canary" in promotion
     assert 'gh release upload canary "$channel_dir/manifest.json"' in promotion
+    assert promotion.count('gh release edit "$CANDIDATE_TAG"') == 1
     assert "--clobber" in promotion
     assert "--prerelease=false --latest" in promotion
     assert "github.ref_name == 'main'" in promotion
@@ -284,7 +293,7 @@ def test_release_version_script_embeds_canary_channel(tmp_path: Path) -> None:
     javascript = (
         f"import {{ updateReleaseVersions }} from {json.dumps(script_url)}; "
         f"updateReleaseVersions(new URL({json.dumps(root_url)}), "
-        '"9999.1.42", "canary");'
+        '"0.21.0-canary.42", "canary");'
     )
 
     subprocess.run(
@@ -298,8 +307,69 @@ def test_release_version_script_embeds_canary_channel(tmp_path: Path) -> None:
     ).read_text(encoding="utf-8") == 'RELEASE_CHANNEL = "canary"\n'
     assert (
         json.loads((tmp_path / "package.json").read_text(encoding="utf-8"))["version"]
-        == "9999.1.42"
+        == "0.21.0-canary.42"
     )
+
+
+def test_canary_version_derives_from_next_stable_release() -> None:
+    """Canary versions should identify their future Stable base and CI build."""
+
+    script = """
+const versions = require('./scripts/canary-release-version.cjs');
+process.stdout.write(JSON.stringify({
+  canary: versions.createCanaryVersion('0.21.0', '142'),
+  fallback: versions.nextPatchVersion(['v0.19.2', 'v0.20.1', 'v0.20.0']),
+}));
+"""
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "canary": "0.21.0-canary.142",
+        "fallback": "0.20.2",
+    }
+
+
+def test_canary_release_notes_direct_normal_users_to_stable(tmp_path: Path) -> None:
+    """Canary notes should immediately route ordinary users to Stable."""
+
+    output_path = tmp_path / "release-notes.md"
+    result = subprocess.run(
+        [
+            "node",
+            "scripts/release-notes-preamble.cjs",
+            "--repository",
+            "Artificial-Sweetener/Substitute-Test",
+            "--version",
+            "0.21.0-canary.42",
+            "--channel",
+            "canary",
+            "--output",
+            str(output_path),
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    notes = output_path.read_text(encoding="utf-8")
+    stable_url = (
+        "https://github.com/Artificial-Sweetener/Substitute-Test/releases/latest"
+    )
+    assert notes.startswith("> [!WARNING]\n")
+    assert f"[download the latest Stable release]({stable_url})" in notes
+    assert "Canary builds are intended for testers" in notes
+    assert "releases/download/canary/SugarSubstitute-0.21.0-canary.42" in notes
 
 
 def test_cross_platform_validation_requires_explicit_invocation() -> None:

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -427,6 +427,20 @@ def test_managed_comfy_install_uses_exact_pin_and_artifact_cache() -> None:
     assert "pip install torch" not in workflow_text
 
 
+def test_required_managed_comfy_check_runs_for_every_protected_pr() -> None:
+    """Required branch checks must not disappear behind path filtering."""
+
+    workflow_text = (
+        PROJECT_ROOT / ".github" / "workflows" / "managed-comfy-install.yml"
+    ).read_text(encoding="utf-8")
+    pull_request_trigger = workflow_text.split("  pull_request:", maxsplit=1)[1].split(
+        "  workflow_dispatch:", maxsplit=1
+    )[0]
+
+    assert "    branches:\n      - main\n      - canary\n" in pull_request_trigger
+    assert "paths:" not in pull_request_trigger
+
+
 def test_release_qualification_covers_clean_launch_and_upgrade_depth() -> None:
     """Release candidates must prove exact installers before stable promotion."""
 

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -381,8 +381,9 @@ def test_canary_release_notes_direct_normal_users_to_stable(tmp_path: Path) -> N
         "https://github.com/Artificial-Sweetener/Substitute-Test/releases/latest"
     )
     assert notes.startswith("> [!WARNING]\n")
-    assert f"[download the latest Stable release]({stable_url})" in notes
-    assert "Canary builds are intended for testers" in notes
+    assert f"[Download the latest Stable release instead]({stable_url})" in notes
+    assert "DO NOT download this Canary build for normal use" in notes
+    assert "Canary builds are intended only for testers" in notes
     assert "releases/download/canary/SugarSubstitute-0.21.0-canary.42" in notes
 
 

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -52,7 +52,7 @@ def test_documentation_only_changes_skip_automatic_ci() -> None:
     }
     triggers = {name: workflow[True] for name, workflow in workflows.items()}
 
-    assert triggers["tests.yml"]["push"]["paths-ignore"] == (_DOCUMENTATION_PATH_FILTER)
+    assert "push" not in triggers["tests.yml"]
     assert triggers["tests.yml"]["pull_request"]["paths-ignore"] == (
         _DOCUMENTATION_PATH_FILTER
     )
@@ -222,10 +222,24 @@ def test_main_release_requires_the_authoritative_cross_platform_suite() -> None:
     )
     assert jobs["determine-version"]["needs"] == "tests"
     assert "  workflow_call:" in tests_workflow_text
-    assert (
-        '    branches-ignore:\n      - main\n      - canary\n      - "dependabot/**"'
-        in (tests_workflow_text)
-    )
+    assert "  push:" not in tests_workflow_text.split("permissions:", maxsplit=1)[0]
+
+
+def test_push_and_pull_request_runs_share_commit_concurrency() -> None:
+    """Opening or updating a PR must cancel its duplicate branch-push run."""
+
+    for workflow_name in ("tests.yml", "comfy-compatibility.yml"):
+        workflow = yaml.safe_load(
+            (PROJECT_ROOT / ".github" / "workflows" / workflow_name).read_text(
+                encoding="utf-8"
+            )
+        )
+        concurrency = workflow["concurrency"]
+
+        assert (
+            "github.event.pull_request.head.sha || github.sha" in concurrency["group"]
+        )
+        assert concurrency["cancel-in-progress"] is True
 
 
 def test_canary_isolated_release_train_contract() -> None:


### PR DESCRIPTION
## Summary
- validate Canary pushes through cross-platform tests, native installer builds, and a focused candidate-artifact integrity gate instead of the exhaustive installation/update matrix
- publish each Canary build into the single rolling Canary release without a second visible candidate release
- derive readable semantic Canary versions from the next Stable version and bind Canary installers to the rolling manifest
- lead Canary release notes with a warning and a direct link to the latest Stable release

## Verification
- focused release, installer-binding, payload, launcher, and update-policy tests
- repository-wide Ruff format check and lint
- strict mypy
- architecture governance

The existing Canary release is unchanged by this PR. Publication occurs only after merge to the protected canary branch.