### PR TITLE
chore(release): sync canary with main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.21.1](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.0...v0.21.1) (2026-08-16)
+
+
+### Bug Fixes
+
+* **releases:** publish existing Stable tags correctly ([#68](https://github.com/Artificial-Sweetener/SugarSubstitute/issues/68)) ([d226fc8](https://github.com/Artificial-Sweetener/SugarSubstitute/commit/d226fc88f3f938a99e37d91f1ba2adaf83a6020f))
+
 # [0.21.0](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.20.1...v0.21.0) (2026-08-16)
 
 

--- a/launcher/sugarsubstitute_launcher/__init__.py
+++ b/launcher/sugarsubstitute_launcher/__init__.py
@@ -18,4 +18,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sugarsubstitute-release",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sugarsubstitute-release",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sugarsubstitute-release",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.21.1",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "packageManager": "npm@10.9.2",

--- a/substitute/_version.py
+++ b/substitute/_version.py
@@ -18,6 +18,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Merge the current main branch into canary before publishing the next canary release. This dedicated synchronization commit allows the required PR checks to run without changing main.