### PR TITLE
fix(releases): show concise Canary version labels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -585,7 +585,7 @@ jobs:
           set -euo pipefail
           channel_dir="build/canary-channel"
           readback_dir="build/canary-readback"
-          canary_release_title="Canary ${CANDIDATE_VERSION/-canary-/.}"
+          canary_release_title="Canary ${CANDIDATE_VERSION/-canary./.}"
           mkdir -p "$readback_dir"
           python -c "import json, os, pathlib; payload=json.loads(pathlib.Path('$channel_dir/manifest.json').read_text()); assert payload['channel']=='canary', payload; assert payload['version']==os.environ['CANDIDATE_VERSION'], payload"
           (cd "$channel_dir" && sha256sum --check checksums.txt)

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -309,9 +309,10 @@ def test_published_release_titles_use_channel_specific_version_labels() -> None:
 
     assert 'name: "v${nextRelease.version}"' in release_configuration
     assert (
-        'canary_release_title="Canary ${CANDIDATE_VERSION/-canary-/.}"'
+        'canary_release_title="Canary ${CANDIDATE_VERSION/-canary./.}"'
         in release_workflow
     )
+    assert "${CANDIDATE_VERSION/-canary-/.}" not in release_workflow
     assert release_workflow.count('title "$canary_release_title"') == 2
     assert "SugarSubstitute Canary $CANDIDATE_VERSION" not in release_workflow
     assert "SugarSubstitute $version release candidate" not in release_workflow


### PR DESCRIPTION
## Summary
- render Canary release titles as Canary 0.21.2.161 while preserving semantic prerelease versions in assets and manifests
- statically forbid the incorrect -canary- separator expression

## Verification
- full format, lint, strict typing, and architecture gates
- focused release workflow contract suite
- full parallel test suite
- all 129 serial test modules