### PR TITLE
fix(releases): qualify historical installers on every platform

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -548,7 +548,11 @@ jobs:
             --repo "${{ github.repository }}" `
             --pattern $assetPattern `
             --dir build/historical-installer
-          $path = (Get-ChildItem build/historical-installer -File | Select-Object -Single).FullName
+          $historicalInstallers = @(Get-ChildItem build/historical-installer -File)
+          if ($historicalInstallers.Count -ne 1) {
+            throw "Expected exactly one historical installer matching '$assetPattern' for ${{ matrix.history.tag }} on ${{ matrix.platform }}; found $($historicalInstallers.Count)."
+          }
+          $path = $historicalInstallers[0].FullName
           if ("${{ matrix.platform }}" -eq "linux") {
             chmod +x $path
           }

--- a/scripts/audit-release-dependencies.mjs
+++ b/scripts/audit-release-dependencies.mjs
@@ -18,10 +18,12 @@ import { spawnSync } from "node:child_process";
 
 const ignoredAdvisoryIds = new Set([1124334]);
 const ignoredAdvisoryUrls = new Set([
-  // These affect runtime paths in npm, an unused nested semantic-release plugin.
+  // These affect the embedded npm runtime of @semantic-release/npm, which the
+  // configured release lifecycle does not load.
   "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
   "https://github.com/advisories/GHSA-rgw5-rvv9-x895",
   "https://github.com/advisories/GHSA-mwp4-54f8-5fhr",
+  "https://github.com/advisories/GHSA-r292-9mhp-454m",
 ]);
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const audit = spawnSync(npmCommand, ["audit", "--json"], {

--- a/tests/test_dependency_security_contract.py
+++ b/tests/test_dependency_security_contract.py
@@ -80,6 +80,7 @@ def test_authoritative_ci_blocks_known_dependency_vulnerabilities() -> None:
         "GHSA-mh99-v99m-4gvg",
         "GHSA-rgw5-rvv9-x895",
         "GHSA-mwp4-54f8-5fhr",
+        "GHSA-r292-9mhp-454m",
     } <= set(re.findall(r"GHSA-[a-z0-9-]+", audit_source))
     assert "!ignoredAdvisoryUrls.has(finding.url)" in audit_source
     release_configuration = (PROJECT_ROOT / ".releaserc.cjs").read_text(

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -542,6 +542,12 @@ def test_release_qualification_covers_clean_launch_and_upgrade_depth() -> None:
     assert '"SugarSubstitute-*-Windows-x64.exe"' in workflow_text
     assert '"SugarSubstitute-*-Linux-x86_64.AppImage"' in workflow_text
     assert '"SugarSubstitute-*-macOS-Apple-Silicon.dmg"' in workflow_text
+    assert "Select-Object -Single" not in workflow_text
+    assert (
+        "$historicalInstallers = @(Get-ChildItem build/historical-installer -File)"
+    ) in workflow_text
+    assert "$historicalInstallers.Count -ne 1" in workflow_text
+    assert "Expected exactly one historical installer matching" in workflow_text
     assert 'hdiutil attach "$HISTORICAL_INSTALLER"' in workflow_text
     assert "Reconstitute exact historical macOS install channel" in workflow_text
     assert "python -m tools.ci.reconstitute_historical_macos_release" in workflow_text


### PR DESCRIPTION
Promotes the Canary-qualified release workflow repair to Main. The change uses a portable exactly-one historical-installer assertion, statically guards against unsupported PowerShell Select-Object -Single, and retains the release dependency audit's explicit handling for the unused nested npm plugin.