### PR TITLE
chore(release): catch Canary up to Main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.21.2](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.1...v0.21.2) (2026-08-21)
+
+
+### Bug Fixes
+
+* **installer:** install managed nodepacks without system Git ([029de3d](https://github.com/Artificial-Sweetener/SugarSubstitute/commit/029de3d421aba9f3fac36f9e9aef27c3cad1e01d))
+* **releases:** restore reliable release links and titles ([da8df40](https://github.com/Artificial-Sweetener/SugarSubstitute/commit/da8df403d506fe9100bf7f9b92fcdb4add3ce1c4))
+
 ## [0.21.1](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.0...v0.21.1) (2026-08-16)
 
 

--- a/launcher/sugarsubstitute_launcher/__init__.py
+++ b/launcher/sugarsubstitute_launcher/__init__.py
@@ -18,4 +18,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.1"
+__version__ = "0.21.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sugarsubstitute-release",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sugarsubstitute-release",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sugarsubstitute-release",
   "private": true,
-  "version": "0.21.1",
+  "version": "0.21.2",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "packageManager": "npm@10.9.2",

--- a/substitute/_version.py
+++ b/substitute/_version.py
@@ -18,6 +18,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.1"
+__version__ = "0.21.2"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Synchronizes Canary with Main's merged release metadata before retrying the corrected Canary-to-Main promotion.