### PR TITLE
fix(ci): stabilize native canvas release checks

### DIFF
--- a/substitute/presentation/canvas/host/canvas_host_activation_controller.py
+++ b/substitute/presentation/canvas/host/canvas_host_activation_controller.py
@@ -54,9 +54,21 @@ class CanvasHostActivationController:
         if keyboard_focus:
             QTimer.singleShot(
                 0,
-                lambda: self._focus_selected_canvas(route_key, entry.page.widget),
+                lambda: self._settle_selected_canvas_focus(
+                    route_key,
+                    entry.page.widget,
+                ),
             )
         return True
+
+    def _settle_selected_canvas_focus(self, route_key: str, widget: QWidget) -> None:
+        """Focus now and settle behind projections spawned by activation."""
+
+        self._focus_selected_canvas(route_key, widget)
+        QTimer.singleShot(
+            0,
+            lambda: self._focus_selected_canvas(route_key, widget),
+        )
 
     def _focus_selected_canvas(self, route_key: str, widget: QWidget) -> None:
         """Transfer focus after the originating pointer event has settled."""

--- a/tests/ci_test_policy.py
+++ b/tests/ci_test_policy.py
@@ -117,6 +117,8 @@ SERIAL_TEST_MODULES = frozenset(
         "tests/test_prompt_projection_input_method.py",
         "tests/test_prompt_projection_layout_surface.py",
         "tests/test_prompt_projection_literal_normalization.py",
+        # Projection layout owns native Qt text geometry that can terminate xdist.
+        "tests/test_prompt_projection_layout_contract.py",
         "tests/test_prompt_projection_lora_surface.py",
         # Paint-cache tests construct Qt text layouts that are not xdist-safe.
         "tests/test_prompt_projection_paint_cache.py",

--- a/tests/test_canvas_host_contract.py
+++ b/tests/test_canvas_host_contract.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from PySide6.QtCore import QRect, Signal, Qt
+from PySide6.QtCore import QRect, QTimer, Signal, Qt
 from PySide6.QtWidgets import QApplication, QWidget
 from qfluentwidgets import Pivot, SegmentedItem  # type: ignore[import-untyped]
 import pytest
@@ -203,6 +203,32 @@ def test_deferred_focus_does_not_override_a_newer_canvas_activation() -> None:
 
         assert host.is_canvas_visible("Output")
         assert output_canvas.hasFocus()
+    finally:
+        host.close()
+
+
+def test_activation_focus_settles_after_nested_same_event_projections() -> None:
+    """Nested toolbar projections must not steal picker-requested canvas focus."""
+
+    host, input_canvas, output_canvas = _host()
+    try:
+        input_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocus()
+        _app().processEvents()
+
+        host.canvas_activated.connect(
+            lambda _route_key: QTimer.singleShot(
+                0,
+                lambda: QTimer.singleShot(0, output_canvas.setFocus),
+            )
+        )
+
+        assert host.activate_canvas("Input", keyboard_focus=True)
+        for _cycle in range(3):
+            _app().processEvents()
+
+        assert input_canvas.hasFocus()
     finally:
         host.close()
 

--- a/tests/test_ci_test_policy.py
+++ b/tests/test_ci_test_policy.py
@@ -37,6 +37,7 @@ from tests.ci_test_policy import (
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 TESTS_ROOT = PROJECT_ROOT / "tests"
 OUTPUT_NAVIGATION_CONTRACT_MODULE = "tests/test_output_canvas_navigation_contract.py"
+PROJECTION_LAYOUT_CONTRACT_MODULE = "tests/test_prompt_projection_layout_contract.py"
 
 
 @pytest.mark.parametrize(
@@ -118,6 +119,12 @@ def test_serial_inventory_covers_existing_xdist_sensitive_modules() -> None:
         for relative_path in SERIAL_TEST_MODULES
         if not (PROJECT_ROOT / relative_path).is_file()
     } == set()
+
+
+def test_projection_layout_contract_remains_isolated_from_xdist() -> None:
+    """Keep native Qt text-layout ownership out of parallel worker teardown."""
+
+    assert PROJECTION_LAYOUT_CONTRACT_MODULE in SERIAL_TEST_MODULES
 
 
 def test_output_navigation_contract_remains_in_ordinary_parallel_ci() -> None:


### PR DESCRIPTION
## Outcome

Stabilizes the two native-canvas failures exposed by Canary release qualification without retries, increased timeouts, or weakened assertions.

- Runs the native Qt projection-layout contract outside xdist so macOS worker teardown cannot terminate with a bus error.
- Uses a two-phase host focus handoff so nested toolbar/context projection cannot steal picker-requested Input editing focus on Linux.

## Evidence

- The formerly crashing projection-layout module passes in its isolated serial process.
- The full real-shell input-editor module passes with the nested-projection focus regression.
- Full format, lint, strict mypy, architecture, parallel, and 129-module serial gates pass locally.