### PR TITLE
ci(release): publish existing Stable tag correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -513,8 +513,19 @@ jobs:
           $tag = "v$version"
           $assets = Get-ChildItem .local-release-channel -File | Select-Object -ExpandProperty FullName
           $releaseNotes = Get-Content -Raw build\release-notes.md
-          $target = if ("${{ needs.determine-version.outputs.first_release }}" -eq "true") { "${{ github.sha }}" } else { $tag }
-          gh release create $tag $assets --repo "${{ github.repository }}" --target $target --title "SugarSubstitute $version release candidate" --generate-notes --notes $releaseNotes --prerelease
+          $releaseArguments = @(
+            "release", "create", $tag
+          ) + $assets + @(
+            "--repo", "${{ github.repository }}",
+            "--title", "SugarSubstitute $version release candidate",
+            "--generate-notes",
+            "--notes", $releaseNotes,
+            "--prerelease"
+          )
+          if ("${{ needs.determine-version.outputs.first_release }}" -eq "true") {
+            $releaseArguments += @("--target", "${{ github.sha }}")
+          }
+          gh @releaseArguments
           $readback = gh release view $tag --repo "${{ github.repository }}" --json isDraft,isPrerelease,assets | ConvertFrom-Json
           if ($readback.isDraft -or -not $readback.isPrerelease) {
             throw "Candidate release was not published as a visible prerelease."

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -1055,7 +1055,7 @@ def test_release_pipeline_uses_one_notes_owner_and_updates_the_changelog() -> No
     assert 'changelogFile: "CHANGELOG.md"' in config
     assert "release-notes-preamble.cjs" in workflow
     assert "--generate-notes" in workflow
-    assert "--notes $releaseNotes" in workflow
+    assert '"--notes", $releaseNotes' in workflow
     assert (PROJECT_ROOT / "CHANGELOG.md").is_file()
 
 
@@ -1171,6 +1171,23 @@ def test_stable_release_push_uses_the_authorized_deploy_key() -> None:
     assert "SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL:" in release_workflow
     assert "git@github.com:${{ github.repository }}.git" in release_workflow
     assert "process.env.SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL" in release_config
+
+
+def test_existing_stable_tag_is_published_without_an_invalid_target() -> None:
+    """Publish Semantic Release tags without reusing the tag as a commitish."""
+
+    release_workflow = (
+        PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+    ).read_text(encoding="utf-8")
+    publish_step = release_workflow.split(
+        "      - name: Publish exact bytes as a visible prerelease candidate",
+        maxsplit=1,
+    )[1].split("      - name:", maxsplit=1)[0]
+
+    assert "gh @releaseArguments" in publish_step
+    assert '$releaseArguments += @("--target", "${{ github.sha }}")' in publish_step
+    assert "$target =" not in publish_step
+    assert "--target $target" not in publish_step
 
 
 def test_windows_quality_workflows_fail_fast_on_native_command_errors() -> None:


### PR DESCRIPTION
Fixes the v0.21.0 candidate publication failure from run 31962149695. Once Semantic Release has created the Stable tag, GitHub release creation omits target_commitish; only the first-release path supplies the source commit. Adds a regression contract for the existing-tag path.