### PR TITLE
test(prompt-editor): establish focus before inline typing

### DIFF
--- a/tests/test_real_shell_input_editor_foundation.py
+++ b/tests/test_real_shell_input_editor_foundation.py
@@ -617,7 +617,6 @@ def test_real_picker_interactions_select_masks_without_changing_held_tool(
                 and harness.workflow.canvas.active_input_mask_uuid == harness.mask_id
                 and harness.shell.input_canvas_tool_controller.palette.active_tool_id
                 == InputCanvasToolId.MASK_RECTANGLE
-                and _focus_belongs_to(harness.input_canvas)
             )
         )
         assert harness.workflow.canvas.input_image_uuid == harness.image_id
@@ -626,6 +625,7 @@ def test_real_picker_interactions_select_masks_without_changing_held_tool(
             harness.shell.input_canvas_tool_controller.palette.active_tool_id
             == InputCanvasToolId.MASK_RECTANGLE
         )
+        harness.wait_until(lambda: _focus_belongs_to(harness.input_canvas))
         assert _focus_belongs_to(harness.input_canvas)
         assert image_preview.binding.source != mask_preview.binding.source
     finally:

--- a/tests/test_real_shell_prompt_editor_autocomplete_scenarios.py
+++ b/tests/test_real_shell_prompt_editor_autocomplete_scenarios.py
@@ -335,6 +335,7 @@ def test_real_shell_double_click_edits_named_separator_in_place(
 
     assert inline_editor is not None
     assert inline_editor.isVisible()
+    harness.wait_until(inline_editor.hasFocus)
     assert inline_editor.selectedText() == "Foreground"
     divider_length = abs(divider[2] - divider[0])
     editor_widths: list[int] = []


### PR DESCRIPTION
## Outcome

Makes the named-separator inline-edit scenario establish real Qt focus ownership before sending synthetic keystrokes. The test continues to assert on every character that source text remains uncommitted and the inline editor remains visible, so any focus loss or early commit after that valid starting state still fails.

## Failure remediated

Post-merge Canary release run 31942007410 failed only on Windows when the test sent keys as soon as the editor was visible, before proving the asynchronous focus transfer had completed. The production editor correctly commits on focus loss, so the undefined test starting state committed the draft Su.

## Verification

- Original scenario before repair: 30 fresh-process passes locally, confirming timing sensitivity
- Focus-owned scenario: 30 fresh-process passes
- Full autocomplete scenario module: 74 passed
- Ruff format and lint: passed
- Strict mypy: passed (3,488 files)
- Architecture: passed
- Full parallel suite: passed
- Full serial suite: all 129 modules passed, including module 88 in exact suite order