### PR TITLE
fix(releases): resolve Stable versions without write access

### DIFF
--- a/scripts/resolve-next-release-version.mjs
+++ b/scripts/resolve-next-release-version.mjs
@@ -58,9 +58,10 @@ if (qualificationVersion) {
   shouldRelease = true;
   firstRelease = !canaryRunNumber;
 } else {
-  const resolvedStableVersion = canaryRunNumber
-    ? await resolveCanaryStableVersion(releaseTags)
-    : await resolveStableVersion();
+  const resolvedStableVersion = await resolveStableVersion(
+    releaseTags,
+    canaryRunNumber ? "patch" : undefined,
+  );
   version = canaryRunNumber
     ? createCanaryVersion(resolvedStableVersion, canaryRunNumber)
     : resolvedStableVersion;
@@ -68,7 +69,14 @@ if (qualificationVersion) {
   firstRelease = false;
 }
 
-async function resolveCanaryStableVersion(tags) {
+/**
+ * Resolve the next Stable version through semantic-release's configured analyzer.
+ *
+ * @param {string[]} tags Existing Stable release tags.
+ * @param {"patch" | undefined} fallbackReleaseType Canary's rolling fallback.
+ * @returns {Promise<string>} Next Stable version, or empty when no release is due.
+ */
+async function resolveStableVersion(tags, fallbackReleaseType) {
   const analyzer = selectVersionResolutionPlugins(releaseConfig)[0];
   const analyzerOptions = Array.isArray(analyzer) ? analyzer[1] : {};
   const stableTag = latestStableTag(tags);
@@ -78,22 +86,12 @@ async function resolveCanaryStableVersion(tags) {
     .filter(Boolean)
     .map((message) => ({ message }));
   const { analyzeCommits } = await import("@semantic-release/commit-analyzer");
-  const releaseType =
-    (await analyzeCommits(analyzerOptions, {
-      commits,
-      logger: { log() {} },
-    })) ?? "patch";
-  return nextStableVersion(tags, releaseType);
-}
-
-async function resolveStableVersion() {
-  const { default: semanticRelease } = await import("semantic-release");
-  const result = await semanticRelease({
-    ci: false,
-    dryRun: true,
-    plugins: selectVersionResolutionPlugins(releaseConfig),
+  const analyzedReleaseType = await analyzeCommits(analyzerOptions, {
+    commits,
+    logger: { log() {} },
   });
-  return result?.nextRelease?.version ?? "";
+  const releaseType = analyzedReleaseType ?? fallbackReleaseType;
+  return releaseType ? nextStableVersion(tags, releaseType) : "";
 }
 
 if (process.env.GITHUB_OUTPUT) {

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -412,12 +412,31 @@ def test_canary_version_resolution_does_not_probe_ambiguous_remote_ref() -> None
         PROJECT_ROOT / "scripts" / "resolve-next-release-version.mjs"
     ).read_text(encoding="utf-8")
 
-    canary_resolver = resolver_text.split(
-        "async function resolveCanaryStableVersion", maxsplit=1
-    )[1].split("async function resolveStableVersion", maxsplit=1)[0]
-    assert "analyzeCommits" in canary_resolver
-    assert "semanticRelease" not in canary_resolver
-    assert "branches:" not in canary_resolver
+    assert "analyzeCommits" in resolver_text
+    assert "branches:" not in resolver_text
+
+
+def test_read_only_version_resolution_never_probes_remote_push_permission() -> None:
+    """Keep pre-publication version calculation independent of repository writes."""
+
+    resolver_text = (
+        PROJECT_ROOT / "scripts" / "resolve-next-release-version.mjs"
+    ).read_text(encoding="utf-8")
+    release_text = (PROJECT_ROOT / ".github" / "workflows" / "release.yml").read_text(
+        encoding="utf-8"
+    )
+    determine_version = release_text.split("  determine-version:", maxsplit=1)[1].split(
+        "  build-windows:", maxsplit=1
+    )[0]
+
+    assert 'import("semantic-release")' not in resolver_text, (
+        "Read-only version resolution must not invoke semantic-release core because "
+        "its dry run probes remote push permission."
+    )
+    assert "contents: write" not in determine_version, (
+        "Version resolution must remain read-only; write access belongs only to "
+        "post-qualification publication."
+    )
 
 
 def test_canary_release_notes_direct_normal_users_to_stable(tmp_path: Path) -> None:
@@ -844,7 +863,7 @@ def test_first_release_publishes_version_090_without_adding_a_commit() -> None:
     ).read_text(encoding="utf-8")
 
     assert 'const FIRST_RELEASE_VERSION = "0.9.0"' in resolver_text
-    assert "result?.nextRelease?.version" in resolver_text
+    assert "resolveStableVersion" in resolver_text
     assert "first_release=${firstRelease}" in resolver_text
     assert "prepare-release-assets.mjs" in workflow_text
     assert "prime-first-release-tag" not in workflow_text


### PR DESCRIPTION
## Outcome

- keeps pre-publication Stable and Canary version calculation read-only
- uses the configured semantic-release commit analyzer without invoking semantic-release core's remote push probe
- preserves Canary's rolling patch fallback and Stable's no-release result
- adds an explicit regression that forbids both the push-probing core call and write permission on version resolution

## Failure addressed

Stable release run 32562154818 passed every cross-platform qualification gate, then failed in version resolution because semantic-release dry-run probed a push with the intentionally read-only workflow token. No build, tag, release, generated commit, or version was consumed.

## Verification

- resolver without a token: 0.21.2
- release-contract tests: 52 passed
- Ruff format and lint
- mypy --strict
- architecture governance
- full parallel suite
- all 129 serial modules