### PR TITLE
fix(releases): prepare the qualified 0.21.2 stable release

### DIFF
--- a/.github/workflows/comfy-compatibility.yml
+++ b/.github/workflows/comfy-compatibility.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: comfy-compatibility-${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  group: comfy-compatibility-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -30,6 +30,7 @@ env:
 jobs:
   real-tag-probe:
     name: ${{ matrix.comfyui }} / ${{ matrix.manager }} (${{ matrix.name }})
+    if: github.event_name != 'pull_request' || github.head_ref != 'canary' || github.base_ref != 'main'
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +91,7 @@ jobs:
 
   real-update-probe:
     name: ${{ matrix.source }} -> ${{ matrix.target }} (${{ matrix.name }})
+    if: github.event_name != 'pull_request' || github.head_ref != 'canary' || github.base_ref != 'main'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -585,7 +585,7 @@ jobs:
           set -euo pipefail
           channel_dir="build/canary-channel"
           readback_dir="build/canary-readback"
-          canary_release_title="Canary ${CANDIDATE_VERSION/-canary-/.}"
+          canary_release_title="Canary ${CANDIDATE_VERSION/-canary./.}"
           mkdir -p "$readback_dir"
           python -c "import json, os, pathlib; payload=json.loads(pathlib.Path('$channel_dir/manifest.json').read_text()); assert payload['channel']=='canary', payload; assert payload['version']==os.environ['CANDIDATE_VERSION'], payload"
           (cd "$channel_dir" && sha256sum --check checksums.txt)

--- a/substitute/presentation/canvas/host/canvas_host_activation_controller.py
+++ b/substitute/presentation/canvas/host/canvas_host_activation_controller.py
@@ -122,6 +122,7 @@ class _CanvasFocusHandoff(QObject):
         if application is not None:
             application.installEventFilter(self)
         self._restore_focus()
+        self._queue_focus_restore()
 
     def stop(self) -> None:
         """Release this handoff after superseding user or lifecycle intent."""

--- a/substitute/presentation/canvas/host/canvas_host_activation_controller.py
+++ b/substitute/presentation/canvas/host/canvas_host_activation_controller.py
@@ -145,6 +145,10 @@ class _CanvasFocusHandoff(QObject):
         if event_type == QEvent.Type.ApplicationDeactivate:
             self.stop()
             return False
+        if event_type == QEvent.Type.FocusOut and isinstance(watched, QWidget):
+            if self._belongs_to_target(watched):
+                self._queue_focus_restore()
+            return False
         if event_type != QEvent.Type.FocusIn or not isinstance(watched, QWidget):
             return False
         if self._belongs_to_target(watched):
@@ -171,6 +175,9 @@ class _CanvasFocusHandoff(QObject):
             return
         if self._state.active_route_key != self._route_key:
             self.stop()
+            return
+        focus_widget = QApplication.focusWidget()
+        if focus_widget is not None and self._belongs_to_target(focus_widget):
             return
         self._widget.setFocus(Qt.FocusReason.OtherFocusReason)
 

--- a/substitute/presentation/canvas/host/canvas_host_activation_controller.py
+++ b/substitute/presentation/canvas/host/canvas_host_activation_controller.py
@@ -102,8 +102,10 @@ class _CanvasFocusHandoff(QObject):
         """Store the authoritative route and target for one focus intent."""
 
         application = QApplication.instance()
+        if not isinstance(application, QApplication):
+            application = None
         super().__init__(application)
-        self._application = application
+        self._application: QApplication | None = application
         self._state = state
         self._route_key = route_key
         self._widget = widget
@@ -121,6 +123,7 @@ class _CanvasFocusHandoff(QObject):
         application = self._application
         if application is not None:
             application.installEventFilter(self)
+            application.focusChanged.connect(self._focus_changed)
         self._restore_focus()
         self._queue_focus_restore()
 
@@ -132,6 +135,7 @@ class _CanvasFocusHandoff(QObject):
         self._active = False
         application = self._application
         if application is not None:
+            application.focusChanged.disconnect(self._focus_changed)
             application.removeEventFilter(self)
         self._finished(self)
         self.deleteLater()
@@ -146,19 +150,24 @@ class _CanvasFocusHandoff(QObject):
         if event_type == QEvent.Type.ApplicationDeactivate:
             self.stop()
             return False
-        if event_type == QEvent.Type.FocusOut and isinstance(watched, QWidget):
-            if self._belongs_to_target(watched):
-                self._queue_focus_restore()
-            return False
-        if event_type != QEvent.Type.FocusIn or not isinstance(watched, QWidget):
-            return False
-        if self._belongs_to_target(watched):
-            return False
-        if watched.window() is not self._widget.window():
-            self.stop()
-            return False
-        self._queue_focus_restore()
         return False
+
+    def _focus_changed(
+        self,
+        _previous: QWidget | None,
+        current: QWidget | None,
+    ) -> None:
+        """Restore same-window projection focus before its transfer returns."""
+
+        if not self._active:
+            return
+        if current is not None and self._belongs_to_target(current):
+            return
+        if current is not None and current.window() is not self._widget.window():
+            self.stop()
+            return
+        self._restore_focus()
+        self._queue_focus_restore()
 
     def _queue_focus_restore(self) -> None:
         """Coalesce competing projections into one queued restoration."""

--- a/tests/test_canvas_host_contract.py
+++ b/tests/test_canvas_host_contract.py
@@ -309,6 +309,27 @@ def test_activation_focus_recovers_after_projection_temporarily_clears_focus() -
         host.close()
 
 
+def test_activation_focus_restores_before_projection_transfer_returns() -> None:
+    """A same-window projection must not expose a transient competing focus."""
+
+    host, input_canvas, _output_canvas = _host()
+    projection_focus = QWidget(host)
+    try:
+        input_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        projection_focus.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        projection_focus.show()
+
+        assert host.activate_canvas("Input", keyboard_focus=True)
+        _app().processEvents()
+        assert input_canvas.hasFocus()
+
+        projection_focus.setFocus()
+
+        assert input_canvas.hasFocus()
+    finally:
+        host.close()
+
+
 def test_activation_focus_handoff_yields_to_later_user_intent() -> None:
     """A later keyboard event must release picker-requested focus ownership."""
 

--- a/tests/test_canvas_host_contract.py
+++ b/tests/test_canvas_host_contract.py
@@ -237,6 +237,28 @@ def test_activation_focus_settles_after_nested_same_event_projections() -> None:
         host.close()
 
 
+def test_activation_focus_recovers_after_projection_temporarily_clears_focus() -> None:
+    """A focusless projection frame must preserve picker-requested canvas focus."""
+
+    host, input_canvas, output_canvas = _host()
+    try:
+        input_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocus()
+        _app().processEvents()
+
+        assert host.activate_canvas("Input", keyboard_focus=True)
+        _app().processEvents()
+        assert input_canvas.hasFocus()
+
+        input_canvas.clearFocus()
+        _app().processEvents()
+
+        assert input_canvas.hasFocus()
+    finally:
+        host.close()
+
+
 def test_activation_focus_handoff_yields_to_later_user_intent() -> None:
     """A later keyboard event must release picker-requested focus ownership."""
 

--- a/tests/test_canvas_host_contract.py
+++ b/tests/test_canvas_host_contract.py
@@ -67,6 +67,26 @@ class _Canvas(QWidget):
         self.availability.append((available, reason))
 
 
+class _DefersFirstFocusCanvas(_Canvas):
+    """Reject the synchronous focus request made inside an activation event."""
+
+    def __init__(self) -> None:
+        """Create a canvas that accepts focus after the current event dispatch."""
+
+        super().__init__()
+        self.focus_requests = 0
+
+    def setFocus(  # noqa: N802
+        self,
+        reason: Qt.FocusReason = Qt.FocusReason.OtherFocusReason,
+    ) -> None:
+        """Accept every focus request after the first synchronous attempt."""
+
+        self.focus_requests += 1
+        if self.focus_requests > 1:
+            super().setFocus(reason)
+
+
 class _FloatingWindow(QWidget):
     """Provide deterministic floating-window behavior for host docking tests."""
 
@@ -183,6 +203,36 @@ def test_host_activation_can_transfer_keyboard_focus_to_selected_canvas() -> Non
         _app().processEvents()
 
         assert host.is_canvas_visible("Input")
+        assert input_canvas.hasFocus()
+    finally:
+        host.close()
+
+
+def test_host_activation_verifies_focus_after_current_event_dispatch() -> None:
+    """Picker activation must recover when synchronous focus is not accepted."""
+
+    _app()
+    input_canvas = _DefersFirstFocusCanvas()
+    output_canvas = _Canvas()
+    host = CanvasHost(
+        pages=(
+            CanvasHostPage("Input", app_text("Input"), input_canvas),
+            CanvasHostPage("Output", app_text("Output"), output_canvas),
+        )
+    )
+    try:
+        input_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        host.show()
+        output_canvas.setFocus()
+        _app().processEvents()
+
+        assert host.activate_canvas("Input", keyboard_focus=True)
+        assert input_canvas.focus_requests == 1
+
+        _app().processEvents()
+
+        assert input_canvas.focus_requests >= 2
         assert input_canvas.hasFocus()
     finally:
         host.close()

--- a/tests/test_comfy_support_matrix.py
+++ b/tests/test_comfy_support_matrix.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from tools.ci.comfy_support_matrix import (
@@ -25,6 +27,9 @@ from tools.ci.comfy_support_matrix import (
     COMFY_UPDATE_MATRIX,
     matrix_entry,
 )
+
+
+_COMPATIBILITY_WORKFLOW = Path(".github/workflows/comfy-compatibility.yml")
 
 
 def test_comfy_support_matrix_starts_at_explicit_floor_and_ends_at_current() -> None:
@@ -69,3 +74,18 @@ def test_update_matrix_covers_incremental_and_direct_manager_transitions() -> No
     ]
     assert matrix_entry("v0.24.0").manager_version == "4.2.1"
     assert matrix_entry("v0.25.0").manager_version == "4.2.2"
+
+
+def test_canary_promotion_preserves_its_completed_compatibility_proof() -> None:
+    """A Main promotion must not cancel or duplicate its Canary push matrix."""
+
+    workflow_text = _COMPATIBILITY_WORKFLOW.read_text(encoding="utf-8")
+    assert (
+        "group: comfy-compatibility-${{ github.workflow }}-${{ github.event_name }}-"
+        "${{ github.event.pull_request.head.sha || github.sha }}" in workflow_text
+    )
+    promotion_guard = (
+        "    if: github.event_name != 'pull_request' || github.head_ref != 'canary' || "
+        "github.base_ref != 'main'"
+    )
+    assert workflow_text.count(promotion_guard) == 2

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -309,9 +309,10 @@ def test_published_release_titles_use_channel_specific_version_labels() -> None:
 
     assert 'name: "v${nextRelease.version}"' in release_configuration
     assert (
-        'canary_release_title="Canary ${CANDIDATE_VERSION/-canary-/.}"'
+        'canary_release_title="Canary ${CANDIDATE_VERSION/-canary./.}"'
         in release_workflow
     )
+    assert "${CANDIDATE_VERSION/-canary-/.}" not in release_workflow
     assert release_workflow.count('title "$canary_release_title"') == 2
     assert "SugarSubstitute Canary $CANDIDATE_VERSION" not in release_workflow
     assert "SugarSubstitute $version release candidate" not in release_workflow


### PR DESCRIPTION
## Summary

- publish concise rolling Canary labels while retaining semantic prerelease versions in assets and manifests
- preserve Input canvas focus through transient Qt projection frames
- promote the exact changes qualified and published as Canary 0.21.2.163

## Canary qualification

- release run 32553051662 passed quality and full Windows, Linux, and macOS suites
- exact staged candidate bytes passed installer and updater validation before publication
- rolling tag canary-latest points to fca7672bcdd43eecebf75daea9811725850d9746
- one prerelease exists: Canary 0.21.2.163
- v0.21.1 remains Latest Stable; no later stable tag exists