### PR TITLE
fix(releases): qualify versioned historical installers

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -539,27 +539,25 @@ jobs:
         run: |
           $PSNativeCommandUseErrorActionPreference = $true
           New-Item -ItemType Directory -Force build/historical-installer | Out-Null
-          $asset = switch ("${{ matrix.platform }}") {
-            "windows" { "SugarSubstitute-Installer-Windows-x64.exe" }
-            "linux" { "SugarSubstitute-Installer-Linux-x86_64.AppImage" }
-            "macos" { "SugarSubstitute-Installer-macOS-Apple-Silicon.dmg" }
+          $assetPattern = switch ("${{ matrix.platform }}") {
+            "windows" { "SugarSubstitute-*-Windows-x64.exe" }
+            "linux" { "SugarSubstitute-*-Linux-x86_64.AppImage" }
+            "macos" { "SugarSubstitute-*-macOS-Apple-Silicon.dmg" }
           }
           gh release download "${{ matrix.history.tag }}" `
             --repo "${{ github.repository }}" `
-            --pattern $asset `
+            --pattern $assetPattern `
             --dir build/historical-installer
-          $path = (Resolve-Path (Join-Path build/historical-installer $asset)).Path
+          $path = (Get-ChildItem build/historical-installer -File | Select-Object -Single).FullName
           if ("${{ matrix.platform }}" -eq "linux") {
             chmod +x $path
           }
-          if ("${{ matrix.platform }}" -ne "macos") {
-            "HISTORICAL_INSTALLER=$path" | Out-File -FilePath $env:GITHUB_ENV -Append
-          }
+          "HISTORICAL_INSTALLER=$path" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Mount real historical macOS installer
         if: matrix.platform == 'macos'
         run: |
           mkdir -p "${{ runner.temp }}/historical-dmg"
-          hdiutil attach "build/historical-installer/SugarSubstitute-Installer-macOS-Apple-Silicon.dmg" -mountpoint "${{ runner.temp }}/historical-dmg" -nobrowse
+          hdiutil attach "$HISTORICAL_INSTALLER" -mountpoint "${{ runner.temp }}/historical-dmg" -nobrowse
           echo "HISTORICAL_INSTALLER=${{ runner.temp }}/historical-dmg/SugarSubstitute Setup.app/Contents/MacOS/SugarSubstitute Setup" >> "$GITHUB_ENV"
       - name: Reconstitute exact historical macOS install channel
         if: matrix.platform == 'macos'

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -539,9 +539,10 @@ def test_release_qualification_covers_clean_launch_and_upgrade_depth() -> None:
     assert "prepare_portable_historical_install" in lifecycle_text
     assert '"--headless-install"' in historical_qualification_text
     assert "Download real historical installer" in workflow_text
-    assert '"SugarSubstitute-Installer-Windows-x64.exe"' in workflow_text
-    assert '"SugarSubstitute-Installer-Linux-x86_64.AppImage"' in workflow_text
-    assert '"SugarSubstitute-Installer-macOS-Apple-Silicon.dmg"' in workflow_text
+    assert '"SugarSubstitute-*-Windows-x64.exe"' in workflow_text
+    assert '"SugarSubstitute-*-Linux-x86_64.AppImage"' in workflow_text
+    assert '"SugarSubstitute-*-macOS-Apple-Silicon.dmg"' in workflow_text
+    assert "hdiutil attach \"$HISTORICAL_INSTALLER\"" in workflow_text
     assert "Reconstitute exact historical macOS install channel" in workflow_text
     assert "python -m tools.ci.reconstitute_historical_macos_release" in workflow_text
     assert workflow_text.count("QT_QPA_PLATFORM: cocoa") == 2

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -542,7 +542,7 @@ def test_release_qualification_covers_clean_launch_and_upgrade_depth() -> None:
     assert '"SugarSubstitute-*-Windows-x64.exe"' in workflow_text
     assert '"SugarSubstitute-*-Linux-x86_64.AppImage"' in workflow_text
     assert '"SugarSubstitute-*-macOS-Apple-Silicon.dmg"' in workflow_text
-    assert "hdiutil attach \"$HISTORICAL_INSTALLER\"" in workflow_text
+    assert 'hdiutil attach "$HISTORICAL_INSTALLER"' in workflow_text
     assert "Reconstitute exact historical macOS install channel" in workflow_text
     assert "python -m tools.ci.reconstitute_historical_macos_release" in workflow_text
     assert workflow_text.count("QT_QPA_PLATFORM: cocoa") == 2


### PR DESCRIPTION
Restores historical-upgrade qualification for releases whose installer assets use versioned names, while retaining legacy asset support.