### PR TITLE
ci(release): authorize generated Stable release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,10 +421,35 @@ jobs:
         shell: pwsh
         run: Copy-Item build\release-notes.md .local-release-channel\.release-notes.md
 
+      - name: Configure authorized Stable release push
+        if: github.event.inputs.qualification_candidate_run_id == '' && needs.determine-version.outputs.channel == 'stable' && needs.determine-version.outputs.first_release != 'true'
+        env:
+          STABLE_RELEASE_DEPLOY_KEY: ${{ secrets.STABLE_RELEASE_DEPLOY_KEY }}
+        shell: pwsh
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          if ([string]::IsNullOrWhiteSpace($env:STABLE_RELEASE_DEPLOY_KEY)) {
+            throw "STABLE_RELEASE_DEPLOY_KEY is required to stage a Stable release."
+          }
+          $keyPath = Join-Path $env:RUNNER_TEMP "stable-release-deploy-key"
+          $keyText = $env:STABLE_RELEASE_DEPLOY_KEY.Trim().Replace("`r", "") + "`n"
+          [System.IO.File]::WriteAllText(
+            $keyPath,
+            $keyText,
+            [System.Text.UTF8Encoding]::new($false)
+          )
+          & icacls.exe $keyPath /inheritance:r /grant:r "$($env:USERNAME):(R)" | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not restrict the Stable release deploy key permissions."
+          }
+          $gitKeyPath = $keyPath.Replace("\", "/")
+          git config --local core.sshCommand "ssh -i `"$gitKeyPath`" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+
       - name: Prepare semantic release commit and tag without publishing stable
         if: github.event.inputs.qualification_candidate_run_id == '' && needs.determine-version.outputs.channel == 'stable' && needs.determine-version.outputs.first_release != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL: git@github.com:${{ github.repository }}.git
           SUGAR_SUBSTITUTE_STAGE_ONLY: "true"
         shell: pwsh
         run: |

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -17,9 +17,13 @@
 const githubRepository = process.env.GITHUB_REPOSITORY?.trim();
 const releaseRepository =
   githubRepository || "Artificial-Sweetener/SugarSubstitute";
-const repositoryUrl = githubRepository
-  ? `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${githubRepository}.git`
-  : "https://github.com/Artificial-Sweetener/SugarSubstitute.git";
+const authorizedRepositoryUrl =
+  process.env.SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL?.trim();
+const repositoryUrl =
+  authorizedRepositoryUrl ||
+  (githubRepository
+    ? `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${githubRepository}.git`
+    : "https://github.com/Artificial-Sweetener/SugarSubstitute.git");
 
 module.exports = {
   branches: ["main"],

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -1158,6 +1158,21 @@ def test_release_configuration_targets_the_active_github_repository() -> None:
     assert "https://github.com/Artificial-Sweetener/SugarSubstitute.git" in config
 
 
+def test_stable_release_push_uses_the_authorized_deploy_key() -> None:
+    """Keep generated Stable commits on the narrowly authorized push identity."""
+
+    release_workflow = (
+        PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+    ).read_text(encoding="utf-8")
+    release_config = (PROJECT_ROOT / ".releaserc.cjs").read_text(encoding="utf-8")
+
+    assert "Configure authorized Stable release push" in release_workflow
+    assert "secrets.STABLE_RELEASE_DEPLOY_KEY" in release_workflow
+    assert "SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL:" in release_workflow
+    assert "git@github.com:${{ github.repository }}.git" in release_workflow
+    assert "process.env.SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL" in release_config
+
+
 def test_windows_quality_workflows_fail_fast_on_native_command_errors() -> None:
     """Dependency and gate failures should stop their PowerShell steps immediately."""
 


### PR DESCRIPTION
Fixes Stable release staging after branch protection correctly rejected Semantic Release's generated version commit. Uses a dedicated write-enabled deploy key only for the Git push while retaining the normal GitHub token for release publication. Adds a contract test for the authorized push identity and SSH repository path.