### PR TITLE
fix(canvas): preserve Input focus through transient projections

### DIFF
--- a/substitute/presentation/canvas/host/canvas_host_activation_controller.py
+++ b/substitute/presentation/canvas/host/canvas_host_activation_controller.py
@@ -145,6 +145,10 @@ class _CanvasFocusHandoff(QObject):
         if event_type == QEvent.Type.ApplicationDeactivate:
             self.stop()
             return False
+        if event_type == QEvent.Type.FocusOut and isinstance(watched, QWidget):
+            if self._belongs_to_target(watched):
+                self._queue_focus_restore()
+            return False
         if event_type != QEvent.Type.FocusIn or not isinstance(watched, QWidget):
             return False
         if self._belongs_to_target(watched):
@@ -171,6 +175,9 @@ class _CanvasFocusHandoff(QObject):
             return
         if self._state.active_route_key != self._route_key:
             self.stop()
+            return
+        focus_widget = QApplication.focusWidget()
+        if focus_widget is not None and self._belongs_to_target(focus_widget):
             return
         self._widget.setFocus(Qt.FocusReason.OtherFocusReason)
 

--- a/tests/test_canvas_host_contract.py
+++ b/tests/test_canvas_host_contract.py
@@ -237,6 +237,28 @@ def test_activation_focus_settles_after_nested_same_event_projections() -> None:
         host.close()
 
 
+def test_activation_focus_recovers_after_projection_temporarily_clears_focus() -> None:
+    """A focusless projection frame must preserve picker-requested canvas focus."""
+
+    host, input_canvas, output_canvas = _host()
+    try:
+        input_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocus()
+        _app().processEvents()
+
+        assert host.activate_canvas("Input", keyboard_focus=True)
+        _app().processEvents()
+        assert input_canvas.hasFocus()
+
+        input_canvas.clearFocus()
+        _app().processEvents()
+
+        assert input_canvas.hasFocus()
+    finally:
+        host.close()
+
+
 def test_activation_focus_handoff_yields_to_later_user_intent() -> None:
     """A later keyboard event must release picker-requested focus ownership."""
 


### PR DESCRIPTION
## Summary

- restore picker-requested canvas focus after a transient focusless Qt projection frame
- preserve focus already held by a child of the active canvas
- add deterministic host-level regression coverage for the Linux CI failure

## Verification

- focused canvas host and real-shell Input editor tests
- full parallel test suite
- all 129 serial test modules
- Ruff format and lint
- mypy strict
- architecture governance
- git diff --check