### PR TITLE
test(prompt-editor): exercise real focus-loss commits

### DIFF
--- a/tests/test_real_shell_prompt_editor_autocomplete_scenarios.py
+++ b/tests/test_real_shell_prompt_editor_autocomplete_scenarios.py
@@ -23,8 +23,8 @@ from itertools import pairwise
 import os
 from typing import Any, cast
 
-from PySide6.QtCore import QCoreApplication, QEvent, QPoint, Qt
-from PySide6.QtGui import QFocusEvent, QKeySequence, QTextCursor
+from PySide6.QtCore import QPoint, Qt
+from PySide6.QtGui import QKeySequence, QTextCursor
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication, QLineEdit
 import pytest
@@ -407,16 +407,15 @@ def test_real_shell_region_inline_edit_commits_when_focus_leaves(
     )
 
     assert inline_editor is not None
+    harness.wait_until(inline_editor.hasFocus)
     QTest.keyClicks(inline_editor, "Background")
-    QCoreApplication.sendEvent(
-        inline_editor,
-        QFocusEvent(QEvent.Type.FocusOut, Qt.FocusReason.MouseFocusReason),
-    )
+    field.editor.setFocus(Qt.FocusReason.MouseFocusReason)
     expected_source = "global\n[SEP|Background]\nregion"
     harness.wait_until(
         lambda: (
             field.editor.toPlainText() == expected_source
             and not inline_editor.isVisible()
+            and field.editor.hasFocus()
         )
     )
 


### PR DESCRIPTION
## Outcome

- replaces an impossible synthetic FocusOut injection with a real Qt focus transition
- proves the inline region editor owns focus before the transition
- verifies the separator name commits, the inline editor closes, and focus reaches the prompt editor

## Failure remediated

Post-merge Canary release run 31936504188 failed only on Windows because the test manually delivered FocusOut without changing Qt's authoritative focus widget. That half-transition is platform-order dependent and does not model a user leaving the field.

## Verification

- focused focus-loss scenario: 10 consecutive fresh-process passes
- complete real-shell autocomplete scenario module: 74 passed
- Ruff format: clean
- Ruff lint: passed
- strict mypy: passed (3488 files)
- architecture governance: passed
- full parallel suite: passed
- full serial suite: all 129 modules passed
- diff check: passed