### PR TITLE
chore(releases): synchronize Main before stable promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.21.3](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.2...v0.21.3) (2026-08-21)
+
+
+### Bug Fixes
+
+* **releases:** qualify versioned historical installers ([2211e40](https://github.com/Artificial-Sweetener/SugarSubstitute/commit/2211e4092282a2c6aeffb610a3e6abf0088be4e9))
+
 ## [0.21.2](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.1...v0.21.2) (2026-08-21)
 
 

--- a/launcher/sugarsubstitute_launcher/__init__.py
+++ b/launcher/sugarsubstitute_launcher/__init__.py
@@ -18,4 +18,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.2"
+__version__ = "0.21.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sugarsubstitute-release",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sugarsubstitute-release",
-      "version": "0.21.2",
+      "version": "0.21.3",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sugarsubstitute-release",
   "private": true,
-  "version": "0.21.2",
+  "version": "0.21.3",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "packageManager": "npm@10.9.2",

--- a/substitute/_version.py
+++ b/substitute/_version.py
@@ -18,6 +18,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.2"
+__version__ = "0.21.3"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Synchronizes Main's release metadata into Canary after the failed staged candidate, preserving the required Main→Canary→Main history before promoting the portable historical-installer qualification fix.