### PR TITLE
fix(ci): stabilize Canary promotion qualification

### DIFF
--- a/.github/workflows/comfy-compatibility.yml
+++ b/.github/workflows/comfy-compatibility.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: comfy-compatibility-${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  group: comfy-compatibility-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -30,6 +30,7 @@ env:
 jobs:
   real-tag-probe:
     name: ${{ matrix.comfyui }} / ${{ matrix.manager }} (${{ matrix.name }})
+    if: github.event_name != 'pull_request' || github.head_ref != 'canary' || github.base_ref != 'main'
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +91,7 @@ jobs:
 
   real-update-probe:
     name: ${{ matrix.source }} -> ${{ matrix.target }} (${{ matrix.name }})
+    if: github.event_name != 'pull_request' || github.head_ref != 'canary' || github.base_ref != 'main'
     strategy:
       fail-fast: false
       matrix:

--- a/substitute/presentation/canvas/host/canvas_host_activation_controller.py
+++ b/substitute/presentation/canvas/host/canvas_host_activation_controller.py
@@ -102,8 +102,10 @@ class _CanvasFocusHandoff(QObject):
         """Store the authoritative route and target for one focus intent."""
 
         application = QApplication.instance()
+        if not isinstance(application, QApplication):
+            application = None
         super().__init__(application)
-        self._application = application
+        self._application: QApplication | None = application
         self._state = state
         self._route_key = route_key
         self._widget = widget
@@ -121,6 +123,7 @@ class _CanvasFocusHandoff(QObject):
         application = self._application
         if application is not None:
             application.installEventFilter(self)
+            application.focusChanged.connect(self._focus_changed)
         self._restore_focus()
         self._queue_focus_restore()
 
@@ -132,6 +135,7 @@ class _CanvasFocusHandoff(QObject):
         self._active = False
         application = self._application
         if application is not None:
+            application.focusChanged.disconnect(self._focus_changed)
             application.removeEventFilter(self)
         self._finished(self)
         self.deleteLater()
@@ -146,19 +150,24 @@ class _CanvasFocusHandoff(QObject):
         if event_type == QEvent.Type.ApplicationDeactivate:
             self.stop()
             return False
-        if event_type == QEvent.Type.FocusOut and isinstance(watched, QWidget):
-            if self._belongs_to_target(watched):
-                self._queue_focus_restore()
-            return False
-        if event_type != QEvent.Type.FocusIn or not isinstance(watched, QWidget):
-            return False
-        if self._belongs_to_target(watched):
-            return False
-        if watched.window() is not self._widget.window():
-            self.stop()
-            return False
-        self._queue_focus_restore()
         return False
+
+    def _focus_changed(
+        self,
+        _previous: QWidget | None,
+        current: QWidget | None,
+    ) -> None:
+        """Restore same-window projection focus before its transfer returns."""
+
+        if not self._active:
+            return
+        if current is not None and self._belongs_to_target(current):
+            return
+        if current is not None and current.window() is not self._widget.window():
+            self.stop()
+            return
+        self._restore_focus()
+        self._queue_focus_restore()
 
     def _queue_focus_restore(self) -> None:
         """Coalesce competing projections into one queued restoration."""

--- a/tests/test_canvas_host_contract.py
+++ b/tests/test_canvas_host_contract.py
@@ -309,6 +309,27 @@ def test_activation_focus_recovers_after_projection_temporarily_clears_focus() -
         host.close()
 
 
+def test_activation_focus_restores_before_projection_transfer_returns() -> None:
+    """A same-window projection must not expose a transient competing focus."""
+
+    host, input_canvas, _output_canvas = _host()
+    projection_focus = QWidget(host)
+    try:
+        input_canvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        projection_focus.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        projection_focus.show()
+
+        assert host.activate_canvas("Input", keyboard_focus=True)
+        _app().processEvents()
+        assert input_canvas.hasFocus()
+
+        projection_focus.setFocus()
+
+        assert input_canvas.hasFocus()
+    finally:
+        host.close()
+
+
 def test_activation_focus_handoff_yields_to_later_user_intent() -> None:
     """A later keyboard event must release picker-requested focus ownership."""
 

--- a/tests/test_comfy_support_matrix.py
+++ b/tests/test_comfy_support_matrix.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from tools.ci.comfy_support_matrix import (
@@ -25,6 +27,9 @@ from tools.ci.comfy_support_matrix import (
     COMFY_UPDATE_MATRIX,
     matrix_entry,
 )
+
+
+_COMPATIBILITY_WORKFLOW = Path(".github/workflows/comfy-compatibility.yml")
 
 
 def test_comfy_support_matrix_starts_at_explicit_floor_and_ends_at_current() -> None:
@@ -69,3 +74,18 @@ def test_update_matrix_covers_incremental_and_direct_manager_transitions() -> No
     ]
     assert matrix_entry("v0.24.0").manager_version == "4.2.1"
     assert matrix_entry("v0.25.0").manager_version == "4.2.2"
+
+
+def test_canary_promotion_preserves_its_completed_compatibility_proof() -> None:
+    """A Main promotion must not cancel or duplicate its Canary push matrix."""
+
+    workflow_text = _COMPATIBILITY_WORKFLOW.read_text(encoding="utf-8")
+    assert (
+        "group: comfy-compatibility-${{ github.workflow }}-${{ github.event_name }}-"
+        "${{ github.event.pull_request.head.sha || github.sha }}" in workflow_text
+    )
+    promotion_guard = (
+        "    if: github.event_name != 'pull_request' || github.head_ref != 'canary' || "
+        "github.base_ref != 'main'"
+    )
+    assert workflow_text.count(promotion_guard) == 2


### PR DESCRIPTION
## Summary

- isolate Comfy compatibility concurrency by trigger type so a Main promotion cannot cancel the Canary push proof on the same SHA
- skip the duplicate compatibility matrix only for the policy-enforced canary-to-main promotion PR
- restore picker-requested canvas focus synchronously when a same-window projection tries to take it
- retain deferred focus verification when a target initially rejects focus
- add static workflow coverage and deterministic focus regressions

## Evidence

- run 32556792052 was canceled by PR run 32556793844 because both used a SHA-only concurrency group
- GitHub attached the canceled push checks to PR #95 and marked it UNSTABLE despite the fresh PR matrix passing
- PR #97 run 32558371407 showed focus becoming correct transiently, then leaving Input before the immediate assertion
- controlled mutation: removing synchronous restoration makes the new projection-transfer regression fail immediately; restoring it passes

## Verification

- focused canvas-host, real-shell Input editor, compatibility, and release workflow contracts
- full parallel test suite
- all 129 isolated serial modules
- Ruff format and lint
- mypy strict
- architecture governance
- YAML pre-commit validation
- git diff --check