### PR TITLE
fix(releases): restore reliable release links and titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,7 +517,7 @@ jobs:
             "release", "create", $tag
           ) + $assets + @(
             "--repo", "${{ github.repository }}",
-            "--title", "SugarSubstitute $version release candidate",
+            "--title", "v$version",
             "--generate-notes",
             "--notes", $releaseNotes,
             "--prerelease"
@@ -607,12 +607,13 @@ jobs:
           set -euo pipefail
           channel_dir="build/canary-channel"
           readback_dir="build/canary-readback"
+          canary_release_title="Canary ${CANDIDATE_VERSION/-canary-/.}"
           mkdir -p "$readback_dir"
           python -c "import json, os, pathlib; payload=json.loads(pathlib.Path('$channel_dir/manifest.json').read_text()); assert payload['channel']=='canary', payload; assert payload['version']==os.environ['CANDIDATE_VERSION'], payload"
           (cd "$channel_dir" && sha256sum --check checksums.txt)
 
           if ! gh release view canary-latest --repo "${{ github.repository }}" > /dev/null 2>&1; then
-            gh release create canary-latest --repo "${{ github.repository }}" --target "${{ github.sha }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION" --notes-file "$channel_dir/.release-notes.md" --prerelease
+            gh release create canary-latest --repo "${{ github.repository }}" --target "${{ github.sha }}" --title "$canary_release_title" --notes-file "$channel_dir/.release-notes.md" --prerelease
           fi
 
           for asset in "$channel_dir"/*; do
@@ -635,7 +636,7 @@ jobs:
           done < <(gh release view canary-latest --repo "${{ github.repository }}" --json assets --jq '.assets[].name')
 
           gh api --method PATCH "repos/${{ github.repository }}/git/refs/tags/canary-latest" -f sha="${{ github.sha }}" -F force=true > /dev/null
-          gh release edit canary-latest --repo "${{ github.repository }}" --title "SugarSubstitute Canary $CANDIDATE_VERSION" --notes-file "$channel_dir/.release-notes.md" --prerelease --latest=false
+          gh release edit canary-latest --repo "${{ github.repository }}" --title "$canary_release_title" --notes-file "$channel_dir/.release-notes.md" --prerelease --latest=false
           gh release download canary-latest --repo "${{ github.repository }}" --pattern manifest.json --dir "$readback_dir"
           cmp "$channel_dir/manifest.json" "$readback_dir/manifest.json"
           gh release view canary-latest --repo "${{ github.repository }}" --json isDraft,isPrerelease --jq 'select(.isDraft == false and .isPrerelease == true)' > /dev/null

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -70,6 +70,7 @@ module.exports = {
       "./scripts/github-release-publisher.cjs",
       {
         repository: releaseRepository,
+        name: "v${nextRelease.version}",
         assets: [
           {
             path: ".local-release-channel/SugarSubstitute-*-Windows-x64-Setup.exe",

--- a/README.es.md
+++ b/README.es.md
@@ -64,7 +64,7 @@ El instalador puede crear un entorno administrado de ComfyUI o conectarse a uno 
 
 ### <img src="docs/release/platforms/windows.svg" width="22" height="22" alt=""> Windows x64
 
-**[Descarga el último instalador para Windows x64](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Windows-x64.exe)**
+**[Descarga el último instalador para Windows x64](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 Ejecuta el instalador y elige una carpeta normal con permisos de escritura, como `C:\SugarSubstitute`. Evita Archivos de programa, ya que los permisos de Windows pueden interferir con la instalación y las actualizaciones.
 
@@ -74,7 +74,7 @@ Siguiente paso: [elige cómo debe usar ComfyUI SugarSubstitute](#elige-tu-instal
 
 ### <img src="docs/release/platforms/apple.svg" width="22" height="22" alt=""> macOS Apple Silicon
 
-**[Descarga el último instalador para macOS Apple Silicon](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-macOS-Apple-Silicon.dmg)**
+**[Descarga el último instalador para macOS Apple Silicon](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 Abre el DMG, inicia SugarSubstitute Setup y usa la carpeta predeterminada `~/Applications/SugarSubstitute` u otra carpeta que te pertenezca. La instalación administrada utiliza la aceleración MPS de Apple en Apple Silicon. Los Mac con Intel no son compatibles.
 
@@ -88,8 +88,8 @@ Siguiente paso: [elige cómo debe usar ComfyUI SugarSubstitute](#elige-tu-instal
 
 Elige el paquete adecuado para tu sistema:
 
-- **[Descarga la última AppImage para Linux x86_64](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-x86_64.AppImage)** si quieres un instalador portátil. Márcala como ejecutable y ábrela.
-- **[Descarga el último paquete Debian para Linux amd64](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-amd64.deb)** para Debian, Ubuntu y distribuciones relacionadas. Instala el paquete y ejecuta `sugarsubstitute-setup`.
+- **[Descarga la última AppImage para Linux x86_64](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)** si quieres un instalador portátil. Márcala como ejecutable y ábrela.
+- **[Descarga el último paquete Debian para Linux amd64](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)** para Debian, Ubuntu y distribuciones relacionadas. Instala el paquete y ejecuta `sugarsubstitute-setup`.
 
 La carpeta de instalación predeterminada es `~/.local/share/SugarSubstitute`. La instalación administrada admite NVIDIA mediante CUDA, AMD mediante ROCm y GPU Intel mediante XPU. Actualmente no hay disponible ningún entorno administrado de Linux que funcione solo con CPU.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,7 @@ SugarSubstitute はパブリックベータです。私は実際の制作に使�
 
 ### <img src="docs/release/platforms/windows.svg" width="22" height="22" alt=""> Windows x64
 
-**[最新の Windows x64 インストーラーをダウンロード](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Windows-x64.exe)**
+**[最新の Windows x64 インストーラーをダウンロード](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 インストーラーを実行し、`C:\SugarSubstitute` のような、通常の書き込み可能なフォルダーを選んでください。Program Files は避けてください。Windows のアクセス権がセットアップや更新を妨げる場合があります。
 
@@ -74,7 +74,7 @@ SugarSubstitute はパブリックベータです。私は実際の制作に使�
 
 ### <img src="docs/release/platforms/apple.svg" width="22" height="22" alt=""> macOS Apple Silicon
 
-**[最新の macOS Apple Silicon インストーラーをダウンロード](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-macOS-Apple-Silicon.dmg)**
+**[最新の macOS Apple Silicon インストーラーをダウンロード](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 DMG を開いて SugarSubstitute Setup を起動し、既定の `~/Applications/SugarSubstitute` フォルダーか、自分が所有する別のフォルダーを選びます。マネージドセットアップは Apple Silicon で Apple の MPS アクセラレーションを使います。Intel Mac はサポートしていません。
 
@@ -88,8 +88,8 @@ DMG を開いて SugarSubstitute Setup を起動し、既定の `~/Applications/
 
 お使いのシステムに合うパッケージを選んでください：
 
-- **[最新の Linux x86_64 AppImage をダウンロード](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-x86_64.AppImage)**：ポータブルインストーラーです。実行可能に設定してから起動してください。
-- **[最新の Linux amd64 Debian パッケージをダウンロード](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-amd64.deb)**：Debian、Ubuntu、および関連ディストリビューション向けです。パッケージをインストールしてから `sugarsubstitute-setup` を実行してください。
+- **[最新の Linux x86_64 AppImage をダウンロード](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**：ポータブルインストーラーです。実行可能に設定してから起動してください。
+- **[最新の Linux amd64 Debian パッケージをダウンロード](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**：Debian、Ubuntu、および関連ディストリビューション向けです。パッケージをインストールしてから `sugarsubstitute-setup` を実行してください。
 
 既定のインストールフォルダーは `~/.local/share/SugarSubstitute` です。マネージドセットアップは、NVIDIA では CUDA、AMD では ROCm、Intel GPU では XPU を利用します。現在、Linux 向けのマネージド CPU 専用環境はありません。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -64,7 +64,7 @@ SugarSubstitute는 공개 베타 버전입니다. 실제 작업에 사용하고 
 
 ### <img src="docs/release/platforms/windows.svg" width="22" height="22" alt=""> Windows x64
 
-**[최신 Windows x64 설치 프로그램 다운로드](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Windows-x64.exe)**
+**[최신 Windows x64 설치 프로그램 다운로드](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 설치 프로그램을 실행하고 `C:\SugarSubstitute`처럼 쓰기 가능한 일반 폴더를 선택하세요. Windows 권한 때문에 설정과 업데이트가 방해받을 수 있으므로 Program Files는 피하세요.
 
@@ -74,7 +74,7 @@ SugarSubstitute는 공개 베타 버전입니다. 실제 작업에 사용하고 
 
 ### <img src="docs/release/platforms/apple.svg" width="22" height="22" alt=""> macOS Apple Silicon
 
-**[최신 macOS Apple Silicon 설치 프로그램 다운로드](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-macOS-Apple-Silicon.dmg)**
+**[최신 macOS Apple Silicon 설치 프로그램 다운로드](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 DMG를 열고 SugarSubstitute Setup을 실행한 다음 기본 `~/Applications/SugarSubstitute` 폴더 또는 본인이 소유한 다른 폴더를 사용하세요. 관리형 설정은 Apple Silicon에서 Apple의 MPS 가속을 사용합니다. Intel Mac은 지원하지 않습니다.
 
@@ -88,8 +88,8 @@ DMG를 열고 SugarSubstitute Setup을 실행한 다음 기본 `~/Applications/S
 
 시스템에 맞는 패키지를 선택하세요.
 
-- 휴대용 설치 프로그램이 필요하면 **[최신 Linux x86_64 AppImage를 다운로드하세요](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-x86_64.AppImage)**. 실행 가능 파일로 표시한 다음 실행하세요.
-- Debian, Ubuntu 및 관련 배포판에서는 **[최신 Linux amd64 Debian 패키지를 다운로드하세요](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-amd64.deb)**. 패키지를 설치한 다음 `sugarsubstitute-setup`을 실행하세요.
+- 휴대용 설치 프로그램이 필요하면 **[최신 Linux x86_64 AppImage를 다운로드하세요](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**. 실행 가능 파일로 표시한 다음 실행하세요.
+- Debian, Ubuntu 및 관련 배포판에서는 **[최신 Linux amd64 Debian 패키지를 다운로드하세요](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**. 패키지를 설치한 다음 `sugarsubstitute-setup`을 실행하세요.
 
 기본 설치 폴더는 `~/.local/share/SugarSubstitute`입니다. 관리형 설정은 CUDA를 통한 NVIDIA, ROCm을 통한 AMD와 XPU를 통한 Intel GPU를 지원합니다. 현재 Linux에서는 관리형 CPU 전용 환경을 사용할 수 없습니다.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Setup can create a managed ComfyUI environment or connect to one you already use
 
 ### <img src="docs/release/platforms/windows.svg" width="22" height="22" alt=""> Windows x64
 
-**[Download the latest Windows x64 installer](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Windows-x64.exe)**
+**[Download the latest Windows x64 installer](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 Run the installer and choose a normal writable folder, such as `C:\SugarSubstitute`. Avoid Program Files because Windows permissions can interfere with setup and updates.
 
@@ -74,7 +74,7 @@ Next: [choose how SugarSubstitute should use ComfyUI](#choose-your-comfyui-setup
 
 ### <img src="docs/release/platforms/apple.svg" width="22" height="22" alt=""> macOS Apple Silicon
 
-**[Download the latest macOS Apple Silicon installer](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-macOS-Apple-Silicon.dmg)**
+**[Download the latest macOS Apple Silicon installer](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 Open the DMG, launch SugarSubstitute Setup, and use the default `~/Applications/SugarSubstitute` folder or another folder you own. Managed setup uses Apple's MPS acceleration on Apple Silicon. Intel Macs are not supported.
 
@@ -88,8 +88,8 @@ Next: [choose how SugarSubstitute should use ComfyUI](#choose-your-comfyui-setup
 
 Choose the package that fits your system:
 
-- **[Download the latest Linux x86_64 AppImage](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-x86_64.AppImage)** for a portable installer. Mark it as executable, then run it.
-- **[Download the latest Linux amd64 Debian package](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-amd64.deb)** for Debian, Ubuntu, and related distributions. Install the package, then run `sugarsubstitute-setup`.
+- **[Download the latest Linux x86_64 AppImage](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)** for a portable installer. Mark it as executable, then run it.
+- **[Download the latest Linux amd64 Debian package](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)** for Debian, Ubuntu, and related distributions. Install the package, then run `sugarsubstitute-setup`.
 
 The default install folder is `~/.local/share/SugarSubstitute`. Managed setup supports NVIDIA through CUDA, AMD through ROCm, and Intel GPUs through XPU. A managed CPU-only Linux environment is not currently available.
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -64,7 +64,7 @@ SugarSubstitute 目前是公开测试版。我确实用它干活，但我也知�
 
 ### <img src="docs/release/platforms/windows.svg" width="22" height="22" alt=""> Windows x64
 
-**[下载最新 Windows x64 安装程序](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Windows-x64.exe)**
+**[下载最新 Windows x64 安装程序](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 运行安装程序，选择一个普通的可写文件夹，例如 `C:\SugarSubstitute`。请避开 Program Files，因为 Windows 权限可能会干扰设置和更新。
 
@@ -74,7 +74,7 @@ SugarSubstitute 目前是公开测试版。我确实用它干活，但我也知�
 
 ### <img src="docs/release/platforms/apple.svg" width="22" height="22" alt=""> macOS Apple Silicon
 
-**[下载最新 macOS Apple Silicon 安装程序](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-macOS-Apple-Silicon.dmg)**
+**[下载最新 macOS Apple Silicon 安装程序](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**
 
 打开 DMG，启动 SugarSubstitute Setup，然后使用默认的 `~/Applications/SugarSubstitute` 文件夹，或者选择另一个归你所有的文件夹。托管设置会在 Apple Silicon 上使用 Apple 的 MPS 加速。不支持 Intel Mac。
 
@@ -88,8 +88,8 @@ SugarSubstitute 采用临时签名，但没有经过公证，因为本项目没�
 
 选择适合你系统的软件包：
 
-- **[下载最新 Linux x86_64 AppImage](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-x86_64.AppImage)**，作为便携式安装程序使用。将它标记为可执行文件，然后运行。
-- **[下载最新 Linux amd64 Debian 软件包](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest/download/SugarSubstitute-Installer-Linux-amd64.deb)**，适用于 Debian、Ubuntu 及相关发行版。安装软件包，然后运行 `sugarsubstitute-setup`。
+- **[下载最新 Linux x86_64 AppImage](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**，作为便携式安装程序使用。将它标记为可执行文件，然后运行。
+- **[下载最新 Linux amd64 Debian 软件包](https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest)**，适用于 Debian、Ubuntu 及相关发行版。安装软件包，然后运行 `sugarsubstitute-setup`。
 
 默认安装文件夹是 `~/.local/share/SugarSubstitute`。托管设置支持通过 CUDA 使用 NVIDIA、通过 ROCm 使用 AMD，以及通过 XPU 使用 Intel GPU。目前还没有可用的 Linux 托管纯 CPU 环境。
 

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -287,6 +287,40 @@ def test_canary_isolated_release_train_contract() -> None:
     assert dependabot_text.count("target-branch: canary") == 3
 
 
+def test_published_release_titles_use_channel_specific_version_labels() -> None:
+    """Keep release names concise and distinguish Canary from Stable."""
+
+    release_configuration = (PROJECT_ROOT / ".releaserc.cjs").read_text(
+        encoding="utf-8"
+    )
+    release_workflow = (
+        PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+    ).read_text(encoding="utf-8")
+
+    assert 'name: "v${nextRelease.version}"' in release_configuration
+    assert (
+        'canary_release_title="Canary ${CANDIDATE_VERSION/-canary-/.}"'
+        in release_workflow
+    )
+    assert release_workflow.count('title "$canary_release_title"') == 2
+    assert "SugarSubstitute Canary $CANDIDATE_VERSION" not in release_workflow
+    assert '"--title", "v$version"' in release_workflow
+    assert "SugarSubstitute $version release candidate" not in release_workflow
+
+
+def test_readme_release_links_target_the_latest_release_page() -> None:
+    """Keep release documentation compatible with versioned installer assets."""
+
+    release_page = (
+        "https://github.com/Artificial-Sweetener/SugarSubstitute/releases/latest"
+    )
+    for readme_path in PROJECT_ROOT.glob("README*.md"):
+        content = readme_path.read_text(encoding="utf-8")
+
+        assert "releases/latest/download/" not in content
+        assert content.count(release_page) >= 5
+
+
 def test_release_version_script_embeds_canary_channel(tmp_path: Path) -> None:
     """Native Canary installers must receive immutable build-channel metadata."""
 


### PR DESCRIPTION
## Summary
- route README platform links through the maintained latest-release page
- restore concise Stable and Canary release titles
- prevent title and link regressions with release-contract coverage

## Verification
- `python -m pytest -n auto -q tests/test_release_workflow_contract.py`
- `python -m ruff format --check tests/test_release_workflow_contract.py`
- `python -m ruff check tests/test_release_workflow_contract.py`
- `node --check .releaserc.cjs`