### PR TITLE
fix(canvas): verify picker focus after event dispatch

### DIFF
--- a/substitute/presentation/canvas/host/canvas_host_activation_controller.py
+++ b/substitute/presentation/canvas/host/canvas_host_activation_controller.py
@@ -122,6 +122,7 @@ class _CanvasFocusHandoff(QObject):
         if application is not None:
             application.installEventFilter(self)
         self._restore_focus()
+        self._queue_focus_restore()
 
     def stop(self) -> None:
         """Release this handoff after superseding user or lifecycle intent."""

--- a/tests/test_canvas_host_contract.py
+++ b/tests/test_canvas_host_contract.py
@@ -67,6 +67,26 @@ class _Canvas(QWidget):
         self.availability.append((available, reason))
 
 
+class _DefersFirstFocusCanvas(_Canvas):
+    """Reject the synchronous focus request made inside an activation event."""
+
+    def __init__(self) -> None:
+        """Create a canvas that accepts focus after the current event dispatch."""
+
+        super().__init__()
+        self.focus_requests = 0
+
+    def setFocus(  # noqa: N802
+        self,
+        reason: Qt.FocusReason = Qt.FocusReason.OtherFocusReason,
+    ) -> None:
+        """Accept every focus request after the first synchronous attempt."""
+
+        self.focus_requests += 1
+        if self.focus_requests > 1:
+            super().setFocus(reason)
+
+
 class _FloatingWindow(QWidget):
     """Provide deterministic floating-window behavior for host docking tests."""
 
@@ -183,6 +203,36 @@ def test_host_activation_can_transfer_keyboard_focus_to_selected_canvas() -> Non
         _app().processEvents()
 
         assert host.is_canvas_visible("Input")
+        assert input_canvas.hasFocus()
+    finally:
+        host.close()
+
+
+def test_host_activation_verifies_focus_after_current_event_dispatch() -> None:
+    """Picker activation must recover when synchronous focus is not accepted."""
+
+    _app()
+    input_canvas = _DefersFirstFocusCanvas()
+    output_canvas = _Canvas()
+    host = CanvasHost(
+        pages=(
+            CanvasHostPage("Input", app_text("Input"), input_canvas),
+            CanvasHostPage("Output", app_text("Output"), output_canvas),
+        )
+    )
+    try:
+        input_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        output_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        host.show()
+        output_canvas.setFocus()
+        _app().processEvents()
+
+        assert host.activate_canvas("Input", keyboard_focus=True)
+        assert input_canvas.focus_requests == 1
+
+        _app().processEvents()
+
+        assert input_canvas.focus_requests >= 2
         assert input_canvas.hasFocus()
     finally:
         host.close()


### PR DESCRIPTION
## Summary

- verify explicit picker-requested canvas focus once after the current Qt event dispatch
- preserve the existing focus handoff through transient focusless projections
- add a deterministic regression canvas that rejects the first synchronous focus request

## Evidence

- PR #95 Linux failed because the second picker activation's synchronous focus request did not settle under the offscreen Qt backend
- controlled mutation: removing the deferred verification makes the new regression fail with one focus request; restoring it passes

## Verification

- focused canvas-host and real-shell Input editor modules
- full parallel suite
- all 129 isolated serial modules
- Ruff format and lint
- mypy strict
- architecture governance
- git diff --check