### PR TITLE
fix(releases): publish only fully qualified builds

### DIFF
--- a/.github/workflows/cross-platform-validation.yml
+++ b/.github/workflows/cross-platform-validation.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   PYTHON_VERSION: "3.12.10"
@@ -187,9 +187,11 @@ jobs:
           retention-days: 1
 
   assemble-release:
-    name: Assemble and publish private test release
+    name: Assemble and publish temporary test prerelease
     needs: [build-windows, build-macos, build-linux]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     outputs:
       release-url: ${{ steps.publish.outputs.url }}
     steps:
@@ -213,12 +215,12 @@ jobs:
       - name: Build release channel
         run: |
           python tools/build_release_payload.py build --version ${{ env.TEST_VERSION }} --channel test --output-dir .local-release-channel --asset-base-url "https://github.com/${{ github.repository }}/releases/download/${{ env.TEST_TAG }}" --platform-input windows_x64 build/native/windows/launcher/SugarSubstitute --installer-input windows_x64 exe build/native/windows/installer/SugarSubstitute-Installer-Windows-x64.exe --platform-input macos_arm64 build/native/macos/launcher --installer-input macos_arm64 dmg build/native/macos/installer/SugarSubstitute-Installer-macOS-Apple-Silicon.dmg --platform-input linux_x64 build/native/linux/launcher/SugarSubstitute --installer-input linux_x64 appimage build/native/linux/installer/SugarSubstitute-Installer-Linux-x86_64.AppImage --installer-input linux_x64 deb build/native/linux/installer/SugarSubstitute-Installer-Linux-amd64.deb
-      - name: Publish and read back private prerelease
+      - name: Publish and read back temporary prerelease
         id: publish
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ env.TEST_TAG }}" .local-release-channel/* --repo "${{ github.repository }}" --target "${{ github.sha }}" --title "Cross-platform validation ${{ env.TEST_VERSION }}" --notes "Automated private installer validation release." --prerelease
+          gh release create "${{ env.TEST_TAG }}" .local-release-channel/* --repo "${{ github.repository }}" --target "${{ github.sha }}" --title "Cross-platform validation ${{ env.TEST_VERSION }}" --notes "Automated temporary installer validation release for run ${{ github.run_id }}, attempt ${{ github.run_attempt }}." --prerelease
           gh release view "${{ env.TEST_TAG }}" --repo "${{ github.repository }}" --json url,assets > build/release-readback.json
           python -c 'import json; from pathlib import Path; p=json.loads(Path("build/release-readback.json").read_text()); names={a["name"] for a in p["assets"]}; expected={x.name for x in Path(".local-release-channel").iterdir() if x.is_file()}; assert names==expected,(names,expected); print("RELEASE_READBACK_OK",p["url"]); print("url="+p["url"], file=open("$GITHUB_OUTPUT","a"))'
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -318,3 +320,22 @@ jobs:
           path: .local-release-channel
       - name: Prove clean install and production onboarding composition
         run: python -m launcher.sugarsubstitute_launcher.dev_install --install-root "${{ runner.temp }}/SugarSubstitute" --release-root .local-release-channel --allow-non-default-clean
+
+  cleanup-test-release:
+    name: Remove temporary test prerelease
+    needs: [assemble-release, linux-distro-trust, installed-app-smoke]
+    if: always() && needs.assemble-release.result != 'skipped'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Delete the exact automation-owned release and tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ env.TEST_TAG }}"
+          if gh release view "$tag" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            test "$(gh release view "$tag" --repo "${{ github.repository }}" --json isPrerelease --jq '.isPrerelease')" = "true"
+            gh release delete "$tag" --repo "${{ github.repository }}" --cleanup-tag --yes
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,10 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-publication
   cancel-in-progress: false
 
 env:
@@ -102,7 +102,7 @@ jobs:
       version: ${{ steps.release-version.outputs.version || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && format('9999.0.{0}', github.run_number) || '') }}
       should_release: ${{ steps.release-version.outputs.should_release || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && 'true' || 'false') }}
       first_release: ${{ steps.release-version.outputs.first_release }}
-      channel: ${{ (github.event_name == 'push' && github.ref_name == 'canary' && 'canary') || 'stable' }}
+      channel: ${{ (github.ref_name == 'canary' && 'canary') || 'stable' }}
 
     steps:
       - name: Checkout complete history
@@ -124,7 +124,7 @@ jobs:
         id: release-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SUGAR_SUBSTITUTE_CANARY_RUN_NUMBER: ${{ github.event_name == 'push' && github.ref_name == 'canary' && github.run_number || '' }}
+          SUGAR_SUBSTITUTE_CANARY_RUN_NUMBER: ${{ github.ref_name == 'canary' && github.run_number || '' }}
           SUGAR_SUBSTITUTE_QUALIFICATION_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && format('9999.0.{0}', github.run_number) || '' }}
         run: node scripts/resolve-next-release-version.mjs
 
@@ -331,12 +331,11 @@ jobs:
       )
     runs-on: windows-latest
     outputs:
-      candidate_tag: ${{ steps.publish.outputs.candidate_tag }}
       candidate_artifact_name: ${{ steps.reuse.outputs.candidate_artifact_name || steps.stage-artifact.outputs.candidate_artifact_name }}
       candidate_run_id: ${{ github.event.inputs.qualification_candidate_run_id || github.run_id }}
       candidate_version: ${{ github.event.inputs.qualification_candidate_version || needs.determine-version.outputs.version }}
       candidate_channel: ${{ needs.determine-version.outputs.channel }}
-      staged: ${{ steps.reuse.outputs.staged || steps.stage-artifact.outputs.staged || steps.publish.outputs.staged }}
+      staged: ${{ steps.reuse.outputs.staged || steps.stage-artifact.outputs.staged }}
 
     steps:
       - name: Checkout
@@ -395,20 +394,13 @@ jobs:
           run-id: ${{ github.event.inputs.release_input_run_id || github.run_id }}
           github-token: ${{ github.token }}
 
-      - name: Prepare first release candidate assets
-        if: github.event.inputs.qualification_candidate_run_id == '' && needs.determine-version.outputs.channel == 'stable' && needs.determine-version.outputs.first_release == 'true'
+      - name: Prepare private release candidate assets
+        if: github.event.inputs.qualification_candidate_run_id == ''
         shell: pwsh
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: node scripts\prepare-release-assets.mjs ${{ needs.determine-version.outputs.version }}
-
-      - name: Prepare Canary release candidate assets
-        if: github.event.inputs.qualification_candidate_run_id == '' && needs.determine-version.outputs.channel == 'canary'
-        shell: pwsh
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          SUGAR_SUBSTITUTE_RELEASE_CHANNEL: canary
-          SUGAR_SUBSTITUTE_ASSET_BASE_URL: https://github.com/${{ github.repository }}/releases/download/canary-latest
+          SUGAR_SUBSTITUTE_RELEASE_CHANNEL: ${{ needs.determine-version.outputs.channel }}
+          SUGAR_SUBSTITUTE_ASSET_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && 'https://localhost:44443' || '' }}
         run: node scripts\prepare-release-assets.mjs ${{ needs.determine-version.outputs.version }}
 
       - name: Prepare installer release notes
@@ -416,65 +408,13 @@ jobs:
         shell: pwsh
         run: node scripts\release-notes-preamble.cjs --repository "${{ github.repository }}" --version "${{ needs.determine-version.outputs.version }}" --channel "${{ needs.determine-version.outputs.channel }}" --output "build\release-notes.md"
 
-      - name: Add Canary release notes to the candidate artifact
-        if: github.event.inputs.qualification_candidate_run_id == '' && needs.determine-version.outputs.channel == 'canary'
+      - name: Add release notes to the private candidate artifact
+        if: github.event.inputs.qualification_candidate_run_id == ''
         shell: pwsh
         run: Copy-Item build\release-notes.md .local-release-channel\.release-notes.md
 
-      - name: Configure authorized Stable release push
-        if: github.event.inputs.qualification_candidate_run_id == '' && needs.determine-version.outputs.channel == 'stable' && needs.determine-version.outputs.first_release != 'true'
-        env:
-          STABLE_RELEASE_DEPLOY_KEY: ${{ secrets.STABLE_RELEASE_DEPLOY_KEY }}
-        shell: pwsh
-        run: |
-          $PSNativeCommandUseErrorActionPreference = $true
-          if ([string]::IsNullOrWhiteSpace($env:STABLE_RELEASE_DEPLOY_KEY)) {
-            throw "STABLE_RELEASE_DEPLOY_KEY is required to stage a Stable release."
-          }
-          $keyPath = Join-Path $env:RUNNER_TEMP "stable-release-deploy-key"
-          $keyText = $env:STABLE_RELEASE_DEPLOY_KEY.Trim().Replace("`r", "") + "`n"
-          [System.IO.File]::WriteAllText(
-            $keyPath,
-            $keyText,
-            [System.Text.UTF8Encoding]::new($false)
-          )
-          & icacls.exe $keyPath /inheritance:r /grant:r "$($env:USERNAME):(R)" | Out-Null
-          if ($LASTEXITCODE -ne 0) {
-            throw "Could not restrict the Stable release deploy key permissions."
-          }
-          $gitKeyPath = $keyPath.Replace("\", "/")
-          git config --local core.sshCommand "ssh -i `"$gitKeyPath`" -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
-
-      - name: Prepare semantic release commit and tag without publishing stable
-        if: github.event.inputs.qualification_candidate_run_id == '' && needs.determine-version.outputs.channel == 'stable' && needs.determine-version.outputs.first_release != 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL: git@github.com:${{ github.repository }}.git
-          SUGAR_SUBSTITUTE_STAGE_ONLY: "true"
-        shell: pwsh
-        run: |
-          if ("${{ github.event_name }}" -eq "workflow_dispatch" -and "${{ github.event.inputs.dry_run }}" -eq "true") {
-            npx semantic-release --dry-run --no-ci
-          } else {
-            npx semantic-release
-          }
-
-      - name: Prepare temporary non-release candidate assets
-        if: github.event.inputs.qualification_candidate_run_id == '' && github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          SUGAR_SUBSTITUTE_ASSET_BASE_URL: https://localhost:44443
-        shell: pwsh
-        run: node scripts\prepare-release-assets.mjs ${{ needs.determine-version.outputs.version }}
-
-      - name: Upload temporary non-release candidate channel
-        if: >-
-          github.event.inputs.qualification_candidate_run_id == '' && (
-            needs.determine-version.outputs.channel == 'canary' || (
-              github.event_name == 'workflow_dispatch' &&
-              github.event.inputs.dry_run == 'true'
-            )
-          )
+      - name: Upload private non-release candidate channel
+        if: github.event.inputs.qualification_candidate_run_id == ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: non-release-candidate-channel
@@ -485,57 +425,10 @@ jobs:
 
       - name: Record temporary candidate channel
         id: stage-artifact
-        if: >-
-          github.event.inputs.qualification_candidate_run_id == '' && (
-            needs.determine-version.outputs.channel == 'canary' || (
-              github.event_name == 'workflow_dispatch' &&
-              github.event.inputs.dry_run == 'true'
-            )
-          )
+        if: github.event.inputs.qualification_candidate_run_id == ''
         shell: pwsh
         run: |
           "candidate_artifact_name=non-release-candidate-channel" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "staged=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - name: Publish exact bytes as a visible prerelease candidate
-        id: publish
-        if: >-
-          github.event.inputs.qualification_candidate_run_id == '' &&
-          needs.determine-version.outputs.channel == 'stable' && (
-            github.event_name != 'workflow_dispatch' ||
-            github.event.inputs.dry_run != 'true'
-          )
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: pwsh
-        run: |
-          $version = "${{ needs.determine-version.outputs.version }}"
-          $tag = "v$version"
-          $assets = Get-ChildItem .local-release-channel -File | Select-Object -ExpandProperty FullName
-          $releaseNotes = Get-Content -Raw build\release-notes.md
-          $releaseArguments = @(
-            "release", "create", $tag
-          ) + $assets + @(
-            "--repo", "${{ github.repository }}",
-            "--title", "v$version",
-            "--generate-notes",
-            "--notes", $releaseNotes,
-            "--prerelease"
-          )
-          if ("${{ needs.determine-version.outputs.first_release }}" -eq "true") {
-            $releaseArguments += @("--target", "${{ github.sha }}")
-          }
-          gh @releaseArguments
-          $readback = gh release view $tag --repo "${{ github.repository }}" --json isDraft,isPrerelease,assets | ConvertFrom-Json
-          if ($readback.isDraft -or -not $readback.isPrerelease) {
-            throw "Candidate release was not published as a visible prerelease."
-          }
-          $expected = @(Get-ChildItem .local-release-channel -File | Select-Object -ExpandProperty Name | Sort-Object)
-          $actual = @($readback.assets | ForEach-Object { $_.name } | Sort-Object)
-          if (Compare-Object $expected $actual) {
-            throw "Candidate release assets differ from the qualified local channel."
-          }
-          "candidate_tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "staged=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Reuse exact temporary candidate channel
@@ -564,30 +457,115 @@ jobs:
     uses: ./.github/workflows/release-qualification.yml
     with:
       candidate_version: ${{ needs.stage-candidate.outputs.candidate_version }}
-      candidate_tag: ${{ needs.stage-candidate.outputs.candidate_tag }}
+      candidate_tag: ''
       candidate_channel: ${{ needs.stage-candidate.outputs.candidate_channel }}
       candidate_artifact_name: ${{ needs.stage-candidate.outputs.candidate_artifact_name }}
       candidate_run_id: ${{ needs.stage-candidate.outputs.candidate_run_id }}
-      qualification_scope: ${{ github.event_name == 'push' && github.ref_name == 'canary' && 'canary-fast' || inputs.qualification_scope == '' && 'all' || inputs.qualification_scope == 'full' && 'all' || inputs.qualification_scope }}
+      qualification_scope: ${{ github.ref_name == 'canary' && 'canary-fast' || inputs.qualification_scope == '' && 'all' || inputs.qualification_scope == 'full' && 'all' || inputs.qualification_scope }}
       upgrade_selection: ${{ inputs.dry_run == 'true' && inputs.qualification_scope != 'full' && inputs.upgrade_selection || 'complete' }}
       qualification_timeout_seconds: ${{ inputs.dry_run == 'true' && inputs.qualification_scope != 'full' && inputs.qualification_timeout_seconds || '3600' }}
 
-  promote-release:
-    name: Promote qualified bytes without rebuilding
+  publish-release:
+    name: Publish qualified bytes without rebuilding
     needs:
       - stage-candidate
       - qualify-candidate
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'
+    if: >-
+      always() &&
+      needs.stage-candidate.result == 'success' &&
+      needs.qualify-candidate.result == 'success' &&
+      (github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true')
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
     steps:
-      - name: Promote the exact qualified Stable prerelease
+      - name: Checkout complete Stable history
+        if: github.ref_name == 'main'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Stable release Node
+        if: github.ref_name == 'main'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install Stable release dependencies
+        if: github.ref_name == 'main'
+        run: npm ci
+
+      - name: Download exact qualified Stable channel
+        if: github.ref_name == 'main'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.stage-candidate.outputs.candidate_artifact_name }}
+          path: .local-release-channel
+          run-id: ${{ needs.stage-candidate.outputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify qualified Stable channel identity
+        if: github.ref_name == 'main'
+        env:
+          CANDIDATE_VERSION: ${{ needs.stage-candidate.outputs.candidate_version }}
+        run: |
+          set -euo pipefail
+          python -c "import json, os, pathlib; payload=json.loads(pathlib.Path('.local-release-channel/manifest.json').read_text()); assert payload['channel']=='stable', payload; assert payload['version']==os.environ['CANDIDATE_VERSION'], payload"
+          (cd .local-release-channel && sha256sum --check checksums.txt)
+
+      - name: Re-resolve semantic release version after qualification
+        if: github.ref_name == 'main'
+        id: final-release-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/resolve-next-release-version.mjs
+
+      - name: Require semantic release version stability
+        if: github.ref_name == 'main'
+        env:
+          CANDIDATE_VERSION: ${{ needs.stage-candidate.outputs.candidate_version }}
+          RESOLVED_VERSION: ${{ steps.final-release-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          test "$RESOLVED_VERSION" = "$CANDIDATE_VERSION"
+
+      - name: Configure authorized Stable release push
+        if: github.ref_name == 'main'
+        env:
+          STABLE_RELEASE_DEPLOY_KEY: ${{ secrets.STABLE_RELEASE_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$STABLE_RELEASE_DEPLOY_KEY"
+          key_path="$RUNNER_TEMP/stable-release-deploy-key"
+          printf '%s\n' "$STABLE_RELEASE_DEPLOY_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          git config --local core.sshCommand "ssh -i '$key_path' -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+
+      - name: Publish exact qualified Stable release with semantic release
+        if: github.ref_name == 'main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL: git@github.com:${{ github.repository }}.git
+        run: |
+          set -euo pipefail
+          npx semantic-release
+
+      - name: Verify Stable release publication and exact asset inventory
         if: github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CANDIDATE_TAG: ${{ needs.stage-candidate.outputs.candidate_tag }}
+          CANDIDATE_VERSION: ${{ needs.stage-candidate.outputs.candidate_version }}
         run: |
-          gh release edit "$CANDIDATE_TAG" --repo "${{ github.repository }}" --prerelease=false --latest
-          gh release view "$CANDIDATE_TAG" --repo "${{ github.repository }}" --json isDraft,isPrerelease --jq 'select(.isDraft == false and .isPrerelease == false)' > /dev/null
+          set -euo pipefail
+          tag="v$CANDIDATE_VERSION"
+          test "$(gh release view "$tag" --repo "${{ github.repository }}" --json isDraft,isPrerelease --jq '[.isDraft, .isPrerelease] | join(":")')" = "false:false"
+          test "$(gh release view --repo "${{ github.repository }}" --json tagName --jq '.tagName')" = "$tag"
+          expected="$(find .local-release-channel -maxdepth 1 -type f ! -name '.release-notes.md' -printf '%f\n' | sort)"
+          actual="$(gh release view "$tag" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' | sort)"
+          test "$actual" = "$expected"
 
       - name: Download qualified Canary candidate
         if: needs.stage-candidate.outputs.candidate_channel == 'canary'
@@ -639,4 +617,4 @@ jobs:
           gh release edit canary-latest --repo "${{ github.repository }}" --title "$canary_release_title" --notes-file "$channel_dir/.release-notes.md" --prerelease --latest=false
           gh release download canary-latest --repo "${{ github.repository }}" --pattern manifest.json --dir "$readback_dir"
           cmp "$channel_dir/manifest.json" "$readback_dir/manifest.json"
-          gh release view canary-latest --repo "${{ github.repository }}" --json isDraft,isPrerelease --jq 'select(.isDraft == false and .isPrerelease == true)' > /dev/null
+          test "$(gh release view canary-latest --repo "${{ github.repository }}" --json isDraft,isPrerelease --jq '[.isDraft, .isPrerelease] | join(":")')" = "false:true"

--- a/.github/workflows/validation-release-cleanup.yml
+++ b/.github/workflows/validation-release-cleanup.yml
@@ -1,0 +1,43 @@
+name: validation release cleanup
+
+on:
+  workflow_run:
+    workflows:
+      - cross-platform validation
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+env:
+  PYTHON_VERSION: "3.12.10"
+  LINUX_PYTHON_VERSION: "3.12.13"
+
+concurrency:
+  group: validation-release-cleanup-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Reconcile temporary validation release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Delete a release or orphan tag owned by the completed run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          TEST_TAG: ci-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TEST_TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            test "$(gh release view "$TEST_TAG" --repo "${{ github.repository }}" --json isPrerelease --jq '.isPrerelease')" = "true"
+            gh release delete "$TEST_TAG" --repo "${{ github.repository }}" --cleanup-tag --yes
+            exit 0
+          fi
+
+          tag_sha="$(gh api "repos/${{ github.repository }}/git/ref/tags/$TEST_TAG" --jq '.object.sha' 2>/dev/null || true)"
+          if [ -n "$tag_sha" ]; then
+            test "$tag_sha" = "$RUN_HEAD_SHA"
+            gh api --method DELETE "repos/${{ github.repository }}/git/refs/tags/$TEST_TAG"
+          fi

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -49,7 +49,7 @@ module.exports = {
         verifyReleaseCmd:
           "node scripts/verify-beta-release-version.mjs ${nextRelease.version}",
         prepareCmd:
-          "node scripts/prepare-release-assets.mjs ${nextRelease.version}",
+          "node scripts/update-release-versions.mjs ${nextRelease.version} stable",
       },
     ],
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,3 @@
-## [0.21.4](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.3...v0.21.4) (2026-08-21)
-
-
-### Bug Fixes
-
-* **releases:** qualify historical installers on every platform ([39c7a4a](https://github.com/Artificial-Sweetener/SugarSubstitute/commit/39c7a4affcc49fea862988e8a11f6c6a431c9e19))
-
-## [0.21.3](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.2...v0.21.3) (2026-08-21)
-
-
-### Bug Fixes
-
-* **releases:** qualify versioned historical installers ([2211e40](https://github.com/Artificial-Sweetener/SugarSubstitute/commit/2211e4092282a2c6aeffb610a3e6abf0088be4e9))
-
-## [0.21.2](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.1...v0.21.2) (2026-08-21)
-
-
-### Bug Fixes
-
-* **installer:** install managed nodepacks without system Git ([029de3d](https://github.com/Artificial-Sweetener/SugarSubstitute/commit/029de3d421aba9f3fac36f9e9aef27c3cad1e01d))
-* **releases:** restore reliable release links and titles ([da8df40](https://github.com/Artificial-Sweetener/SugarSubstitute/commit/da8df403d506fe9100bf7f9b92fcdb4add3ce1c4))
-
 ## [0.21.1](https://github.com/Artificial-Sweetener/SugarSubstitute/compare/v0.21.0...v0.21.1) (2026-08-16)
 
 

--- a/launcher/sugarsubstitute_launcher/__init__.py
+++ b/launcher/sugarsubstitute_launcher/__init__.py
@@ -18,4 +18,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.4"
+__version__ = "0.21.1"

--- a/launcher/sugarsubstitute_launcher/update_orchestrator.py
+++ b/launcher/sugarsubstitute_launcher/update_orchestrator.py
@@ -28,7 +28,10 @@ from urllib.error import URLError
 
 from launcher.sugarsubstitute_launcher import __version__ as LAUNCHER_VERSION
 
-from launcher.sugarsubstitute_launcher.config import LauncherConfig
+from launcher.sugarsubstitute_launcher.config import (
+    STABLE_RELEASE_CHANNEL,
+    LauncherConfig,
+)
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from launcher.sugarsubstitute_launcher.localized_text import launcher_text
 from launcher.sugarsubstitute_launcher.manifest import ReleaseManifest
@@ -63,7 +66,10 @@ from sugarsubstitute_shared.launcher_update.targets import (
     LauncherBundleTarget,
     launcher_bundle_target_for_key,
 )
-from sugarsubstitute_shared.launcher_update.versions import compare_release_versions
+from sugarsubstitute_shared.launcher_update.versions import (
+    compare_release_versions,
+    is_prerelease_version,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -227,6 +233,18 @@ class LauncherUpdateOrchestrator:
                 checked_manifest=True,
                 installed_update=False,
                 skipped_reason="channel_mismatch",
+            )
+        if config.channel == STABLE_RELEASE_CHANNEL and is_prerelease_version(
+            manifest.version
+        ):
+            state.with_update_check(
+                channel=manifest.channel,
+                checked_at=self._now(),
+            ).save(layout.state_path)
+            return PreLaunchUpdateResult(
+                checked_manifest=True,
+                installed_update=False,
+                skipped_reason="stable_prerelease_rejected",
             )
 
         launcher_request = self._stage_launcher_update(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sugarsubstitute-release",
-  "version": "0.21.4",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sugarsubstitute-release",
-      "version": "0.21.4",
+      "version": "0.21.1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sugarsubstitute-release",
   "private": true,
-  "version": "0.21.4",
+  "version": "0.21.1",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "packageManager": "npm@10.9.2",

--- a/scripts/github-release-publisher.cjs
+++ b/scripts/github-release-publisher.cjs
@@ -39,16 +39,6 @@ async function verifyConditions(pluginConfig, context) {
  * @returns {Promise<Record<string, unknown>>} Published release metadata.
  */
 async function publish(pluginConfig, context) {
-  if (process.env.SUGAR_SUBSTITUTE_STAGE_ONLY === "true") {
-    const version = context.nextRelease?.version;
-    if (typeof version !== "string" || !version) {
-      throw new Error("Semantic-release context is missing nextRelease.version.");
-    }
-    return {
-      name: `Staged SugarSubstitute ${version}`,
-      url: `https://github.com/${pluginConfig.repository}/releases/tag/v${version}`,
-    };
-  }
   const github = await loadGitHubPlugin();
   return github.publish(
     githubConfig(pluginConfig),

--- a/substitute/_version.py
+++ b/substitute/_version.py
@@ -18,6 +18,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.21.4"
+__version__ = "0.21.1"
 
 __all__ = ["__version__"]

--- a/substitute/infrastructure/launcher_update/legacy_bridge.py
+++ b/substitute/infrastructure/launcher_update/legacy_bridge.py
@@ -36,7 +36,10 @@ from sugarsubstitute_shared.launcher_update.targets import (
     LauncherBundleTarget,
     detect_launcher_bundle_target,
 )
-from sugarsubstitute_shared.launcher_update.versions import compare_release_versions
+from sugarsubstitute_shared.launcher_update.versions import (
+    compare_release_versions,
+    is_prerelease_version,
+)
 from sugarsubstitute_shared.tls import SystemTrustTlsContext
 
 
@@ -90,6 +93,8 @@ class LegacyLauncherUpdateBridge:
             target_key=target.key,
         )
         if release.channel != _string(config, "channel", default="stable"):
+            return False
+        if release.channel == "stable" and is_prerelease_version(release.version):
             return False
         installation_path = root / "launcher" / "installation.json"
         installed = LauncherInstallationRecord.load(installation_path)

--- a/sugarsubstitute_shared/launcher_update/versions.py
+++ b/sugarsubstitute_shared/launcher_update/versions.py
@@ -57,6 +57,12 @@ def validate_release_version(version: str) -> None:
     _parse_release_version(version)
 
 
+def is_prerelease_version(version: str) -> bool:
+    """Return whether a validated release version has a prerelease suffix."""
+
+    return _parse_release_version(version).prerelease is not None
+
+
 def _parse_release_version(version: str) -> _ReleaseVersion:
     """Parse one release version without accepting path-like values."""
 
@@ -115,4 +121,8 @@ def _compare_prerelease_parts(
     return (len(left) > len(right)) - (len(left) < len(right))
 
 
-__all__ = ["compare_release_versions", "validate_release_version"]
+__all__ = [
+    "compare_release_versions",
+    "is_prerelease_version",
+    "validate_release_version",
+]

--- a/tests/test_launcher_self_update.py
+++ b/tests/test_launcher_self_update.py
@@ -584,6 +584,37 @@ def test_legacy_bridge_does_not_reschedule_current_launcher(tmp_path: Path) -> N
     assert scheduled == []
 
 
+def test_legacy_bridge_rejects_stable_prerelease(tmp_path: Path) -> None:
+    """Legacy Stable installations must not migrate to prerelease launchers."""
+
+    install_root = _write_installed_layout(tmp_path / "SugarSubstitute")
+    runtime_python = install_root / "runtime" / ".venv" / "Scripts" / "python.exe"
+    runtime_python.parent.mkdir(parents=True, exist_ok=True)
+    runtime_python.write_text("python", encoding="utf-8")
+    (install_root / "app" / "main.py").write_text("", encoding="utf-8")
+    _write_launcher_config(install_root, runtime_python=runtime_python)
+    archive = _write_bundle(tmp_path / "launcher.zip", marker="new")
+    scheduled: list[dict[str, object]] = []
+
+    def schedule(**kwargs: object) -> int:
+        """Record any unexpected helper scheduling request."""
+
+        scheduled.append(kwargs)
+        return 1234
+
+    bridge = LegacyLauncherUpdateBridge(
+        target_detector=lambda: WINDOWS_X64_BUNDLE,
+        manifest_loader=lambda _url: _manifest_payload(
+            archive,
+            version="0.21.2-canary.149",
+        ),
+        scheduler=schedule,
+    )
+
+    assert bridge.run(install_root=install_root) is False
+    assert scheduled == []
+
+
 def _write_installed_layout(root: Path) -> Path:
     """Create an old Windows launcher plus unrelated preserved install content."""
 
@@ -655,14 +686,18 @@ def _asset(path: Path) -> LauncherBundleAsset:
     )
 
 
-def _manifest_payload(archive: Path) -> dict[str, object]:
+def _manifest_payload(
+    archive: Path,
+    *,
+    version: str = "0.11.0",
+) -> dict[str, object]:
     """Create the launcher portion of a production manifest."""
 
     asset = _asset(archive)
     return {
         "schema_version": 2,
         "channel": "stable",
-        "version": "0.11.0",
+        "version": version,
         "minimum_launcher_version": "0.10.0",
         "launchers": {
             "windows_x64": {

--- a/tests/test_launcher_update_orchestrator.py
+++ b/tests/test_launcher_update_orchestrator.py
@@ -163,6 +163,29 @@ def test_pre_launch_update_never_crosses_release_channels(
     assert installer.installed_layouts == []
 
 
+def test_stable_update_rejects_prerelease_manifest(tmp_path: Path) -> None:
+    """Stable installations must never install a semantic prerelease."""
+
+    layout = InstallLayout.from_root(tmp_path / "SugarSubstitute")
+    config = LauncherConfig.from_layout(layout=layout, channel="stable")
+    installer = _PayloadInstaller(version="0.21.2-canary.149")
+
+    result = LauncherUpdateOrchestrator(
+        payload_installer=installer,
+        runtime_reconciler=_RuntimeReconciler(),
+        now=_fixed_now,
+    ).run(
+        layout=layout,
+        config=config,
+        release_source=_ReleaseSource(_manifest(version="0.21.2-canary.149")),
+        no_update_check=False,
+    )
+
+    assert result.skipped_reason == "stable_prerelease_rejected"
+    assert result.installed_update is False
+    assert installer.installed_layouts == []
+
+
 def test_pre_launch_update_respects_disabled_policy(tmp_path: Path) -> None:
     """Disabled update checks should not load the manifest."""
 

--- a/tests/test_launcher_update_policy.py
+++ b/tests/test_launcher_update_policy.py
@@ -32,7 +32,10 @@ from launcher.sugarsubstitute_launcher.update_policy import (
     decide_update_check,
 )
 from launcher.sugarsubstitute_launcher.update_state import LauncherUpdateState
-from sugarsubstitute_shared.launcher_update.versions import compare_release_versions
+from sugarsubstitute_shared.launcher_update.versions import (
+    compare_release_versions,
+    is_prerelease_version,
+)
 
 
 def test_launcher_update_state_defaults_when_missing(tmp_path: Path) -> None:
@@ -165,3 +168,10 @@ def test_compare_release_versions_supports_semantic_prereleases() -> None:
         compare_release_versions("0.4/evil", "0.4.0")
     with pytest.raises(ValueError, match="semantic"):
         compare_release_versions("latest", "0.4.0")
+
+
+def test_release_version_identifies_prerelease_suffixes() -> None:
+    """Stable update policy must distinguish full and prerelease versions."""
+
+    assert is_prerelease_version("0.21.2-canary.149") is True
+    assert is_prerelease_version("v0.21.2") is False

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -255,10 +255,21 @@ def test_canary_isolated_release_train_contract() -> None:
     )
 
     assert "      - main\n      - canary" in release_text
-    assert "SUGAR_SUBSTITUTE_CANARY_RUN_NUMBER:" in release_text
+    assert (
+        "SUGAR_SUBSTITUTE_CANARY_RUN_NUMBER: "
+        "${{ github.ref_name == 'canary' && github.run_number || '' }}"
+    ) in release_text
+    assert (
+        "channel: ${{ (github.ref_name == 'canary' && 'canary') || 'stable' }}"
+    ) in release_text
+    assert "github.event_name == 'push' && github.ref_name == 'canary'" not in (
+        release_text
+    )
     assert "format('9999.1.{0}', github.run_number)" not in release_text
-    assert "SUGAR_SUBSTITUTE_RELEASE_CHANNEL: canary" in release_text
-    assert "releases/download/canary-latest" in release_text
+    assert (
+        "SUGAR_SUBSTITUTE_RELEASE_CHANNEL: "
+        "${{ needs.determine-version.outputs.channel }}"
+    ) in release_text
     assert "releases/download/canary/" not in release_text
     prepare_assets_text = (
         PROJECT_ROOT / "scripts" / "prepare-release-assets.mjs"
@@ -267,20 +278,19 @@ def test_canary_isolated_release_train_contract() -> None:
     assert '"canary-v$version"' not in release_text
     assert "release-qualification.yml" in release_text
     assert "'canary-fast'" in release_text
-    assert "Upload temporary non-release candidate channel" in release_text
+    assert "Upload private non-release candidate channel" in release_text
     assert "validate-candidate-artifact:" in (
         PROJECT_ROOT / ".github" / "workflows" / "release-qualification.yml"
     ).read_text(encoding="utf-8")
-    promotion = release_text.split("  promote-release:", maxsplit=1)[1]
-    assert "Download qualified Canary candidate" in promotion
-    assert "gh release upload canary-latest" in promotion
-    assert 'gh release upload canary-latest "$channel_dir/manifest.json"' in promotion
-    assert "git/refs/tags/canary-latest" in promotion
-    assert 'git/refs/tags/canary"' not in promotion
-    assert promotion.count('gh release edit "$CANDIDATE_TAG"') == 1
-    assert "--clobber" in promotion
-    assert "--prerelease=false --latest" in promotion
-    assert "github.ref_name == 'main'" in promotion
+    publication = release_text.split("  publish-release:", maxsplit=1)[1]
+    assert "Download qualified Canary candidate" in publication
+    assert "gh release upload canary-latest" in publication
+    assert 'gh release upload canary-latest "$channel_dir/manifest.json"' in publication
+    assert "git/refs/tags/canary-latest" in publication
+    assert 'git/refs/tags/canary"' not in publication
+    assert "--clobber" in publication
+    assert "--prerelease --latest=false" in publication
+    assert "github.ref_name == 'main'" in publication
     assert "HEAD_BRANCH: ${{ github.head_ref }}" in policy_text
     assert '[ "$HEAD_BRANCH" != "canary" ]' in policy_text
     assert policy_text.count("branches:\n      - main") == 1
@@ -304,7 +314,6 @@ def test_published_release_titles_use_channel_specific_version_labels() -> None:
     )
     assert release_workflow.count('title "$canary_release_title"') == 2
     assert "SugarSubstitute Canary $CANDIDATE_VERSION" not in release_workflow
-    assert '"--title", "v$version"' in release_workflow
     assert "SugarSubstitute $version release candidate" not in release_workflow
 
 
@@ -575,7 +584,8 @@ def test_release_dry_run_qualifies_temporary_bytes_without_publishing() -> None:
         PROJECT_ROOT / "scripts" / "prepare-release-assets.mjs"
     ).read_text(encoding="utf-8")
 
-    assert "SUGAR_SUBSTITUTE_ASSET_BASE_URL: https://localhost:44443" in release_text
+    assert "SUGAR_SUBSTITUTE_ASSET_BASE_URL:" in release_text
+    assert "'https://localhost:44443'" in release_text
     assert "include-hidden-files: true" in release_text
     assert "SUGAR_SUBSTITUTE_QUALIFICATION_VERSION:" in release_text
     assert "format('9999.0.{0}', github.run_number)" in release_text
@@ -643,7 +653,10 @@ def test_focused_release_qualification_cannot_skip_publishing_gates() -> None:
         "candidate_run_id: ${{ needs.stage-candidate.outputs.candidate_run_id }}"
         in (release_text)
     )
-    assert "  actions: read\n  contents: write" in release_text
+    assert "  actions: read\n  contents: read" in release_text
+    assert (
+        "    permissions:\n      actions: read\n      contents: write" in release_text
+    )
     assert "steps.release-version.outputs.should_release ||" in release_text
     assert "format('9999.0.{0}', github.run_number) || ''" in release_text
     assert release_text.count("github.event.inputs.qualification_scope != 'full'") == 6
@@ -712,6 +725,44 @@ def test_cross_platform_validation_proves_packaged_linux_system_trust() -> None:
     assert "APPIMAGE_EXTRACT_AND_RUN=1" in job_script
 
 
+def test_cross_platform_validation_always_cleans_its_temporary_release() -> None:
+    """Synthetic validation releases must be removed after failure or cancellation."""
+
+    workflow_path = (
+        PROJECT_ROOT / ".github" / "workflows" / "cross-platform-validation.yml"
+    )
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    cleanup = workflow["jobs"]["cleanup-test-release"]
+    reconciler = (
+        PROJECT_ROOT / ".github" / "workflows" / "validation-release-cleanup.yml"
+    ).read_text(encoding="utf-8")
+
+    assert workflow["permissions"]["contents"] == "read"
+    assert workflow["jobs"]["assemble-release"]["permissions"]["contents"] == "write"
+    assert set(cleanup["needs"]) == {
+        "assemble-release",
+        "linux-distro-trust",
+        "installed-app-smoke",
+    }
+    assert "always()" in cleanup["if"]
+    assert cleanup["permissions"]["contents"] == "write"
+    cleanup_script = _job_script(cleanup)
+    assert "--jq '.isPrerelease'" in cleanup_script
+    assert '= "true"' in cleanup_script
+    assert "select(" not in cleanup_script
+    assert "gh release delete" in cleanup_script
+    assert "--cleanup-tag --yes" in cleanup_script
+    assert "workflow_run:" in reconciler
+    assert "cross-platform validation" in reconciler
+    assert "ci-${{ github.event.workflow_run.id }}-" in reconciler
+    assert "--jq '.isPrerelease'" in reconciler
+    assert '= "true"' in reconciler
+    assert "select(" not in reconciler
+    assert "gh release delete" in reconciler
+    assert "git/refs/tags/$TEST_TAG" in reconciler
+
+
 def test_release_workflow_builds_every_published_platform_after_version_resolution() -> (
     None
 ):
@@ -731,7 +782,7 @@ def test_release_workflow_builds_every_published_platform_after_version_resoluti
         "build-linux",
         "stage-candidate",
         "qualify-candidate",
-        "promote-release",
+        "publish-release",
     }
     for job_name in ("build-windows", "build-macos", "build-linux"):
         job = jobs[job_name]
@@ -748,26 +799,37 @@ def test_release_workflow_builds_every_published_platform_after_version_resoluti
     assert jobs["qualify-candidate"]["uses"] == (
         "./.github/workflows/release-qualification.yml"
     )
-    assert set(jobs["promote-release"]["needs"]) == {
+    assert set(jobs["publish-release"]["needs"]) == {
         "stage-candidate",
         "qualify-candidate",
     }
 
 
-def test_release_stages_then_promotes_the_same_candidate_bytes() -> None:
-    """Stable publication must be promotion after qualification, never a rebuild."""
+def test_release_qualifies_private_bytes_before_any_stable_publication() -> None:
+    """Stable qualification must precede every tag, commit, and release mutation."""
 
     workflow_text = (PROJECT_ROOT / ".github" / "workflows" / "release.yml").read_text(
         encoding="utf-8"
     )
 
-    assert "--prerelease" in workflow_text
     assert "release-qualification.yml" in workflow_text
-    assert "--prerelease=false --latest" in workflow_text
-    assert "SUGAR_SUBSTITUTE_STAGE_ONLY" in workflow_text
-    promotion = workflow_text.split("  promote-release:", maxsplit=1)[1]
-    assert "prepare-release-assets" not in promotion
-    assert "PyInstaller" not in promotion
+    stage = workflow_text.split("  stage-candidate:", maxsplit=1)[1].split(
+        "  qualify-candidate:", maxsplit=1
+    )[0]
+    publication = workflow_text.split("  publish-release:", maxsplit=1)[1]
+    assert "Upload private non-release candidate channel" in stage
+    assert "npx semantic-release" not in stage
+    assert "gh release" not in stage
+    assert "contents: write" not in stage
+    assert "needs.qualify-candidate.result == 'success'" in publication
+    assert "Download exact qualified Stable channel" in publication
+    assert "Re-resolve semantic release version after qualification" in publication
+    assert "npx semantic-release" in publication
+    assert "select(" not in publication
+    assert '= "false:false"' in publication
+    assert '= "false:true"' in publication
+    assert "prepare-release-assets" not in publication
+    assert "PyInstaller" not in publication
 
 
 def test_first_release_publishes_version_090_without_adding_a_commit() -> None:
@@ -783,7 +845,6 @@ def test_first_release_publishes_version_090_without_adding_a_commit() -> None:
     assert 'const FIRST_RELEASE_VERSION = "0.9.0"' in resolver_text
     assert "result?.nextRelease?.version" in resolver_text
     assert "first_release=${firstRelease}" in resolver_text
-    assert "gh release create" in workflow_text
     assert "prepare-release-assets.mjs" in workflow_text
     assert "prime-first-release-tag" not in workflow_text
 
@@ -1026,30 +1087,14 @@ process.stdout.write(JSON.stringify({
     assert notes["original"] == "## Features\n\n* Added Cubes."
 
 
-def test_semantic_release_stage_mode_does_not_publish_stable() -> None:
-    """Semantic release should prepare its commit and tag while GitHub stays staged."""
+def test_semantic_release_publisher_has_no_prequalification_bypass() -> None:
+    """The GitHub publisher must not retain an early staging publication mode."""
 
-    script = """
-process.env.SUGAR_SUBSTITUTE_STAGE_ONLY = 'true';
-const publisher = require('./scripts/github-release-publisher.cjs');
-publisher.publish(
-  {repository: 'Artificial-Sweetener/Substitute-Test'},
-  {nextRelease: {version: '1.2.3'}},
-).then((result) => process.stdout.write(JSON.stringify(result)));
-"""
-    result = subprocess.run(
-        ["node", "-e", script],
-        cwd=PROJECT_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
+    publisher = (PROJECT_ROOT / "scripts" / "github-release-publisher.cjs").read_text(
+        encoding="utf-8"
     )
 
-    assert result.returncode == 0, result.stderr
-    staged = json.loads(result.stdout)
-    assert staged["name"] == "Staged SugarSubstitute 1.2.3"
-    assert staged["url"].endswith("/releases/tag/v1.2.3")
+    assert "SUGAR_SUBSTITUTE_STAGE_ONLY" not in publisher
 
 
 def test_release_notes_generator_rejects_unsafe_versions(tmp_path: Path) -> None:
@@ -1094,8 +1139,11 @@ def test_release_pipeline_uses_one_notes_owner_and_updates_the_changelog() -> No
     assert config.index(changelog_plugin) < config.index(github_publisher)
     assert 'changelogFile: "CHANGELOG.md"' in config
     assert "release-notes-preamble.cjs" in workflow
-    assert "--generate-notes" in workflow
-    assert '"--notes", $releaseNotes' in workflow
+    publisher = (PROJECT_ROOT / "scripts" / "github-release-publisher.cjs").read_text(
+        encoding="utf-8"
+    )
+    assert "createInstallerReleaseNotes" in publisher
+    assert "withInstallerReleaseNotes" in publisher
     assert (PROJECT_ROOT / "CHANGELOG.md").is_file()
 
 
@@ -1213,21 +1261,20 @@ def test_stable_release_push_uses_the_authorized_deploy_key() -> None:
     assert "process.env.SUGAR_SUBSTITUTE_RELEASE_REPOSITORY_URL" in release_config
 
 
-def test_existing_stable_tag_is_published_without_an_invalid_target() -> None:
-    """Publish Semantic Release tags without reusing the tag as a commitish."""
+def test_stable_release_is_created_only_by_postqualification_semantic_release() -> None:
+    """Keep Stable publication under semantic-release after qualification."""
 
     release_workflow = (
         PROJECT_ROOT / ".github" / "workflows" / "release.yml"
     ).read_text(encoding="utf-8")
-    publish_step = release_workflow.split(
-        "      - name: Publish exact bytes as a visible prerelease candidate",
-        maxsplit=1,
-    )[1].split("      - name:", maxsplit=1)[0]
+    stage = release_workflow.split("  stage-candidate:", maxsplit=1)[1].split(
+        "  qualify-candidate:", maxsplit=1
+    )[0]
+    publication = release_workflow.split("  publish-release:", maxsplit=1)[1]
 
-    assert "gh @releaseArguments" in publish_step
-    assert '$releaseArguments += @("--target", "${{ github.sha }}")' in publish_step
-    assert "$target =" not in publish_step
-    assert "--target $target" not in publish_step
+    assert "gh release create" not in stage
+    assert "npx semantic-release" not in stage
+    assert publication.count("npx semantic-release") == 1
 
 
 def test_windows_quality_workflows_fail_fast_on_native_command_errors() -> None:


### PR DESCRIPTION
Qualifies private release artifacts before any Stable tag, commit, or GitHub Release mutation; publishes the exact verified bytes through semantic-release; cleans temporary validation prereleases after failure or cancellation; rejects prerelease manifests on Stable update channels; and restores release metadata to the authorized v0.21.1 baseline. Local validation: full Ruff format and lint, strict mypy, architecture governance, full parallel tests, and all 129 serial modules passed.