### PR TITLE
chore(release): synchronize Main release metadata into Canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.21.4](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.3...v0.21.4) (2026-08-21)
+
+
+### Bug Fixes
+
+* **releases:** qualify historical installers on every platform ([39c7a4a](https://github.com/Artificial-Sweetener/SugarSubstitute/commit/39c7a4affcc49fea862988e8a11f6c6a431c9e19))
+
 ## [0.21.3](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.2...v0.21.3) (2026-08-21)
 
 

--- a/launcher/sugarsubstitute_launcher/__init__.py
+++ b/launcher/sugarsubstitute_launcher/__init__.py
@@ -18,4 +18,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.3"
+__version__ = "0.21.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sugarsubstitute-release",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sugarsubstitute-release",
-      "version": "0.21.3",
+      "version": "0.21.4",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sugarsubstitute-release",
   "private": true,
-  "version": "0.21.3",
+  "version": "0.21.4",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "packageManager": "npm@10.9.2",

--- a/substitute/_version.py
+++ b/substitute/_version.py
@@ -18,6 +18,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.3"
+__version__ = "0.21.4"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Synchronizes the failed Main release metadata commit into Canary before the corrected Canary-to-Main promotion.