### PR TITLE
fix(releases): publish existing Stable tags correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -513,8 +513,19 @@ jobs:
           $tag = "v$version"
           $assets = Get-ChildItem .local-release-channel -File | Select-Object -ExpandProperty FullName
           $releaseNotes = Get-Content -Raw build\release-notes.md
-          $target = if ("${{ needs.determine-version.outputs.first_release }}" -eq "true") { "${{ github.sha }}" } else { $tag }
-          gh release create $tag $assets --repo "${{ github.repository }}" --target $target --title "SugarSubstitute $version release candidate" --generate-notes --notes $releaseNotes --prerelease
+          $releaseArguments = @(
+            "release", "create", $tag
+          ) + $assets + @(
+            "--repo", "${{ github.repository }}",
+            "--title", "SugarSubstitute $version release candidate",
+            "--generate-notes",
+            "--notes", $releaseNotes,
+            "--prerelease"
+          )
+          if ("${{ needs.determine-version.outputs.first_release }}" -eq "true") {
+            $releaseArguments += @("--target", "${{ github.sha }}")
+          }
+          gh @releaseArguments
           $readback = gh release view $tag --repo "${{ github.repository }}" --json isDraft,isPrerelease,assets | ConvertFrom-Json
           if ($readback.isDraft -or -not $readback.isPrerelease) {
             throw "Candidate release was not published as a visible prerelease."

--- a/tests/test_real_shell_input_editor_foundation.py
+++ b/tests/test_real_shell_input_editor_foundation.py
@@ -713,16 +713,17 @@ def test_two_real_picker_pairs_route_exact_image_and_mask_identity(
             ImagePicker,
             harness.picker(ImagePicker, harness.CUBE_ALIAS, harness.IMAGE_NODE),
         )
+        harness.shell.editor_panel.setFocus()
         QTest.mouseClick(first_image_picker.preview_surface, Qt.MouseButton.LeftButton)
         harness.wait_until(
             lambda: (
                 workflow.canvas.input_image_uuid == first_image_id
                 and workflow.canvas.active_input_mask_uuid == first_mask_id
-                and _focus_belongs_to(harness.input_canvas)
             )
         )
         assert workflow.canvas.input_image_uuid == first_image_id
         assert workflow.canvas.active_input_mask_uuid == first_mask_id
+        harness.wait_until(lambda: _focus_belongs_to(harness.input_canvas))
         assert _focus_belongs_to(harness.input_canvas)
 
         assert harness.shell.input_canvas_tool_controller.request_tool(
@@ -732,6 +733,7 @@ def test_two_real_picker_pairs_route_exact_image_and_mask_identity(
             MaskPicker,
             harness.picker(MaskPicker, second_alias, harness.MASK_NODE),
         )
+        harness.shell.editor_panel.setFocus()
         QTest.mouseClick(second_mask_picker.preview_surface, Qt.MouseButton.LeftButton)
         harness.wait_until(
             lambda: (
@@ -739,7 +741,6 @@ def test_two_real_picker_pairs_route_exact_image_and_mask_identity(
                 and workflow.canvas.active_input_mask_uuid == second_mask_id
                 and harness.shell.input_canvas_tool_controller.palette.active_tool_id
                 == InputCanvasToolId.MOVE
-                and _focus_belongs_to(harness.input_canvas)
             )
         )
         assert workflow.canvas.input_image_uuid == second_image_id
@@ -748,6 +749,7 @@ def test_two_real_picker_pairs_route_exact_image_and_mask_identity(
             harness.shell.input_canvas_tool_controller.palette.active_tool_id
             == InputCanvasToolId.MOVE
         )
+        harness.wait_until(lambda: _focus_belongs_to(harness.input_canvas))
         assert _focus_belongs_to(harness.input_canvas)
     finally:
         harness.close()

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -1055,7 +1055,7 @@ def test_release_pipeline_uses_one_notes_owner_and_updates_the_changelog() -> No
     assert 'changelogFile: "CHANGELOG.md"' in config
     assert "release-notes-preamble.cjs" in workflow
     assert "--generate-notes" in workflow
-    assert "--notes $releaseNotes" in workflow
+    assert '"--notes", $releaseNotes' in workflow
     assert (PROJECT_ROOT / "CHANGELOG.md").is_file()
 
 
@@ -1171,6 +1171,23 @@ def test_stable_release_push_uses_the_authorized_deploy_key() -> None:
     assert "SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL:" in release_workflow
     assert "git@github.com:${{ github.repository }}.git" in release_workflow
     assert "process.env.SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL" in release_config
+
+
+def test_existing_stable_tag_is_published_without_an_invalid_target() -> None:
+    """Publish Semantic Release tags without reusing the tag as a commitish."""
+
+    release_workflow = (
+        PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+    ).read_text(encoding="utf-8")
+    publish_step = release_workflow.split(
+        "      - name: Publish exact bytes as a visible prerelease candidate",
+        maxsplit=1,
+    )[1].split("      - name:", maxsplit=1)[0]
+
+    assert "gh @releaseArguments" in publish_step
+    assert '$releaseArguments += @("--target", "${{ github.sha }}")' in publish_step
+    assert "$target =" not in publish_step
+    assert "--target $target" not in publish_step
 
 
 def test_windows_quality_workflows_fail_fast_on_native_command_errors() -> None:


### PR DESCRIPTION
Promotes the verified Canary fix for Stable candidate publication. Existing Semantic Release tags are published without an invalid target_commitish; first-release creation retains its explicit source target. PR #67 passed every required Canary check.