### PR TITLE
fix(releases): publish Canary through an unambiguous rolling feed

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -113,7 +113,7 @@ env:
   CANDIDATE_VERSION: ${{ inputs.candidate_version }}
   CANDIDATE_TAG: ${{ inputs.candidate_tag }}
   CANDIDATE_MANIFEST_URL: https://github.com/${{ github.repository }}/releases/download/${{ inputs.candidate_tag }}/manifest.json
-  EXPECTED_UPDATE_MANIFEST_URL: ${{ inputs.candidate_channel == 'canary' && format('https://github.com/{0}/releases/download/canary/manifest.json', github.repository) || format('https://github.com/{0}/releases/latest/download/manifest.json', github.repository) }}
+  EXPECTED_UPDATE_MANIFEST_URL: ${{ inputs.candidate_channel == 'canary' && format('https://github.com/{0}/releases/download/canary-latest/manifest.json', github.repository) || format('https://github.com/{0}/releases/latest/download/manifest.json', github.repository) }}
   QUALIFICATION_TIMEOUT_SECONDS: ${{ inputs.qualification_timeout_seconds }}
   STANDALONE_CACHE: build/managed-comfy-cache
   LINUX_QT_PACKAGES: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,7 +408,7 @@ jobs:
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           SUGAR_SUBSTITUTE_RELEASE_CHANNEL: canary
-          SUGAR_SUBSTITUTE_ASSET_BASE_URL: https://github.com/${{ github.repository }}/releases/download/canary
+          SUGAR_SUBSTITUTE_ASSET_BASE_URL: https://github.com/${{ github.repository }}/releases/download/canary-latest
         run: node scripts\prepare-release-assets.mjs ${{ needs.determine-version.outputs.version }}
 
       - name: Prepare installer release notes
@@ -575,31 +575,31 @@ jobs:
           python -c "import json, os, pathlib; payload=json.loads(pathlib.Path('$channel_dir/manifest.json').read_text()); assert payload['channel']=='canary', payload; assert payload['version']==os.environ['CANDIDATE_VERSION'], payload"
           (cd "$channel_dir" && sha256sum --check checksums.txt)
 
-          if ! gh release view canary --repo "${{ github.repository }}" > /dev/null 2>&1; then
-            gh release create canary --repo "${{ github.repository }}" --target "${{ github.sha }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION" --notes-file "$channel_dir/.release-notes.md" --prerelease
+          if ! gh release view canary-latest --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            gh release create canary-latest --repo "${{ github.repository }}" --target "${{ github.sha }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION" --notes-file "$channel_dir/.release-notes.md" --prerelease
           fi
 
           for asset in "$channel_dir"/*; do
             case "$(basename "$asset")" in
               manifest.json|*.exe|*.dmg|*.AppImage|*.deb) continue ;;
             esac
-            gh release upload canary "$asset" --repo "${{ github.repository }}" --clobber
+            gh release upload canary-latest "$asset" --repo "${{ github.repository }}" --clobber
           done
-          gh release upload canary "$channel_dir/manifest.json" --repo "${{ github.repository }}" --clobber
+          gh release upload canary-latest "$channel_dir/manifest.json" --repo "${{ github.repository }}" --clobber
           for asset in "$channel_dir"/*.exe "$channel_dir"/*.dmg "$channel_dir"/*.AppImage "$channel_dir"/*.deb; do
             if [ -f "$asset" ]; then
-              gh release upload canary "$asset" --repo "${{ github.repository }}" --clobber
+              gh release upload canary-latest "$asset" --repo "${{ github.repository }}" --clobber
             fi
           done
 
           while IFS= read -r asset_name; do
             if [ ! -f "$channel_dir/$asset_name" ]; then
-              gh release delete-asset canary "$asset_name" --repo "${{ github.repository }}" --yes
+              gh release delete-asset canary-latest "$asset_name" --repo "${{ github.repository }}" --yes
             fi
-          done < <(gh release view canary --repo "${{ github.repository }}" --json assets --jq '.assets[].name')
+          done < <(gh release view canary-latest --repo "${{ github.repository }}" --json assets --jq '.assets[].name')
 
-          gh api --method PATCH "repos/${{ github.repository }}/git/refs/tags/canary" -f sha="${{ github.sha }}" -F force=true > /dev/null
-          gh release edit canary --repo "${{ github.repository }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION" --notes-file "$channel_dir/.release-notes.md" --prerelease --latest=false
-          gh release download canary --repo "${{ github.repository }}" --pattern manifest.json --dir "$readback_dir"
+          gh api --method PATCH "repos/${{ github.repository }}/git/refs/tags/canary-latest" -f sha="${{ github.sha }}" -F force=true > /dev/null
+          gh release edit canary-latest --repo "${{ github.repository }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION" --notes-file "$channel_dir/.release-notes.md" --prerelease --latest=false
+          gh release download canary-latest --repo "${{ github.repository }}" --pattern manifest.json --dir "$readback_dir"
           cmp "$channel_dir/manifest.json" "$readback_dir/manifest.json"
-          gh release view canary --repo "${{ github.repository }}" --json isDraft,isPrerelease --jq 'select(.isDraft == false and .isPrerelease == true)' > /dev/null
+          gh release view canary-latest --repo "${{ github.repository }}" --json isDraft,isPrerelease --jq 'select(.isDraft == false and .isPrerelease == true)' > /dev/null

--- a/launcher/sugarsubstitute_launcher/config.py
+++ b/launcher/sugarsubstitute_launcher/config.py
@@ -35,7 +35,7 @@ DEFAULT_RELEASE_MANIFEST_URL = (
 )
 DEFAULT_CANARY_RELEASE_MANIFEST_URL = (
     "https://github.com/Artificial-Sweetener/SugarSubstitute/"
-    "releases/download/canary/manifest.json"
+    "releases/download/canary-latest/manifest.json"
 )
 RELEASE_SOURCE_KIND_GITHUB: Literal["github_release_manifest"] = (
     "github_release_manifest"

--- a/scripts/canary-release-version.cjs
+++ b/scripts/canary-release-version.cjs
@@ -36,12 +36,13 @@ function createCanaryVersion(nextStableVersion, runNumber) {
 }
 
 /**
- * Return the patch release following the greatest Stable tag.
+ * Return the Stable version implied by a semantic-release change type.
  *
  * @param {string[]} releaseTags Stable tags in vMAJOR.MINOR.PATCH form.
- * @returns {string} Next patch version.
+ * @param {"major" | "minor" | "patch"} releaseType Semantic release type.
+ * @returns {string} Next Stable version.
  */
-function nextPatchVersion(releaseTags) {
+function nextStableVersion(releaseTags, releaseType) {
   const versions = releaseTags.map((tag) => {
     const match = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(tag);
     if (!match) {
@@ -61,7 +62,30 @@ function nextPatchVersion(releaseTags) {
     return 0;
   });
   const [major, minor, patch] = versions.at(-1);
-  return `${major}.${minor}.${patch + 1}`;
+  if (releaseType === "major") {
+    return `${major + 1}.0.0`;
+  }
+  if (releaseType === "minor") {
+    return `${major}.${minor + 1}.0`;
+  }
+  if (releaseType === "patch") {
+    return `${major}.${minor}.${patch + 1}`;
+  }
+  throw new Error(`Expected a semantic release type: ${releaseType}`);
 }
 
-module.exports = { createCanaryVersion, nextPatchVersion };
+/**
+ * Return the greatest Stable tag by semantic version precedence.
+ *
+ * @param {string[]} releaseTags Stable tags in vMAJOR.MINOR.PATCH form.
+ * @returns {string} Greatest Stable tag.
+ */
+function latestStableTag(releaseTags) {
+  const version = nextStableVersion(releaseTags, "patch")
+    .split(".")
+    .map(Number);
+  version[2] -= 1;
+  return `v${version.join(".")}`;
+}
+
+module.exports = { createCanaryVersion, latestStableTag, nextStableVersion };

--- a/scripts/prepare-release-assets.mjs
+++ b/scripts/prepare-release-assets.mjs
@@ -186,7 +186,7 @@ function resolvePythonPath(root) {
 function resolveAssetBaseUrl(repositoryName, version, channel) {
   const configuredBaseUrl = process.env.SUGAR_SUBSTITUTE_ASSET_BASE_URL;
   if (!configuredBaseUrl) {
-    const releaseTag = channel === "canary" ? "canary" : `v${version}`;
+    const releaseTag = channel === "canary" ? "canary-latest" : `v${version}`;
     return `https://github.com/${repositoryName}/releases/download/${releaseTag}`;
   }
   if (!configuredBaseUrl.startsWith("https://")) {

--- a/scripts/release-notes-preamble.cjs
+++ b/scripts/release-notes-preamble.cjs
@@ -30,7 +30,7 @@ function createInstallerReleaseNotes(repository, version, channel = "stable") {
   const normalizedRepository = validateRepository(repository);
   const normalizedVersion = validateVersion(version);
   const normalizedChannel = validateChannel(channel);
-  const releaseTag = normalizedChannel === "canary" ? "canary" : `v${normalizedVersion}`;
+  const releaseTag = normalizedChannel === "canary" ? "canary-latest" : `v${normalizedVersion}`;
   const assetRoot = `https://github.com/${normalizedRepository}/releases/download/${releaseTag}`;
   const iconRoot = `https://raw.githubusercontent.com/${normalizedRepository}/${releaseTag}/docs/release/platforms`;
   const stableReleaseUrl = `https://github.com/${normalizedRepository}/releases/latest`;

--- a/scripts/resolve-next-release-version.mjs
+++ b/scripts/resolve-next-release-version.mjs
@@ -22,7 +22,7 @@ import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 const releaseConfig = require("../.releaserc.cjs");
-const { createCanaryVersion, nextPatchVersion } = require(
+const { createCanaryVersion, latestStableTag, nextStableVersion } = require(
   "./canary-release-version.cjs",
 );
 const { selectVersionResolutionPlugins } = require(
@@ -58,23 +58,42 @@ if (qualificationVersion) {
   shouldRelease = true;
   firstRelease = !canaryRunNumber;
 } else {
+  const resolvedStableVersion = canaryRunNumber
+    ? await resolveCanaryStableVersion(releaseTags)
+    : await resolveStableVersion();
+  version = canaryRunNumber
+    ? createCanaryVersion(resolvedStableVersion, canaryRunNumber)
+    : resolvedStableVersion;
+  shouldRelease = canaryRunNumber ? true : version.length > 0;
+  firstRelease = false;
+}
+
+async function resolveCanaryStableVersion(tags) {
+  const analyzer = selectVersionResolutionPlugins(releaseConfig)[0];
+  const analyzerOptions = Array.isArray(analyzer) ? analyzer[1] : {};
+  const stableTag = latestStableTag(tags);
+  const commits = git(["log", `${stableTag}..HEAD`, "--format=%B%x00"])
+    .split("\0")
+    .map((message) => message.trim())
+    .filter(Boolean)
+    .map((message) => ({ message }));
+  const { analyzeCommits } = await import("@semantic-release/commit-analyzer");
+  const releaseType =
+    (await analyzeCommits(analyzerOptions, {
+      commits,
+      logger: { log() {} },
+    })) ?? "patch";
+  return nextStableVersion(tags, releaseType);
+}
+
+async function resolveStableVersion() {
   const { default: semanticRelease } = await import("semantic-release");
   const result = await semanticRelease({
-    ...(canaryRunNumber
-      ? { branches: [process.env.GITHUB_REF_NAME ?? "canary"] }
-      : {}),
     ci: false,
     dryRun: true,
     plugins: selectVersionResolutionPlugins(releaseConfig),
   });
-  const nextStableVersion =
-    result?.nextRelease?.version ??
-    (canaryRunNumber ? nextPatchVersion(releaseTags) : "");
-  version = canaryRunNumber
-    ? createCanaryVersion(nextStableVersion, canaryRunNumber)
-    : nextStableVersion;
-  shouldRelease = canaryRunNumber ? true : version.length > 0;
-  firstRelease = false;
+  return result?.nextRelease?.version ?? "";
 }
 
 if (process.env.GITHUB_OUTPUT) {

--- a/tests/test_installer_release_binding.py
+++ b/tests/test_installer_release_binding.py
@@ -64,7 +64,7 @@ def test_canary_installer_binds_exact_build_and_persists_canary_feed() -> None:
 
     assert source.manifest_url == (
         "https://github.com/Artificial-Sweetener/SugarSubstitute/"
-        "releases/download/canary/manifest.json"
+        "releases/download/canary-latest/manifest.json"
     )
     assert source.expected_version == "0.21.0-canary.42"
     assert source.expected_channel == "canary"
@@ -99,11 +99,11 @@ def test_bound_installer_rejects_manifest_channel_mismatch(
     monkeypatch.setattr(
         GitHubReleaseSource,
         "load_manifest",
-        lambda _self: _manifest("9999.1.42", channel="stable"),
+        lambda _self: _manifest("0.21.0-canary.42", channel="stable"),
     )
     source = VersionBoundReleaseSource(
-        manifest_url="https://example.invalid/canary-v9999.1.42/manifest.json",
-        expected_version="9999.1.42",
+        manifest_url="https://example.invalid/canary-latest/manifest.json",
+        expected_version="0.21.0-canary.42",
         expected_channel="canary",
         update_manifest_url=DEFAULT_CANARY_RELEASE_MANIFEST_URL,
     )

--- a/tests/test_launcher_skeleton.py
+++ b/tests/test_launcher_skeleton.py
@@ -436,9 +436,11 @@ def test_frozen_canary_installer_binds_rolling_canary_release(
     assert isinstance(source, VersionBoundReleaseSource)
     assert source.expected_channel == "canary"
     assert source.expected_version == "0.21.0-canary.42"
-    assert source.manifest_url.endswith("/releases/download/canary/manifest.json")
+    assert source.manifest_url.endswith(
+        "/releases/download/canary-latest/manifest.json"
+    )
     assert source.update_manifest_url.endswith(
-        "/releases/download/canary/manifest.json"
+        "/releases/download/canary-latest/manifest.json"
     )
 
 

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -259,7 +259,12 @@ def test_canary_isolated_release_train_contract() -> None:
     assert "SUGAR_SUBSTITUTE_CANARY_RUN_NUMBER:" in release_text
     assert "format('9999.1.{0}', github.run_number)" not in release_text
     assert "SUGAR_SUBSTITUTE_RELEASE_CHANNEL: canary" in release_text
-    assert "releases/download/canary" in release_text
+    assert "releases/download/canary-latest" in release_text
+    assert "releases/download/canary/" not in release_text
+    prepare_assets_text = (
+        PROJECT_ROOT / "scripts" / "prepare-release-assets.mjs"
+    ).read_text(encoding="utf-8")
+    assert 'channel === "canary" ? "canary-latest"' in prepare_assets_text
     assert '"canary-v$version"' not in release_text
     assert "release-qualification.yml" in release_text
     assert "'canary-fast'" in release_text
@@ -269,8 +274,10 @@ def test_canary_isolated_release_train_contract() -> None:
     ).read_text(encoding="utf-8")
     promotion = release_text.split("  promote-release:", maxsplit=1)[1]
     assert "Download qualified Canary candidate" in promotion
-    assert "gh release upload canary" in promotion
-    assert 'gh release upload canary "$channel_dir/manifest.json"' in promotion
+    assert "gh release upload canary-latest" in promotion
+    assert 'gh release upload canary-latest "$channel_dir/manifest.json"' in promotion
+    assert "git/refs/tags/canary-latest" in promotion
+    assert 'git/refs/tags/canary"' not in promotion
     assert promotion.count('gh release edit "$CANDIDATE_TAG"') == 1
     assert "--clobber" in promotion
     assert "--prerelease=false --latest" in promotion
@@ -332,7 +339,9 @@ def test_canary_version_derives_from_next_stable_release() -> None:
 const versions = require('./scripts/canary-release-version.cjs');
 process.stdout.write(JSON.stringify({
   canary: versions.createCanaryVersion('0.21.0', '142'),
-  fallback: versions.nextPatchVersion(['v0.19.2', 'v0.20.1', 'v0.20.0']),
+  latest: versions.latestStableTag(['v0.19.2', 'v0.20.1', 'v0.20.0']),
+  patch: versions.nextStableVersion(['v0.19.2', 'v0.20.1'], 'patch'),
+  minor: versions.nextStableVersion(['v0.19.2', 'v0.20.1'], 'minor'),
 }));
 """
     result = subprocess.run(
@@ -347,8 +356,25 @@ process.stdout.write(JSON.stringify({
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout) == {
         "canary": "0.21.0-canary.142",
-        "fallback": "0.20.2",
+        "latest": "v0.20.1",
+        "patch": "0.20.2",
+        "minor": "0.21.0",
     }
+
+
+def test_canary_version_resolution_does_not_probe_ambiguous_remote_ref() -> None:
+    """Canary analysis must work while the legacy Canary tag still exists."""
+
+    resolver_text = (
+        PROJECT_ROOT / "scripts" / "resolve-next-release-version.mjs"
+    ).read_text(encoding="utf-8")
+
+    canary_resolver = resolver_text.split(
+        "async function resolveCanaryStableVersion", maxsplit=1
+    )[1].split("async function resolveStableVersion", maxsplit=1)[0]
+    assert "analyzeCommits" in canary_resolver
+    assert "semanticRelease" not in canary_resolver
+    assert "branches:" not in canary_resolver
 
 
 def test_canary_release_notes_direct_normal_users_to_stable(tmp_path: Path) -> None:
@@ -384,7 +410,7 @@ def test_canary_release_notes_direct_normal_users_to_stable(tmp_path: Path) -> N
     assert f"[Download the latest Stable release instead]({stable_url})" in notes
     assert "DO NOT download this Canary build for normal use" in notes
     assert "Canary builds are intended only for testers" in notes
-    assert "releases/download/canary/SugarSubstitute-0.21.0-canary.42" in notes
+    assert "releases/download/canary-latest/SugarSubstitute-0.21.0-canary.42" in notes
 
 
 def test_cross_platform_validation_requires_explicit_invocation() -> None:


### PR DESCRIPTION
## Summary
- publish the single rolling Canary release and update manifest through the unambiguous canary-latest tag
- resolve semantic Canary versions from commit analysis without a remote branch push probe
- keep the legacy Canary releases intact until the replacement has been qualified and verified

## Verification
- focused release, launcher, and installer contracts
- full Ruff format and lint
- strict mypy
- architecture governance
- full parallel tests
- all 129 serial test modules