### PR TITLE
fix(installer): install managed nodepacks without system Git

### DIFF
--- a/substitute/app/bootstrap/managed_recovery_adapters.py
+++ b/substitute/app/bootstrap/managed_recovery_adapters.py
@@ -313,15 +313,14 @@ def reconcile_attached_local_owned_dependencies(
 ) -> None:
     """Refresh only Substitute-owned nodepacks in an attached local workspace."""
 
-    ensure_attached_workspace_manager(
+    manager_runtime = ensure_attached_workspace_manager(
         workspace,
         python_executable=python_executable,
         on_log=emit_log,
     )
     emit_log("Updating Substitute Comfy nodepacks.")
     ensure_core_comfy_nodepacks(
-        workspace,
-        python_executable=python_executable,
+        manager_runtime=manager_runtime,
         refresh_nodepacks=nodepacks,
         on_log=emit_log,
     )

--- a/substitute/infrastructure/comfy/attached_install.py
+++ b/substitute/infrastructure/comfy/attached_install.py
@@ -107,7 +107,7 @@ def prepare_verified_attached_comfy_setup(
         )
     if on_status is not None:
         on_status(app_text("Provisioning ComfyUI-Manager."))
-    ensure_attached_workspace_manager(
+    manager_runtime = ensure_attached_workspace_manager(
         workspace,
         python_executable=binding.executable,
         on_log=on_log,
@@ -115,8 +115,7 @@ def prepare_verified_attached_comfy_setup(
     if on_status is not None:
         on_status(app_text("Installing Substitute Comfy nodepacks."))
     ensure_core_comfy_nodepacks(
-        workspace,
-        python_executable=binding.executable,
+        manager_runtime=manager_runtime,
         on_log=on_log,
     )
     if configure_model_root:

--- a/substitute/infrastructure/comfy/comfy_manager_runtime.py
+++ b/substitute/infrastructure/comfy/comfy_manager_runtime.py
@@ -14,31 +14,41 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Bind Comfy-Manager subprocesses to the selected Comfy runtime."""
+"""Own every protected Comfy Manager CLI command and process environment."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-import os
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
-from substitute.infrastructure.process.hidden_process_runner import run_command
+from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
+from substitute.infrastructure.comfy.manager_environment import (
+    manager_runtime_environment,
+)
+from substitute.infrastructure.process.hidden_process_runner import (
+    run_command,
+    stream_command_collecting_output,
+)
 from sugarsubstitute_shared.windows_long_paths import subprocess_path
+
+LogCallback = Callable[[str], None]
 
 
 def selected_comfy_environment(
     *,
-    workspace: Path,
-    python_executable: Path,
+    runtime: ComfyManagerRuntime,
     env: Mapping[str, str] | None,
 ) -> dict[str, str]:
-    """Bind Manager work to one explicit Comfy workspace and Python runtime."""
+    """Bind CLI work to one validated Manager runtime without system Git."""
 
-    selected_env = dict(os.environ if env is None else env)
+    selected_env = manager_runtime_environment(
+        runtime.workspace,
+        env,
+        use_pygit2=runtime.uses_pygit2,
+    )
     selected_env.pop("CONDA_PREFIX", None)
-    selected_env["COMFYUI_PATH"] = str(workspace.resolve())
-    selected_env["COMFYUI_FOLDERS_BASE_PATH"] = str(workspace.resolve())
-    executable_directory = python_executable.resolve().parent
+    selected_env["COMFYUI_FOLDERS_BASE_PATH"] = str(runtime.workspace.resolve())
+    executable_directory = runtime.python_executable.resolve().parent
     if executable_directory.name.casefold() in {"scripts", "bin"}:
         selected_env["VIRTUAL_ENV"] = str(executable_directory.parent)
     else:
@@ -46,33 +56,131 @@ def selected_comfy_environment(
     return selected_env
 
 
-def python_module_available(
-    *,
-    module_name: str,
-    workspace: Path,
-    python_executable: Path,
-    env: Mapping[str, str] | None,
-) -> bool:
-    """Return whether the selected Comfy Python exposes one module."""
+class ComfyManagerCommandRunner:
+    """Run supported ComfyCLI operations through one protected boundary."""
 
-    probe = run_command(
-        [
-            subprocess_path(python_executable),
-            "-c",
-            (
-                "import importlib.util; "
-                f"raise SystemExit(importlib.util.find_spec({module_name!r}) is None)"
-            ),
-        ],
-        cwd=workspace,
-        check=False,
-        env=selected_comfy_environment(
-            workspace=workspace,
-            python_executable=python_executable,
-            env=env,
-        ),
-    )
-    return probe.returncode == 0
+    def __init__(
+        self,
+        *,
+        runtime: ComfyManagerRuntime,
+        env: Mapping[str, str] | None,
+    ) -> None:
+        """Capture the validated runtime and caller's base environment."""
+
+        self._runtime = runtime
+        self._environment = selected_comfy_environment(runtime=runtime, env=env)
+
+    def install_registry_nodepack(
+        self,
+        *,
+        node_spec: str,
+        on_line: LogCallback | None,
+        timeout_seconds: int,
+    ) -> tuple[int, tuple[str, ...]] | None:
+        """Install one exact Registry nodepack through the available ComfyCLI."""
+
+        command = self._registry_install_command(node_spec)
+        if command is None:
+            return None
+        return stream_command_collecting_output(
+            command,
+            cwd=self._runtime.workspace,
+            on_line=on_line,
+            timeout_seconds=timeout_seconds,
+            env=self._environment,
+        )
+
+    def settle_registry_updates(
+        self,
+        *,
+        session_path: Path,
+        on_line: LogCallback | None,
+        timeout_seconds: int,
+    ) -> tuple[int, tuple[str, ...]] | None:
+        """Run Manager's pre-startup executor for queued Registry updates."""
+
+        if not self._module_available("comfyui_manager.prestartup_script"):
+            return None
+        environment = dict(self._environment)
+        environment["__COMFY_CLI_SESSION__"] = str(session_path)
+        return stream_command_collecting_output(
+            [
+                subprocess_path(self._runtime.python_executable),
+                "-m",
+                "comfyui_manager.prestartup_script",
+            ],
+            cwd=self._runtime.workspace,
+            on_line=on_line,
+            timeout_seconds=timeout_seconds,
+            env=environment,
+        )
+
+    def _registry_install_command(self, node_spec: str) -> list[str] | None:
+        """Select the supported command exposed by the validated runtime."""
+
+        python = subprocess_path(self._runtime.python_executable)
+        workspace = subprocess_path(self._runtime.workspace)
+        if self._module_available("comfy_cli"):
+            return [
+                python,
+                "-m",
+                "comfy_cli",
+                "--workspace",
+                workspace,
+                "--skip-prompt",
+                "node",
+                "install",
+                "--exit-on-fail",
+                "--no-deps",
+                node_spec,
+                "--mode",
+                "remote",
+            ]
+        if self._module_available("cm_cli"):
+            return [
+                python,
+                "-m",
+                "cm_cli",
+                "install",
+                "--exit-on-fail",
+                "--no-deps",
+                node_spec,
+                "--mode",
+                "remote",
+            ]
+        if (
+            self._runtime.kind is ComfyManagerKind.LEGACY_CUSTOM_NODE
+            and self._runtime.legacy_cli_path is not None
+            and self._runtime.legacy_cli_path.is_file()
+        ):
+            return [
+                python,
+                subprocess_path(self._runtime.legacy_cli_path),
+                "install",
+                "--no-deps",
+                node_spec,
+                "--mode",
+                "remote",
+            ]
+        return None
+
+    def _module_available(self, module_name: str) -> bool:
+        """Return whether the selected Comfy Python exposes one module."""
+
+        probe = run_command(
+            [
+                subprocess_path(self._runtime.python_executable),
+                "-c",
+                (
+                    "import importlib.util; "
+                    f"raise SystemExit(importlib.util.find_spec({module_name!r}) is None)"
+                ),
+            ],
+            cwd=self._runtime.workspace,
+            check=False,
+            env=self._environment,
+        )
+        return probe.returncode == 0
 
 
-__all__ = ["python_module_available", "selected_comfy_environment"]
+__all__ = ["ComfyManagerCommandRunner", "selected_comfy_environment"]

--- a/substitute/infrastructure/comfy/core_nodepack_reconciler.py
+++ b/substitute/infrastructure/comfy/core_nodepack_reconciler.py
@@ -27,6 +27,7 @@ from substitute.application.comfy_nodepacks.core_nodepack_reconciliation_plan im
     plan_initial_reconciliation,
 )
 from substitute.domain.comfy_nodepacks import CoreNodepackId, NodepackManagementKind
+from substitute.domain.comfy_manager import ComfyManagerRuntime
 from substitute.infrastructure.comfy.legacy_nodepack_distribution import (
     LegacyNodepackDistributionCleaner,
 )
@@ -62,8 +63,8 @@ from substitute.infrastructure.comfy.nodepack_registry_update_settler import (
 from substitute.infrastructure.comfy.pinned_nodepack_source import (
     PinnedNodepackSourceInstaller,
 )
-from substitute.infrastructure.comfy.workspace_python_resolver import (
-    resolve_workspace_python,
+from substitute.infrastructure.comfy.manager_runtime_probe import (
+    detect_workspace_manager_runtime,
 )
 from substitute.infrastructure.version_control import (
     RepositoryService,
@@ -102,18 +103,20 @@ class CoreNodepackReconciler:
 
     def ensure(
         self,
-        workspace: Path,
         *,
-        python_executable: Path,
+        manager_runtime: ComfyManagerRuntime,
         refresh_nodepacks: Collection[CoreNodepackId],
         on_log: LogCallback | None,
         env: Mapping[str, str] | None,
     ) -> None:
         """Converge every required nodepack through the Registry-first policy."""
 
+        workspace = manager_runtime.workspace
+        python_executable = manager_runtime.python_executable
         refresh_targets = frozenset(refresh_nodepacks)
         for nodepack in CORE_COMFY_NODEPACKS:
             self._ensure_one(
+                manager_runtime=manager_runtime,
                 workspace=workspace,
                 python_executable=python_executable,
                 nodepack=nodepack,
@@ -125,6 +128,7 @@ class CoreNodepackReconciler:
     def _ensure_one(
         self,
         *,
+        manager_runtime: ComfyManagerRuntime,
         workspace: Path,
         python_executable: Path,
         nodepack: CoreComfyNodepack,
@@ -225,8 +229,7 @@ class CoreNodepackReconciler:
             snapshot = self._inspector.inspect(workspace=workspace, nodepack=nodepack)
         if action is CoreNodepackAction.INSTALL_REGISTRY:
             registry_result = self._registry.install_exact(
-                workspace=workspace,
-                python_executable=python_executable,
+                manager_runtime=manager_runtime,
                 nodepack=nodepack,
                 on_log=on_log,
                 env=env,
@@ -242,8 +245,7 @@ class CoreNodepackReconciler:
             changed = True
         if action is CoreNodepackAction.SETTLE_REGISTRY_UPDATE:
             self._registry_update_settler.settle(
-                workspace=workspace,
-                python_executable=python_executable,
+                manager_runtime=manager_runtime,
                 nodepack=nodepack,
                 on_log=on_log,
                 env=env,
@@ -348,20 +350,17 @@ class CoreNodepackReconciler:
 
 
 def ensure_core_comfy_nodepacks(
-    workspace: Path,
     *,
+    manager_runtime: ComfyManagerRuntime,
     refresh_nodepacks: Collection[CoreNodepackId] = frozenset(),
     on_log: LogCallback | None = None,
     env: Mapping[str, str] | None = None,
-    python_executable: Path | None = None,
     repositories: RepositoryService | None = None,
 ) -> None:
     """Ensure required core nodepacks through the production composition."""
 
-    resolved_python = python_executable or resolve_workspace_python(workspace)
     CoreNodepackReconciler(repositories=repositories or repository_service()).ensure(
-        workspace,
-        python_executable=resolved_python,
+        manager_runtime=manager_runtime,
         refresh_nodepacks=refresh_nodepacks,
         on_log=on_log,
         env=env,
@@ -377,8 +376,9 @@ def refresh_core_comfy_nodepacks(
 ) -> None:
     """Refresh selected core nodepacks through Registry-first reconciliation."""
 
+    manager_runtime = detect_workspace_manager_runtime(workspace)
     ensure_core_comfy_nodepacks(
-        workspace,
+        manager_runtime=manager_runtime,
         refresh_nodepacks=nodepacks,
         on_log=on_log,
         env=env,

--- a/substitute/infrastructure/comfy/managed_existing_setup.py
+++ b/substitute/infrastructure/comfy/managed_existing_setup.py
@@ -29,6 +29,7 @@ from substitute.application.onboarding.managed_runtime_state_recorder import (
     ManagedRuntimeStateRecorder,
 )
 from substitute.domain.comfy_nodepacks import CoreNodepackId
+from substitute.domain.comfy_manager import ComfyManagerRuntime
 from substitute.domain.onboarding import ManagedRuntimeValidationStatus
 from substitute.infrastructure.comfy.hardware_models import HardwareDetectionResult
 from substitute.infrastructure.comfy.install_strategy import ManagedInstallStrategy
@@ -92,7 +93,11 @@ class ExistingManagedSetupOperations(Protocol):
     ) -> None:
         """Converge checkout-declared Python requirements."""
 
-    def provision_manager(self, workspace: Path, env: Mapping[str, str]) -> None:
+    def provision_manager(
+        self,
+        workspace: Path,
+        env: Mapping[str, str],
+    ) -> ComfyManagerRuntime:
         """Converge the checkout-declared Manager runtime."""
 
     def configure_model_root(
@@ -118,7 +123,7 @@ class ExistingManagedSetupOperations(Protocol):
 
     def ensure_nodepacks(
         self,
-        workspace: Path,
+        manager_runtime: ComfyManagerRuntime,
         refresh_nodepacks: Collection[CoreNodepackId],
         env: Mapping[str, str],
     ) -> None:
@@ -218,7 +223,7 @@ def reconcile_existing_managed_setup(
     )
     if not remote_steps.degraded:
         operations.emit_status("Provisioning ComfyUI-Manager.")
-    remote_steps.run(
+    manager_step = remote_steps.run(
         operation="provision_manager",
         action=lambda: _provision_manager(
             operations=operations,
@@ -226,6 +231,7 @@ def reconcile_existing_managed_setup(
             managed_env=request.managed_env,
         ),
     )
+    manager_runtime = manager_step.value
     with trace_span("managed_setup.detect_hardware"):
         detection = operations.detect_hardware()
     with trace_span("managed_setup.select_install_strategy"):
@@ -284,6 +290,7 @@ def reconcile_existing_managed_setup(
             action=lambda: _ensure_nodepacks(
                 operations=operations,
                 request=request,
+                manager_runtime=manager_runtime,
             ),
         )
         if not remote_steps.degraded:
@@ -374,23 +381,28 @@ def _provision_manager(
     operations: ExistingManagedSetupOperations,
     workspace: Path,
     managed_env: Mapping[str, str],
-) -> None:
+) -> ComfyManagerRuntime:
     """Run Manager provisioning inside its startup trace span."""
 
     with trace_span("managed_setup.existing.provision_manager"):
-        operations.provision_manager(workspace, managed_env)
+        return operations.provision_manager(workspace, managed_env)
 
 
 def _ensure_nodepacks(
     *,
     operations: ExistingManagedSetupOperations,
     request: ExistingManagedSetupRequest,
+    manager_runtime: ComfyManagerRuntime | None,
 ) -> None:
     """Run core nodepack reconciliation inside its startup trace span."""
 
     with trace_span("managed_setup.existing.ensure_nodepacks"):
+        if manager_runtime is None:
+            raise RuntimeError(
+                "Managed nodepack setup requires a validated Manager runtime."
+            )
         operations.ensure_nodepacks(
-            request.workspace,
+            manager_runtime,
             request.refresh_core_nodepacks,
             request.managed_env,
         )

--- a/substitute/infrastructure/comfy/managed_existing_setup_operations.py
+++ b/substitute/infrastructure/comfy/managed_existing_setup_operations.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Callable
 
 from substitute.domain.comfy_nodepacks import CoreNodepackId
+from substitute.domain.comfy_manager import ComfyManagerRuntime
 from substitute.infrastructure.comfy.backend_model_root_configurator import (
     configure_backend_model_root,
 )
@@ -103,10 +104,14 @@ class ManagedExistingSetupOperations(ExistingManagedSetupOperations):
             env=env,
         )
 
-    def provision_manager(self, workspace: Path, env: Mapping[str, str]) -> None:
+    def provision_manager(
+        self,
+        workspace: Path,
+        env: Mapping[str, str],
+    ) -> ComfyManagerRuntime:
         """Converge the integrated Manager runtime."""
 
-        ensure_managed_workspace_manager(
+        return ensure_managed_workspace_manager(
             workspace,
             on_log=self._on_log,
             env=dict(env),
@@ -150,14 +155,14 @@ class ManagedExistingSetupOperations(ExistingManagedSetupOperations):
 
     def ensure_nodepacks(
         self,
-        workspace: Path,
+        manager_runtime: ComfyManagerRuntime,
         refresh_nodepacks: Collection[CoreNodepackId],
         env: Mapping[str, str],
     ) -> None:
         """Converge required SugarSubstitute nodepacks."""
 
         ensure_core_comfy_nodepacks(
-            workspace,
+            manager_runtime=manager_runtime,
             refresh_nodepacks=refresh_nodepacks,
             on_log=self._on_log,
             env=env,

--- a/substitute/infrastructure/comfy/managed_install.py
+++ b/substitute/infrastructure/comfy/managed_install.py
@@ -304,7 +304,7 @@ def _ensure_managed_comfy_setup(
         emit_status(on_status, "Provisioning ComfyUI-Manager.")
         trace_mark("managed_setup.manager.start")
         with trace_span("managed_setup.manager"):
-            ensure_managed_workspace_manager(
+            manager_runtime = ensure_managed_workspace_manager(
                 workspace,
                 on_log=on_log,
                 env=managed_env,
@@ -313,7 +313,7 @@ def _ensure_managed_comfy_setup(
         trace_mark("managed_setup.nodepacks.start")
         with trace_span("managed_setup.nodepacks"):
             ensure_core_comfy_nodepacks(
-                workspace,
+                manager_runtime=manager_runtime,
                 refresh_nodepacks=refresh_core_nodepacks,
                 on_log=on_log,
                 env=managed_env,

--- a/substitute/infrastructure/comfy/manager_environment.py
+++ b/substitute/infrastructure/comfy/manager_environment.py
@@ -35,6 +35,7 @@ def manager_environment(
     environment["COMFYUI_PATH"] = subprocess_path(workspace)
     environment.setdefault("PYTHONUTF8", "1")
     environment.setdefault("PYTHONIOENCODING", "utf-8:replace")
+    environment["GIT_PYTHON_REFRESH"] = "quiet"
     environment.pop("CM_USE_PYGIT2", None)
     return environment
 

--- a/substitute/infrastructure/comfy/nodepack_registry_installer.py
+++ b/substitute/infrastructure/comfy/nodepack_registry_installer.py
@@ -20,24 +20,19 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from pathlib import Path
 
 from substitute.application.comfy_nodepacks.core_nodepack_reconciliation_plan import (
     RegistryInstallOutcome,
 )
+from substitute.domain.comfy_manager import ComfyManagerRuntime
 from substitute.infrastructure.comfy.comfy_manager_runtime import (
-    python_module_available,
-    selected_comfy_environment,
+    ComfyManagerCommandRunner,
 )
 from substitute.infrastructure.comfy.nodepack_manifest import (
     CLI_INSTALL_TIMEOUT_SECONDS,
     CoreComfyNodepack,
 )
-from substitute.infrastructure.process.hidden_process_runner import (
-    stream_command_collecting_output,
-)
 from substitute.shared.logging.logger import get_logger, log_info
-from sugarsubstitute_shared.windows_long_paths import subprocess_path
 
 LogCallback = Callable[[str], None]
 _LOGGER = get_logger("infrastructure.comfy.nodepack_registry_installer")
@@ -57,21 +52,30 @@ class ComfyNodepackRegistryInstaller:
     def install_exact(
         self,
         *,
-        workspace: Path,
-        python_executable: Path,
+        manager_runtime: ComfyManagerRuntime,
         nodepack: CoreComfyNodepack,
         on_log: LogCallback | None,
         env: Mapping[str, str] | None,
     ) -> RegistryInstallResult:
         """Ask Comfy Manager to install one exact Registry nodepack release."""
 
-        command = self._command(
-            workspace=workspace,
-            python_executable=python_executable,
-            nodepack=nodepack,
+        command_runner = ComfyManagerCommandRunner(
+            runtime=manager_runtime,
             env=env,
         )
-        if command is None:
+        self._emit(
+            on_log,
+            (
+                f"[ComfyNodepacks] Asking Comfy Registry for "
+                f"{nodepack.registry_id}@{nodepack.required_version}."
+            ),
+        )
+        process_result = command_runner.install_registry_nodepack(
+            node_spec=f"{nodepack.registry_id}@{nodepack.required_version}",
+            on_line=on_log,
+            timeout_seconds=CLI_INSTALL_TIMEOUT_SECONDS,
+        )
+        if process_result is None:
             output: tuple[str, ...] = (
                 "The selected Comfy environment exposes no supported Manager CLI.",
             )
@@ -80,92 +84,11 @@ class ComfyNodepackRegistryInstaller:
                 RegistryInstallOutcome.REGISTRY_UNREACHABLE,
                 output,
             )
-        self._emit(
-            on_log,
-            (
-                f"[ComfyNodepacks] Asking Comfy Registry for "
-                f"{nodepack.registry_id}@{nodepack.required_version}."
-            ),
-        )
-        exit_code, output = stream_command_collecting_output(
-            command,
-            cwd=workspace,
-            on_line=on_log,
-            timeout_seconds=CLI_INSTALL_TIMEOUT_SECONDS,
-            env=selected_comfy_environment(
-                workspace=workspace,
-                python_executable=python_executable,
-                env=env,
-            ),
-        )
+        exit_code, output = process_result
         return RegistryInstallResult(
             _classify_registry_result(exit_code=exit_code, output=output),
             output,
         )
-
-    def _command(
-        self,
-        *,
-        workspace: Path,
-        python_executable: Path,
-        nodepack: CoreComfyNodepack,
-        env: Mapping[str, str] | None,
-    ) -> list[str] | None:
-        """Resolve integrated comfy-cli first and legacy Manager CLI second."""
-
-        node_spec = f"{nodepack.registry_id}@{nodepack.required_version}"
-        if python_module_available(
-            module_name="comfy_cli",
-            workspace=workspace,
-            python_executable=python_executable,
-            env=env,
-        ):
-            return [
-                subprocess_path(python_executable),
-                "-m",
-                "comfy_cli",
-                "--workspace",
-                subprocess_path(workspace),
-                "--skip-prompt",
-                "node",
-                "install",
-                "--exit-on-fail",
-                "--no-deps",
-                node_spec,
-                "--mode",
-                "remote",
-            ]
-        if python_module_available(
-            module_name="cm_cli",
-            workspace=workspace,
-            python_executable=python_executable,
-            env=env,
-        ):
-            return [
-                subprocess_path(python_executable),
-                "-m",
-                "cm_cli",
-                "install",
-                "--exit-on-fail",
-                "--no-deps",
-                node_spec,
-                "--mode",
-                "remote",
-            ]
-        legacy_cli = workspace / "custom_nodes" / "ComfyUI-Manager" / "cm-cli.py"
-        if not legacy_cli.is_file():
-            legacy_cli = workspace / "custom_nodes" / "comfyui-manager" / "cm-cli.py"
-        if not legacy_cli.is_file():
-            return None
-        return [
-            subprocess_path(python_executable),
-            subprocess_path(legacy_cli),
-            "install",
-            "--no-deps",
-            node_spec,
-            "--mode",
-            "remote",
-        ]
 
     @staticmethod
     def _emit(callback: LogCallback | None, message: str) -> None:

--- a/substitute/infrastructure/comfy/nodepack_registry_update_settler.py
+++ b/substitute/infrastructure/comfy/nodepack_registry_update_settler.py
@@ -23,19 +23,15 @@ from dataclasses import dataclass
 from pathlib import Path
 import tempfile
 
+from substitute.domain.comfy_manager import ComfyManagerRuntime
 from substitute.infrastructure.comfy.comfy_manager_runtime import (
-    python_module_available,
-    selected_comfy_environment,
+    ComfyManagerCommandRunner,
 )
 from substitute.infrastructure.comfy.nodepack_manifest import (
     CLI_INSTALL_TIMEOUT_SECONDS,
     CoreComfyNodepack,
 )
-from substitute.infrastructure.process.hidden_process_runner import (
-    stream_command_collecting_output,
-)
 from substitute.shared.logging.logger import get_logger, log_info, log_warning
-from sugarsubstitute_shared.windows_long_paths import subprocess_path
 
 LogCallback = Callable[[str], None]
 _LOGGER = get_logger("infrastructure.comfy.nodepack_registry_update_settler")
@@ -55,52 +51,38 @@ class ComfyNodepackRegistryUpdateSettler:
     def settle(
         self,
         *,
-        workspace: Path,
-        python_executable: Path,
+        manager_runtime: ComfyManagerRuntime,
         nodepack: CoreComfyNodepack,
         on_log: LogCallback | None,
         env: Mapping[str, str] | None,
     ) -> RegistryUpdateSettlement:
         """Execute Manager's queued switch before Comfy imports custom nodes."""
 
-        if not python_module_available(
-            module_name="comfyui_manager.prestartup_script",
-            workspace=workspace,
-            python_executable=python_executable,
-            env=env,
-        ):
-            message = (
-                "Comfy-Manager deferred the Registry update, but its pre-startup "
-                "executor is unavailable in the selected Python environment."
-            )
-            self._emit_warning(on_log, message, nodepack=nodepack)
-            return RegistryUpdateSettlement(False, (message,))
-
         message = (
             f"[ComfyNodepacks] Applying Comfy-Manager's queued update for "
             f"{nodepack.registry_id}@{nodepack.required_version}."
         )
         self._emit_info(on_log, message, nodepack=nodepack)
+        command_runner = ComfyManagerCommandRunner(
+            runtime=manager_runtime,
+            env=env,
+        )
         with tempfile.TemporaryDirectory(prefix="substitute-comfy-manager-") as temp:
             session_path = Path(temp) / "session"
-            process_env = selected_comfy_environment(
-                workspace=workspace,
-                python_executable=python_executable,
-                env=env,
-            )
-            process_env["__COMFY_CLI_SESSION__"] = str(session_path)
-            exit_code, output = stream_command_collecting_output(
-                [
-                    subprocess_path(python_executable),
-                    "-m",
-                    "comfyui_manager.prestartup_script",
-                ],
-                cwd=workspace,
+            process_result = command_runner.settle_registry_updates(
+                session_path=session_path,
                 on_line=on_log,
                 timeout_seconds=CLI_INSTALL_TIMEOUT_SECONDS,
-                env=process_env,
             )
             reboot_requested = session_path.with_suffix(".reboot").is_file()
+        if process_result is None:
+            unavailable = (
+                "Comfy-Manager deferred the Registry update, but its pre-startup "
+                "executor is unavailable in the selected Python environment."
+            )
+            self._emit_warning(on_log, unavailable, nodepack=nodepack)
+            return RegistryUpdateSettlement(False, (unavailable,))
+        exit_code, output = process_result
 
         succeeded = exit_code == 0 and reboot_requested
         if not succeeded:

--- a/tests/test_architecture_governance.py
+++ b/tests/test_architecture_governance.py
@@ -237,3 +237,36 @@ def test_current_repository_has_no_architecture_governance_errors() -> None:
     errors = [item for item in validate_repository(root) if item.severity == "error"]
 
     assert errors == []
+
+
+def test_system_git_policy_rejects_direct_git_processes(tmp_path: Path) -> None:
+    """Fail with an actionable error when authored runtime code invokes Git."""
+
+    _write_policy(tmp_path)
+    _write(
+        tmp_path / "substitute/infrastructure/unsafe.py",
+        "import subprocess\nsubprocess.run(['git', 'status'])\n",
+    )
+
+    diagnostics = validate_repository(tmp_path, today=date(2026, 8, 11))
+
+    error = next(item for item in diagnostics if item.rule == "GIT001")
+    assert error.path == "substitute/infrastructure/unsafe.py"
+    assert "System Git is forbidden" in error.message
+    assert "pygit2" in error.message
+
+
+def test_system_git_policy_rejects_unguarded_comfy_cli_calls(tmp_path: Path) -> None:
+    """Keep every ComfyCLI invocation behind the protected command owner."""
+
+    _write_policy(tmp_path)
+    _write(
+        tmp_path / "launcher/unsafe.py",
+        "COMMAND = ['python', '-m', 'cm_cli', 'install', 'node']\n",
+    )
+
+    diagnostics = validate_repository(tmp_path, today=date(2026, 8, 11))
+
+    error = next(item for item in diagnostics if item.rule == "GIT002")
+    assert error.path == "launcher/unsafe.py"
+    assert "protected Comfy Manager command owner" in error.message

--- a/tests/test_attached_comfy_install.py
+++ b/tests/test_attached_comfy_install.py
@@ -18,8 +18,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import pytest
 
@@ -27,6 +28,7 @@ from substitute.domain.onboarding import (
     ComfyPythonBinding,
     ComfyPythonSelectionSource,
 )
+from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
 from substitute.infrastructure.comfy import attached_install
 
 
@@ -101,8 +103,27 @@ def test_attached_preparation_passes_one_verified_python_to_every_consumer(
         lambda *_args, **_kwargs: binding,
     )
 
-    def record(name: str) -> Any:
-        """Build one dependency consumer that records its explicit Python."""
+    manager_runtime = ComfyManagerRuntime(
+        kind=ComfyManagerKind.INTEGRATED,
+        workspace=workspace,
+        python_executable=executable,
+        version="4.1",
+    )
+
+    def provision_manager(_workspace: Path, **kwargs: object) -> ComfyManagerRuntime:
+        """Record Manager provisioning and return its validated runtime."""
+
+        calls.append(("manager", cast(Path, kwargs["python_executable"])))
+        return manager_runtime
+
+    def reconcile_nodepacks(**kwargs: object) -> None:
+        """Record the Python carried by the validated Manager runtime."""
+
+        runtime = cast(ComfyManagerRuntime, kwargs["manager_runtime"])
+        calls.append(("nodepacks", runtime.python_executable))
+
+    def record_python_consumer(name: str) -> Callable[..., None]:
+        """Build one remaining dependency consumer that records its Python."""
 
         def operation(_workspace: Path, **kwargs: object) -> None:
             calls.append((name, cast(Path | None, kwargs.get("python_executable"))))
@@ -110,15 +131,15 @@ def test_attached_preparation_passes_one_verified_python_to_every_consumer(
         return operation
 
     monkeypatch.setattr(
-        attached_install, "ensure_attached_workspace_manager", record("manager")
+        attached_install, "ensure_attached_workspace_manager", provision_manager
     )
     monkeypatch.setattr(
-        attached_install, "ensure_core_comfy_nodepacks", record("nodepacks")
+        attached_install, "ensure_core_comfy_nodepacks", reconcile_nodepacks
     )
     monkeypatch.setattr(
         attached_install,
         "attempt_sugarcubes_startup_maintenance",
-        record("sugarcubes"),
+        record_python_consumer("sugarcubes"),
     )
     monkeypatch.setattr(attached_install, "detect_hardware", lambda: object())
     monkeypatch.setattr(

--- a/tests/test_core_nodepack_reconciler.py
+++ b/tests/test_core_nodepack_reconciler.py
@@ -27,6 +27,7 @@ import pytest
 from substitute.application.comfy_nodepacks.core_nodepack_reconciliation_plan import (
     RegistryInstallOutcome,
 )
+from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
 from substitute.infrastructure.comfy import core_nodepack_reconciler
 from substitute.infrastructure.comfy.core_nodepack_reconciler import (
     CoreNodepackReconciler,
@@ -64,15 +65,15 @@ class _RegistryInstaller:
     def install_exact(
         self,
         *,
-        workspace: Path,
-        python_executable: Path,
+        manager_runtime: ComfyManagerRuntime,
         nodepack: CoreComfyNodepack,
         on_log: object | None,
         env: object | None,
     ) -> RegistryInstallResult:
         """Materialize exact CNR state only for successful Registry results."""
 
-        _ = python_executable, on_log, env
+        workspace = manager_runtime.workspace
+        _ = on_log, env
         self.calls.append((workspace, nodepack))
         if self.outcome in {
             RegistryInstallOutcome.INSTALLED,
@@ -130,15 +131,15 @@ class _RegistryUpdateSettler:
     def settle(
         self,
         *,
-        workspace: Path,
-        python_executable: Path,
+        manager_runtime: ComfyManagerRuntime,
         nodepack: CoreComfyNodepack,
         on_log: object | None,
         env: object | None,
     ) -> RegistryUpdateSettlement:
         """Apply the queued Registry fixture when configured to succeed."""
 
-        _ = python_executable, on_log, env
+        workspace = manager_runtime.workspace
+        _ = on_log, env
         self.calls.append((workspace, nodepack))
         if self.materialize:
             root = _existing_or_canonical_root(workspace, nodepack)
@@ -175,8 +176,9 @@ def test_missing_nodepack_installs_through_registry_and_only_then_dependencies(
     _patch_dependencies(monkeypatch, dependency_installs, satisfied=True)
 
     _reconciler(registry=registry, cleaner=cleaner).ensure(
-        tmp_path,
-        python_executable=tmp_path / ".venv" / "Scripts" / "python.exe",
+        manager_runtime=_runtime(
+            tmp_path, tmp_path / ".venv" / "Scripts" / "python.exe"
+        ),
         refresh_nodepacks=(),
         on_log=None,
         env=None,
@@ -204,8 +206,7 @@ def test_exact_registry_installation_is_idempotent(
     _patch_dependencies(monkeypatch, dependency_installs, satisfied=True)
 
     _reconciler(registry=registry).ensure(
-        tmp_path,
-        python_executable=tmp_path / "python.exe",
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
         refresh_nodepacks=(),
         on_log=None,
         env=None,
@@ -248,8 +249,7 @@ def test_existing_clean_official_git_install_migrates_then_registry_updates(
         ),
         legacy_cleaner=cast(LegacyNodepackDistributionCleaner, _LegacyCleaner()),
     ).ensure(
-        tmp_path,
-        python_executable=tmp_path / "python.exe",
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
         refresh_nodepacks=(),
         on_log=None,
         env=None,
@@ -284,8 +284,7 @@ def test_fallback_install_is_later_adopted_by_exact_registry_update(
     _patch_dependencies(monkeypatch, [], satisfied=True)
 
     _reconciler(registry=unavailable_registry, fallback=fallback).ensure(
-        tmp_path,
-        python_executable=tmp_path / "python.exe",
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
         refresh_nodepacks=(),
         on_log=None,
         env=None,
@@ -300,8 +299,7 @@ def test_fallback_install_is_later_adopted_by_exact_registry_update(
     _select_nodepacks(monkeypatch, next_release)
     available_registry = _RegistryInstaller(RegistryInstallOutcome.INSTALLED)
     _reconciler(registry=available_registry).ensure(
-        tmp_path,
-        python_executable=tmp_path / "python.exe",
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
         refresh_nodepacks=(),
         on_log=None,
         env=None,
@@ -334,8 +332,7 @@ def test_dirty_outdated_git_checkout_is_preserved_and_blocks_repair(
             repositories=repositories,
             registry_installer=cast(ComfyNodepackRegistryInstaller, registry),
         ).ensure(
-            tmp_path,
-            python_executable=tmp_path / "python.exe",
+            manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
             refresh_nodepacks=(),
             on_log=None,
             env=None,
@@ -369,8 +366,7 @@ def test_queued_registry_update_must_reach_exact_disk_state(
                 settler,
             ),
         ).ensure(
-            tmp_path,
-            python_executable=tmp_path / "python.exe",
+            manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
             refresh_nodepacks=(),
             on_log=None,
             env=None,
@@ -397,8 +393,7 @@ def test_explicit_local_source_bypasses_registry_acquisition(
     assert env_name is not None
 
     _reconciler(registry=registry).ensure(
-        tmp_path,
-        python_executable=tmp_path / "python.exe",
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
         refresh_nodepacks=(),
         on_log=None,
         env={env_name: str(source)},
@@ -428,6 +423,17 @@ def _reconciler(
             else None
         ),
         legacy_cleaner=cast(LegacyNodepackDistributionCleaner, selected_cleaner),
+    )
+
+
+def _runtime(workspace: Path, python: Path) -> ComfyManagerRuntime:
+    """Build one validated integrated Manager runtime fixture."""
+
+    return ComfyManagerRuntime(
+        kind=ComfyManagerKind.INTEGRATED,
+        workspace=workspace,
+        python_executable=python,
+        version="4.1",
     )
 
 

--- a/tests/test_managed_comfy_install_service.py
+++ b/tests/test_managed_comfy_install_service.py
@@ -31,6 +31,7 @@ from substitute.application.onboarding.managed_runtime_service import (
     ManagedRuntimeService,
 )
 from substitute.domain.comfy_nodepacks import CoreNodepackId
+from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
 from substitute.infrastructure.comfy import managed_install
 from substitute.infrastructure.comfy import managed_existing_setup
 from substitute.infrastructure.comfy import managed_existing_setup_operations
@@ -70,6 +71,17 @@ def _managed_setup_record_path(workspace: Path) -> Path:
         return cache.record_path
     finally:
         cache.close()
+
+
+def _manager_runtime(workspace: Path) -> ComfyManagerRuntime:
+    """Build one validated integrated Manager runtime fixture."""
+
+    return ComfyManagerRuntime(
+        kind=ComfyManagerKind.INTEGRATED,
+        workspace=workspace,
+        python_executable=workspace_python_path(workspace),
+        version="4.1",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -181,12 +193,16 @@ def _disable_shared_models_link(
     monkeypatch.setattr(
         managed_install,
         "ensure_core_comfy_nodepacks",
-        lambda workspace, refresh_nodepacks=frozenset(), on_log=None, env=None: None,
+        lambda manager_runtime, refresh_nodepacks=frozenset(), on_log=None, env=None: (
+            None
+        ),
     )
     monkeypatch.setattr(
         managed_existing_setup_operations,
         "ensure_core_comfy_nodepacks",
-        lambda workspace, refresh_nodepacks=frozenset(), on_log=None, env=None: None,
+        lambda manager_runtime, refresh_nodepacks=frozenset(), on_log=None, env=None: (
+            None
+        ),
     )
     monkeypatch.setattr(
         managed_install,
@@ -251,20 +267,20 @@ def test_ensure_managed_comfy_setup_reuses_installed_workspace(
         workspace: Path,
         on_log: object | None = None,
         env: object | None = None,
-    ) -> Path:
+    ) -> ComfyManagerRuntime:
         _ = on_log, env
         provision_calls.append(workspace)
-        return workspace / "custom_nodes" / "ComfyUI-Manager" / "cm-cli.py"
+        return _manager_runtime(workspace)
 
     def _record_nodepack_install(
-        workspace: Path,
+        manager_runtime: ComfyManagerRuntime,
         refresh_nodepacks: frozenset[CoreNodepackId] = frozenset(),
         on_log: object | None = None,
         env: object | None = None,
     ) -> None:
         """Record nodepack convergence before model-root configuration."""
 
-        _ = workspace, on_log, env
+        _ = manager_runtime, on_log, env
         refresh_targets.append(frozenset(refresh_nodepacks))
         mutation_order.append("nodepacks")
 
@@ -515,22 +531,22 @@ def test_ensure_managed_comfy_setup_skips_fresh_installed_checks(
         workspace: Path,
         on_log: object | None = None,
         env: object | None = None,
-    ) -> Path:
+    ) -> ComfyManagerRuntime:
         """Record manager provisioning."""
 
         _ = on_log, env
         calls.append("manager")
-        return workspace / "custom_nodes" / "ComfyUI-Manager" / "cm-cli.py"
+        return _manager_runtime(workspace)
 
     def _fake_ensure_core_comfy_nodepacks(
-        workspace: Path,
+        manager_runtime: ComfyManagerRuntime,
         refresh_nodepacks: object = frozenset(),
         on_log: object | None = None,
         env: object | None = None,
     ) -> None:
         """Record nodepack reconciliation."""
 
-        _ = workspace, on_log, env
+        _ = manager_runtime, on_log, env
         calls.append("nodepacks")
         refresh_targets.append(frozenset(cast(set[CoreNodepackId], refresh_nodepacks)))
 
@@ -659,7 +675,7 @@ def test_existing_setup_repairs_torch_only_when_explicitly_authorized(
     monkeypatch.setattr(
         managed_existing_setup_operations,
         "ensure_managed_workspace_manager",
-        lambda workspace, on_log=None, env=None: workspace / "manager.py",
+        lambda workspace, on_log=None, env=None: _manager_runtime(workspace),
     )
 
     first = managed_install.ensure_managed_comfy_setup(workspace=tmp_path)
@@ -758,12 +774,12 @@ def test_ensure_managed_comfy_setup_retries_after_state_commit_failure(
     monkeypatch.setattr(
         managed_existing_setup_operations,
         "ensure_managed_workspace_manager",
-        lambda workspace, on_log=None, env=None: manager_dir / "cm-cli.py",
+        lambda workspace, on_log=None, env=None: _manager_runtime(workspace),
     )
     monkeypatch.setattr(
         managed_existing_setup_operations,
         "ensure_core_comfy_nodepacks",
-        lambda workspace, refresh_nodepacks=frozenset(), on_log=None, env=None: (
+        lambda manager_runtime, refresh_nodepacks=frozenset(), on_log=None, env=None: (
             reconciliation_calls.append("nodepacks")
         ),
     )
@@ -1049,7 +1065,7 @@ def test_ensure_managed_comfy_setup_does_not_fallback_after_storage_error(
         python_runtime: str | None = None,
         on_log: object | None = None,
         env: object | None = None,
-    ) -> Path:
+    ) -> ComfyManagerRuntime:
         _ = workspace, python_runtime, on_log, env
         workspace_python.parent.mkdir(parents=True, exist_ok=True)
         workspace_python.write_text("", encoding="utf-8")
@@ -1167,7 +1183,7 @@ def test_ensure_managed_comfy_setup_installs_and_marks_workspace(
     ) -> Path:
         _ = on_log, env
         provision_calls.append(workspace)
-        return workspace / "custom_nodes" / "ComfyUI-Manager" / "cm-cli.py"
+        return _manager_runtime(workspace)
 
     monkeypatch.setattr(
         managed_install,
@@ -1290,9 +1306,7 @@ def test_new_stable_workspace_uses_verified_standalone_environment(
     monkeypatch.setattr(
         managed_install,
         "ensure_managed_workspace_manager",
-        lambda workspace, on_log=None, env=None: (
-            workspace / "custom_nodes" / "ComfyUI-Manager" / "cm-cli.py"
-        ),
+        lambda workspace, on_log=None, env=None: _manager_runtime(workspace),
     )
 
     result = managed_install.ensure_managed_comfy_setup(workspace=tmp_path)
@@ -1401,9 +1415,7 @@ def test_ensure_managed_comfy_setup_falls_back_to_stable_when_nightly_validation
     monkeypatch.setattr(
         managed_install,
         "ensure_managed_workspace_manager",
-        lambda workspace, on_log=None, env=None: (
-            workspace / "custom_nodes" / "ComfyUI-Manager" / "cm-cli.py"
-        ),
+        lambda workspace, on_log=None, env=None: _manager_runtime(workspace),
     )
     validations = iter(
         (
@@ -1497,9 +1509,7 @@ def test_ensure_managed_comfy_setup_removes_incomplete_workspace_before_install(
     monkeypatch.setattr(
         managed_install,
         "ensure_managed_workspace_manager",
-        lambda workspace, on_log=None, env=None: (
-            workspace / "custom_nodes" / "ComfyUI-Manager" / "cm-cli.py"
-        ),
+        lambda workspace, on_log=None, env=None: _manager_runtime(workspace),
     )
 
     result = managed_install.ensure_managed_comfy_setup(
@@ -1575,9 +1585,7 @@ def test_ensure_managed_comfy_setup_accepts_owned_model_paths_bootstrap_file(
     monkeypatch.setattr(
         managed_install,
         "ensure_managed_workspace_manager",
-        lambda workspace, on_log=None, env=None: (
-            workspace / "custom_nodes" / "ComfyUI-Manager" / "cm-cli.py"
-        ),
+        lambda workspace, on_log=None, env=None: _manager_runtime(workspace),
     )
     monkeypatch.setattr(
         managed_install,
@@ -1630,9 +1638,7 @@ def test_ensure_managed_comfy_setup_migrates_legacy_nested_workspace(
     monkeypatch.setattr(
         managed_existing_setup_operations,
         "ensure_managed_workspace_manager",
-        lambda workspace, on_log=None, env=None: (
-            workspace / "custom_nodes" / "ComfyUI-Manager" / "cm-cli.py"
-        ),
+        lambda workspace, on_log=None, env=None: _manager_runtime(workspace),
     )
 
     result = managed_install.ensure_managed_comfy_setup(

--- a/tests/test_managed_comfy_install_service.py
+++ b/tests/test_managed_comfy_install_service.py
@@ -1065,7 +1065,7 @@ def test_ensure_managed_comfy_setup_does_not_fallback_after_storage_error(
         python_runtime: str | None = None,
         on_log: object | None = None,
         env: object | None = None,
-    ) -> ComfyManagerRuntime:
+    ) -> Path:
         _ = workspace, python_runtime, on_log, env
         workspace_python.parent.mkdir(parents=True, exist_ok=True)
         workspace_python.write_text("", encoding="utf-8")
@@ -1180,7 +1180,7 @@ def test_ensure_managed_comfy_setup_installs_and_marks_workspace(
         workspace: Path,
         on_log: object | None = None,
         env: object | None = None,
-    ) -> Path:
+    ) -> ComfyManagerRuntime:
         _ = on_log, env
         provision_calls.append(workspace)
         return _manager_runtime(workspace)

--- a/tests/test_managed_recovery_adapters.py
+++ b/tests/test_managed_recovery_adapters.py
@@ -36,6 +36,7 @@ from substitute.application.comfy_startup_diagnostics import (
     ComfyStartupDiagnosticsCollector,
 )
 from substitute.domain.comfy_nodepacks import CoreNodepackId
+from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
 from substitute.domain.onboarding import (
     ComfyEndpoint,
     ComfyPythonBinding,
@@ -187,16 +188,15 @@ def test_reconcile_owned_dependencies_for_attached_target_runs_nodepack_policy(
     baseline_calls: list[tuple[Path, object]] = []
 
     def fake_ensure_core_nodepacks(
-        workspace: Path,
         *,
+        manager_runtime: ComfyManagerRuntime,
         refresh_nodepacks: frozenset[CoreNodepackId],
-        python_executable: Path,
         on_log: object,
     ) -> None:
         """Record core nodepack reconciliation arguments."""
 
-        core_calls.append((workspace, refresh_nodepacks, on_log))
-        assert python_executable.name == "python.exe"
+        core_calls.append((manager_runtime.workspace, refresh_nodepacks, on_log))
+        assert manager_runtime.python_executable.name == "python.exe"
         assert callable(on_log)
         on_log("core ready")
 
@@ -236,7 +236,12 @@ def test_reconcile_owned_dependencies_for_attached_target_runs_nodepack_policy(
     monkeypatch.setattr(
         managed_recovery_adapters,
         "ensure_attached_workspace_manager",
-        lambda *_args, **_kwargs: None,
+        lambda workspace, python_executable, **_kwargs: ComfyManagerRuntime(
+            kind=ComfyManagerKind.INTEGRATED,
+            workspace=workspace,
+            python_executable=python_executable,
+            version="4.1",
+        ),
     )
     logs: list[str] = []
 

--- a/tests/test_manager_runtime_probe.py
+++ b/tests/test_manager_runtime_probe.py
@@ -28,11 +28,49 @@ import pytest
 
 from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
 from substitute.infrastructure.comfy import manager_runtime_probe
+from substitute.infrastructure.comfy.comfy_manager_runtime import (
+    selected_comfy_environment,
+)
 from substitute.infrastructure.comfy.manager_contract import ComfyManagerContract
+from tools.ci.comfy_support_matrix import (
+    COMFY_RELEASE_CONTRACTS,
+    ComfySupportMatrixEntry,
+)
 from sugarsubstitute_shared.windows_long_paths import (
     subprocess_path,
     subprocess_working_directory,
 )
+
+
+@pytest.mark.parametrize(
+    "entry",
+    COMFY_RELEASE_CONTRACTS,
+    ids=lambda entry: entry.comfyui_tag,
+)
+def test_comfy_cli_environment_never_requires_system_git(
+    tmp_path: Path,
+    entry: ComfySupportMatrixEntry,
+) -> None:
+    """Protect every supported Manager runtime from a system-Git dependency."""
+
+    python = tmp_path / ".venv" / "Scripts" / "python.exe"
+    runtime = ComfyManagerRuntime(
+        kind=ComfyManagerKind.INTEGRATED,
+        workspace=tmp_path,
+        python_executable=python,
+        version=entry.manager_version,
+        supports_pygit2=entry.supports_pygit2,
+        uses_pygit2=entry.supports_pygit2,
+    )
+
+    environment = selected_comfy_environment(
+        runtime=runtime,
+        env={"PATH": "", "GIT_PYTHON_REFRESH": "error"},
+    )
+
+    assert environment["PATH"] == ""
+    assert environment["GIT_PYTHON_REFRESH"] == "quiet"
+    assert environment.get("CM_USE_PYGIT2") == ("1" if entry.supports_pygit2 else None)
 
 
 def test_integrated_manager_4_1_probe_requires_no_pygit2_api(

--- a/tests/test_nodepack_registry_installer.py
+++ b/tests/test_nodepack_registry_installer.py
@@ -26,6 +26,7 @@ import pytest
 from substitute.application.comfy_nodepacks.core_nodepack_reconciliation_plan import (
     RegistryInstallOutcome,
 )
+from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
 from substitute.infrastructure.comfy.nodepack_manifest import CORE_COMFY_NODEPACKS
 from substitute.infrastructure.comfy.nodepack_registry_installer import (
     ComfyNodepackRegistryInstaller,
@@ -42,8 +43,8 @@ def test_integrated_cli_installs_exact_registry_release_without_manager_deps(
     python = tmp_path / ".venv" / "Scripts" / "python.exe"
     observed: dict[str, object] = {}
     monkeypatch.setattr(
-        "substitute.infrastructure.comfy.nodepack_registry_installer.python_module_available",
-        lambda **kwargs: True,
+        "substitute.infrastructure.comfy.comfy_manager_runtime.ComfyManagerCommandRunner._module_available",
+        lambda self, module_name: True,
     )
 
     def fake_stream(command: list[str], **kwargs: Any) -> tuple[int, tuple[str, ...]]:
@@ -54,13 +55,12 @@ def test_integrated_cli_installs_exact_registry_release_without_manager_deps(
         return 0, ("[INSTALLED] substitute-backend [1.9.1]",)
 
     monkeypatch.setattr(
-        "substitute.infrastructure.comfy.nodepack_registry_installer.stream_command_collecting_output",
+        "substitute.infrastructure.comfy.comfy_manager_runtime.stream_command_collecting_output",
         fake_stream,
     )
 
     result = ComfyNodepackRegistryInstaller().install_exact(
-        workspace=tmp_path,
-        python_executable=python,
+        manager_runtime=_runtime(tmp_path, python),
         nodepack=CORE_COMFY_NODEPACKS[0],
         on_log=None,
         env={"VIRTUAL_ENV": "wrong", "CONDA_PREFIX": "also-wrong"},
@@ -87,6 +87,7 @@ def test_integrated_cli_installs_exact_registry_release_without_manager_deps(
     assert selected_env["VIRTUAL_ENV"] == str(python.parent.parent)
     assert selected_env["COMFYUI_PATH"] == str(tmp_path.resolve())
     assert selected_env["COMFYUI_FOLDERS_BASE_PATH"] == str(tmp_path.resolve())
+    assert selected_env["GIT_PYTHON_REFRESH"] == "quiet"
     assert "CONDA_PREFIX" not in selected_env
 
 
@@ -98,8 +99,8 @@ def test_integrated_manager_module_is_used_when_comfy_cli_is_absent(
 
     probe_results = iter((False, True))
     monkeypatch.setattr(
-        "substitute.infrastructure.comfy.nodepack_registry_installer.python_module_available",
-        lambda **kwargs: next(probe_results),
+        "substitute.infrastructure.comfy.comfy_manager_runtime.ComfyManagerCommandRunner._module_available",
+        lambda self, module_name: next(probe_results),
     )
     observed: list[str] = []
 
@@ -114,13 +115,12 @@ def test_integrated_manager_module_is_used_when_comfy_cli_is_absent(
         return 0, ("[INSTALLED] substitute-backend [1.9.1]",)
 
     monkeypatch.setattr(
-        "substitute.infrastructure.comfy.nodepack_registry_installer.stream_command_collecting_output",
+        "substitute.infrastructure.comfy.comfy_manager_runtime.stream_command_collecting_output",
         fake_stream,
     )
 
     result = ComfyNodepackRegistryInstaller().install_exact(
-        workspace=tmp_path,
-        python_executable=tmp_path / "python.exe",
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
         nodepack=CORE_COMFY_NODEPACKS[0],
         on_log=None,
         env={},
@@ -158,11 +158,11 @@ def test_registry_failures_are_classified_for_safe_fallback_policy(
     """Distinguish availability failures from arbitrary Manager failures."""
 
     monkeypatch.setattr(
-        "substitute.infrastructure.comfy.nodepack_registry_installer.python_module_available",
-        lambda **kwargs: True,
+        "substitute.infrastructure.comfy.comfy_manager_runtime.ComfyManagerCommandRunner._module_available",
+        lambda self, module_name: True,
     )
     monkeypatch.setattr(
-        "substitute.infrastructure.comfy.nodepack_registry_installer.stream_command_collecting_output",
+        "substitute.infrastructure.comfy.comfy_manager_runtime.stream_command_collecting_output",
         lambda *args, **kwargs: (
             0 if expected is RegistryInstallOutcome.PENDING_STARTUP else 1,
             output,
@@ -170,8 +170,7 @@ def test_registry_failures_are_classified_for_safe_fallback_policy(
     )
 
     result = ComfyNodepackRegistryInstaller().install_exact(
-        workspace=tmp_path,
-        python_executable=tmp_path / "python.exe",
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
         nodepack=CORE_COMFY_NODEPACKS[0],
         on_log=None,
         env={},
@@ -187,16 +186,26 @@ def test_missing_manager_cli_is_an_availability_failure(
     """Allow pinned fallback when an existing Comfy lacks callable Manager tooling."""
 
     monkeypatch.setattr(
-        "substitute.infrastructure.comfy.nodepack_registry_installer.python_module_available",
-        lambda **kwargs: False,
+        "substitute.infrastructure.comfy.comfy_manager_runtime.ComfyManagerCommandRunner._module_available",
+        lambda self, module_name: False,
     )
 
     result = ComfyNodepackRegistryInstaller().install_exact(
-        workspace=tmp_path,
-        python_executable=tmp_path / "python.exe",
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
         nodepack=CORE_COMFY_NODEPACKS[0],
         on_log=None,
         env={},
     )
 
     assert result.outcome is RegistryInstallOutcome.REGISTRY_UNREACHABLE
+
+
+def _runtime(workspace: Path, python: Path) -> ComfyManagerRuntime:
+    """Build one validated integrated Manager runtime fixture."""
+
+    return ComfyManagerRuntime(
+        kind=ComfyManagerKind.INTEGRATED,
+        workspace=workspace,
+        python_executable=python,
+        version="4.1",
+    )

--- a/tests/test_nodepack_registry_update_settler.py
+++ b/tests/test_nodepack_registry_update_settler.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import pytest
 
-from substitute.infrastructure.comfy import nodepack_registry_update_settler
+from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
 from substitute.infrastructure.comfy.nodepack_manifest import CORE_COMFY_NODEPACKS
 from substitute.infrastructure.comfy.nodepack_registry_update_settler import (
     ComfyNodepackRegistryUpdateSettler,
@@ -41,9 +41,8 @@ def test_settler_runs_manager_prestartup_in_selected_cli_session(
     python = tmp_path / ".venv" / "Scripts" / "python.exe"
     observed: dict[str, object] = {}
     monkeypatch.setattr(
-        nodepack_registry_update_settler,
-        "python_module_available",
-        lambda **kwargs: True,
+        "substitute.infrastructure.comfy.comfy_manager_runtime.ComfyManagerCommandRunner._module_available",
+        lambda self, module_name: True,
     )
 
     def fake_stream(
@@ -61,14 +60,12 @@ def test_settler_runs_manager_prestartup_in_selected_cli_session(
         return 0, ("[ComfyUI-Manager] Startup script completed.",)
 
     monkeypatch.setattr(
-        nodepack_registry_update_settler,
-        "stream_command_collecting_output",
+        "substitute.infrastructure.comfy.comfy_manager_runtime.stream_command_collecting_output",
         fake_stream,
     )
 
     result = ComfyNodepackRegistryUpdateSettler().settle(
-        workspace=tmp_path,
-        python_executable=python,
+        manager_runtime=_runtime(tmp_path, python),
         nodepack=CORE_COMFY_NODEPACKS[0],
         on_log=None,
         env={"CONDA_PREFIX": "wrong"},
@@ -85,6 +82,7 @@ def test_settler_runs_manager_prestartup_in_selected_cli_session(
     assert selected_env["VIRTUAL_ENV"] == str(python.parent.parent)
     assert selected_env["COMFYUI_PATH"] == str(tmp_path.resolve())
     assert selected_env["COMFYUI_FOLDERS_BASE_PATH"] == str(tmp_path.resolve())
+    assert selected_env["GIT_PYTHON_REFRESH"] == "quiet"
     assert "CONDA_PREFIX" not in selected_env
 
 
@@ -95,14 +93,12 @@ def test_settler_rejects_missing_manager_prestartup_owner(
     """Do not invent replacement update mechanics when Manager cannot settle work."""
 
     monkeypatch.setattr(
-        nodepack_registry_update_settler,
-        "python_module_available",
-        lambda **kwargs: False,
+        "substitute.infrastructure.comfy.comfy_manager_runtime.ComfyManagerCommandRunner._module_available",
+        lambda self, module_name: False,
     )
 
     result = ComfyNodepackRegistryUpdateSettler().settle(
-        workspace=tmp_path,
-        python_executable=tmp_path / "python.exe",
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
         nodepack=CORE_COMFY_NODEPACKS[0],
         on_log=None,
         env={},
@@ -110,3 +106,14 @@ def test_settler_rejects_missing_manager_prestartup_owner(
 
     assert not result.succeeded
     assert "pre-startup executor is unavailable" in result.output[0]
+
+
+def _runtime(workspace: Path, python: Path) -> ComfyManagerRuntime:
+    """Build one validated integrated Manager runtime fixture."""
+
+    return ComfyManagerRuntime(
+        kind=ComfyManagerKind.INTEGRATED,
+        workspace=workspace,
+        python_executable=python,
+        version="4.1",
+    )

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import ast
 import json
 from pathlib import Path
 import re
@@ -1203,22 +1202,6 @@ def test_windows_quality_workflows_fail_fast_on_native_command_errors() -> None:
     fail_fast_setting = "$PSNativeCommandUseErrorActionPreference = $true"
     assert release_workflow.count(fail_fast_setting) >= 2
     assert fail_fast_setting in test_workflow
-
-
-def test_production_python_contains_no_system_git_command() -> None:
-    """Supported runtime paths should never execute a system Git binary."""
-
-    offenders: list[str] = []
-    for source_root in (PROJECT_ROOT / "substitute", PROJECT_ROOT / "launcher"):
-        for path in source_root.rglob("*.py"):
-            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-            for node in ast.walk(tree):
-                if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
-                    continue
-                first = node.elts[0]
-                if isinstance(first, ast.Constant) and first.value == "git":
-                    offenders.append(str(path.relative_to(PROJECT_ROOT)))
-    assert offenders == []
 
 
 def test_installer_sources_do_not_reference_obsolete_comfy_desktop_repository() -> None:

--- a/tools/architecture_governance/system_git_policy.py
+++ b/tools/architecture_governance/system_git_policy.py
@@ -1,0 +1,193 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Reject system-Git dependencies and unprotected ComfyCLI commands."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from .model import Diagnostic
+
+_COMMAND_OWNER = "substitute/infrastructure/comfy/comfy_manager_runtime.py"
+_ENVIRONMENT_OWNER = "substitute/infrastructure/comfy/manager_environment.py"
+_COMFY_CLI_MODULES = frozenset(
+    {"comfy_cli", "cm_cli", "comfyui_manager.prestartup_script"}
+)
+
+
+def validate_system_git_policy(root: Path) -> list[Diagnostic]:
+    """Return violations from authored runtime Python sources."""
+
+    diagnostics: list[Diagnostic] = []
+    for source_root_name in ("substitute", "launcher"):
+        source_root = root / source_root_name
+        if not source_root.is_dir():
+            continue
+        for path in sorted(source_root.rglob("*.py")):
+            relative = path.relative_to(root).as_posix()
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+            except (OSError, UnicodeError, SyntaxError):
+                continue
+            diagnostics.extend(_source_diagnostics(tree, relative))
+    return diagnostics
+
+
+def _source_diagnostics(tree: ast.AST, relative_path: str) -> list[Diagnostic]:
+    """Inspect one parsed source tree for forbidden process contracts."""
+
+    diagnostics: list[Diagnostic] = []
+    reported_rules: set[str] = set()
+    for node in ast.walk(tree):
+        if _is_system_git_command(node) or _is_system_git_discovery(node):
+            _report_once(
+                diagnostics,
+                reported_rules,
+                "GIT001",
+                relative_path,
+                "System Git is forbidden in SugarSubstitute runtime code; use the "
+                "repository pygit2 owner instead.",
+            )
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value in _COMFY_CLI_MODULES and relative_path != _COMMAND_OWNER:
+                _report_once(
+                    diagnostics,
+                    reported_rules,
+                    "GIT002",
+                    relative_path,
+                    "ComfyCLI commands must run through the protected Comfy Manager "
+                    "command owner so external GitPython imports cannot require system Git.",
+                )
+            if node.value == "GIT_PYTHON_GIT_EXECUTABLE":
+                _report_once(
+                    diagnostics,
+                    reported_rules,
+                    "GIT003",
+                    relative_path,
+                    "SugarSubstitute must not discover or configure a system Git executable.",
+                )
+            if (
+                node.value == "GIT_PYTHON_REFRESH"
+                and relative_path != _ENVIRONMENT_OWNER
+            ):
+                _report_once(
+                    diagnostics,
+                    reported_rules,
+                    "GIT004",
+                    relative_path,
+                    "GitPython import protection belongs only to the authoritative "
+                    "Comfy Manager environment owner.",
+                )
+    return diagnostics
+
+
+def _is_system_git_command(node: ast.AST) -> bool:
+    """Return whether a literal argv begins with a Git executable."""
+
+    if isinstance(node, (ast.List, ast.Tuple)) and node.elts:
+        values = tuple(_string_constant(element) for element in node.elts[:2])
+        if _is_git_executable(values[0]):
+            return True
+        return (
+            values[0] is not None
+            and _executable_name(values[0]) in {"where", "where.exe"}
+            and len(values) > 1
+            and _is_git_executable(values[1])
+        )
+    if not isinstance(node, ast.Call) or not node.args:
+        return False
+    function_name = (
+        node.func.attr
+        if isinstance(node.func, ast.Attribute)
+        else node.func.id
+        if isinstance(node.func, ast.Name)
+        else ""
+    )
+    command = _string_constant(node.args[0])
+    return (
+        function_name in {"Popen", "call", "check_call", "check_output", "run"}
+        and command is not None
+        and _is_git_executable(command.split(maxsplit=1)[0])
+    )
+
+
+def _is_system_git_discovery(node: ast.AST) -> bool:
+    """Return whether code explicitly searches for a Git executable."""
+
+    if not isinstance(node, ast.Call) or not node.args:
+        return False
+    function = node.func
+    is_which = (
+        isinstance(function, ast.Attribute)
+        and function.attr == "which"
+        or isinstance(function, ast.Name)
+        and function.id == "which"
+    )
+    if not is_which:
+        return False
+    argument = node.args[0]
+    return (
+        isinstance(argument, ast.Constant)
+        and isinstance(argument.value, str)
+        and _is_git_executable(argument.value)
+    )
+
+
+def _string_constant(node: ast.AST) -> str | None:
+    """Return one literal string without evaluating authored code."""
+
+    return (
+        node.value
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        else None
+    )
+
+
+def _is_git_executable(value: str | None) -> bool:
+    """Recognize portable and Windows system-Git executable names."""
+
+    return value is not None and _executable_name(value) in {
+        "git",
+        "git.bat",
+        "git.cmd",
+        "git.exe",
+    }
+
+
+def _executable_name(value: str) -> str:
+    """Extract an executable name independent of the checker host platform."""
+
+    return value.replace("\\", "/").rsplit("/", maxsplit=1)[-1].casefold()
+
+
+def _report_once(
+    diagnostics: list[Diagnostic],
+    reported_rules: set[str],
+    rule: str,
+    path: str,
+    message: str,
+) -> None:
+    """Append one file-level diagnostic per policy rule."""
+
+    if rule in reported_rules:
+        return
+    reported_rules.add(rule)
+    diagnostics.append(Diagnostic(rule, path, message))
+
+
+__all__ = ["validate_system_git_policy"]

--- a/tools/architecture_governance/validation.py
+++ b/tools/architecture_governance/validation.py
@@ -65,6 +65,11 @@ def validate_repository(
         *_validate_state(root, policy, state, current_date),
     ]
     diagnostics.extend(_validate_structure(root, policy, state, current_date))
+    from tools.architecture_governance.system_git_policy import (
+        validate_system_git_policy,
+    )
+
+    diagnostics.extend(validate_system_git_policy(root))
     if (root / "substitute/app/bootstrap/persistent_cache_catalog.py").is_file():
         from tools.cache_governance.validation import validate_cache_governance
 

--- a/tools/ci/historical_install_qualification.py
+++ b/tools/ci/historical_install_qualification.py
@@ -223,14 +223,13 @@ def _prepare_qualified_existing_managed_workspace(
 
     python_executable = workspace_python_path(workspace)
     environment = dict(os.environ)
-    ensure_managed_workspace_manager(
+    manager_runtime = ensure_managed_workspace_manager(
         workspace,
         python_executable=python_executable,
         env=environment,
     )
     ensure_core_comfy_nodepacks(
-        workspace,
-        python_executable=python_executable,
+        manager_runtime=manager_runtime,
         env=environment,
     )
     run_sugarcubes_baseline_maintenance(

--- a/tools/ci/run_comfy_compatibility_probe.py
+++ b/tools/ci/run_comfy_compatibility_probe.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 from collections.abc import Sequence
 import json
+import os
 from pathlib import Path
 
 from substitute.infrastructure.comfy.core_nodepack_reconciler import (
@@ -72,10 +73,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         entry.manager_version,
         entry.supports_pygit2,
     )
+    git_free_environment = _git_free_cli_environment(python_executable)
     ensure_core_comfy_nodepacks(
-        workspace,
-        python_executable=python_executable,
+        manager_runtime=managed_runtime,
         on_log=log,
+        env=git_free_environment,
     )
 
     preservation_marker = workspace / "custom_nodes" / "User-Owned-Node" / "data.txt"
@@ -87,9 +89,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         on_log=log,
     )
     ensure_core_comfy_nodepacks(
-        workspace,
-        python_executable=python_executable,
+        manager_runtime=attached_runtime,
         on_log=log,
+        env=git_free_environment,
     )
     if preservation_marker.read_text(encoding="utf-8") != "preserve attached content":
         raise RuntimeError(
@@ -141,6 +143,16 @@ def _parse_arguments(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument("--comfyui-tag", required=True)
     parser.add_argument("--workspace", type=Path)
     return parser.parse_args(argv)
+
+
+def _git_free_cli_environment(python_executable: Path) -> dict[str, str]:
+    """Remove system executables while proving the protected ComfyCLI boundary."""
+
+    environment = dict(os.environ)
+    environment["PATH"] = str(python_executable.resolve().parent)
+    environment["GIT_PYTHON_REFRESH"] = "error"
+    environment.pop("GIT_PYTHON_GIT_EXECUTABLE", None)
+    return environment
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- route ComfyCLI registry installs and queued-update settlement through one protected Manager runtime
- select Manager pygit2 support across the ComfyUI compatibility matrix and prevent GitPython executable discovery from requiring system Git
- add an architecture gate that rejects direct system-Git invocations and ComfyCLI calls outside the protected runtime owner

## Verification

- `.venv\Scripts\python.exe -m ruff format .`
- commit hooks: GPL headers, architecture governance, whitespace, line endings, merge-conflict checks
- full platform and compatibility verification delegated to this PR's GitHub Actions checks