### PR TITLE
fix(releases): preserve self-contained macOS history

### DIFF
--- a/tests/test_historical_release_reconstitution.py
+++ b/tests/test_historical_release_reconstitution.py
@@ -136,6 +136,46 @@ def test_reconstitution_rejects_unreviewed_archive_roots(tmp_path: Path) -> None
         )
 
 
+def test_reconstitution_preserves_self_contained_historical_app(tmp_path: Path) -> None:
+    """Qualification must retain exact bundles that need no onedir repair."""
+
+    source_root = tmp_path / "source"
+    output_root = tmp_path / "output"
+    app_path = _write_asset(source_root / "app.zip", b"historical app")
+    launcher_path = source_root / "launcher.zip"
+    launcher_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(launcher_path, "w") as archive:
+        archive.writestr(
+            "SugarSubstitute.app/Contents/MacOS/SugarSubstitute",
+            b"app launcher",
+        )
+        archive.writestr(
+            "SugarSubstitute.app/Contents/Frameworks/python3.12/lib-dynload/_struct.so",
+            b"app runtime",
+        )
+    (source_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": "0.21.1",
+                "app": _asset_metadata(app_path),
+                "launchers": {"macos_arm64": _asset_metadata(launcher_path)},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    reconstitute_historical_macos_release(
+        source_root=source_root,
+        output_root=output_root,
+    )
+
+    assert (output_root / "launcher.zip").read_bytes() == launcher_path.read_bytes()
+    evidence = json.loads(
+        (output_root / "historical-reconstitution.json").read_text(encoding="utf-8")
+    )
+    assert evidence["removed_roots"] == []
+
+
 def _write_asset(path: Path, content: bytes) -> Path:
     """Write one fixture release asset."""
 

--- a/tools/ci/reconstitute_historical_macos_release.py
+++ b/tools/ci/reconstitute_historical_macos_release.py
@@ -145,6 +145,9 @@ def _write_reconstituted_launcher(
             )
             written_names.add(destination_name.as_posix())
             retained_members += 1
+    if encountered_roots == {_APP_ROOT}:
+        shutil.copy2(source, destination)
+        return ()
     expected_roots = {_APP_ROOT, _PYINSTALLER_SIBLING_ROOT}
     if encountered_roots != expected_roots:
         raise ValueError(


### PR DESCRIPTION
Allows historical macOS launcher archives that are already self-contained app bundles to pass through byte-for-byte. Retains strict one-folder reconstruction for the reviewed two-root historical defect and adds regression coverage.