### PR TITLE
fix(releases): qualify private Stable assets before publication

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -540,7 +540,7 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $true
           New-Item -ItemType Directory -Force build/historical-installer | Out-Null
           $assetPattern = switch ("${{ matrix.platform }}") {
-            "windows" { "SugarSubstitute-*-Windows-x64.exe" }
+            "windows" { "SugarSubstitute-*-Windows-x64*.exe" }
             "linux" { "SugarSubstitute-*-Linux-x86_64.AppImage" }
             "macos" { "SugarSubstitute-*-macOS-Apple-Silicon.dmg" }
           }

--- a/tests/test_installer_qualification.py
+++ b/tests/test_installer_qualification.py
@@ -439,10 +439,52 @@ def test_local_candidate_channel_uses_trusted_https_and_exact_files(
 
     release_root = tmp_path / "candidate"
     release_root.mkdir()
-    (release_root / "manifest.json").write_text(
-        '{"version":"9999.0.1"}\n',
-        encoding="utf-8",
+    asset_names = {
+        "app": "SugarSubstitute-app-v9999.0.1.zip",
+        "launcher": "SugarSubstitute-installer-payload-windows-x64-v9999.0.1.zip",
+        "installer": "SugarSubstitute-9999.0.1-Windows-x64.exe",
+    }
+    for name in asset_names.values():
+        (release_root / name).write_bytes(f"exact bytes for {name}".encode())
+    public_root = (
+        "https://github.com/Artificial-Sweetener/SugarSubstitute/"
+        "releases/download/v9999.0.1"
     )
+
+    def asset(name: str) -> dict[str, str | int]:
+        """Build one production-addressed staged asset fixture."""
+
+        path = release_root / name
+        return {
+            "filename": name,
+            "url": f"{public_root}/{name}",
+            "sha256": "a" * 64,
+            "size_bytes": path.stat().st_size,
+        }
+
+    source_manifest = (
+        json.dumps(
+            {
+                "schema_version": 2,
+                "channel": "stable",
+                "version": "9999.0.1",
+                "minimum_launcher_version": "0.1.0",
+                "release_metadata": {"publication": "pending"},
+                "app": asset(asset_names["app"]),
+                "launchers": {
+                    "windows_x64": asset(asset_names["launcher"]),
+                },
+                "installers": {
+                    "windows_x64_exe": asset(asset_names["installer"]),
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    manifest_path = release_root / "manifest.json"
+    manifest_path.write_text(source_manifest, encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     with LocalReleaseServer(
         release_root=release_root,
@@ -465,9 +507,26 @@ def test_local_candidate_channel_uses_trusted_https_and_exact_files(
             context=legacy_context,
         ) as response:
             assert response.status == 200
+        with urllib.request.urlopen(
+            payload["app"]["url"],
+            timeout=5.0,
+            context=legacy_context,
+        ) as response:
+            assert response.read() == (release_root / asset_names["app"]).read_bytes()
 
         assert server.manifest_url == f"{LOCAL_RELEASE_BASE_URL}/manifest.json"
-        assert payload == {"version": "9999.0.1"}
+        assert payload["version"] == "9999.0.1"
+        assert payload["release_metadata"] == {"publication": "pending"}
+        assert payload["app"]["url"] == (
+            f"{LOCAL_RELEASE_BASE_URL}/{asset_names['app']}"
+        )
+        assert payload["launchers"]["windows_x64"]["url"] == (
+            f"{LOCAL_RELEASE_BASE_URL}/{asset_names['launcher']}"
+        )
+        assert payload["installers"]["windows_x64_exe"]["url"] == (
+            f"{LOCAL_RELEASE_BASE_URL}/{asset_names['installer']}"
+        )
+        assert manifest_path.read_text(encoding="utf-8") == source_manifest
         assert server.certificate_path.is_absolute()
         assert server.trust_bundle_path.is_absolute()
         requests = [
@@ -477,6 +536,7 @@ def test_local_candidate_channel_uses_trusted_https_and_exact_files(
         assert [request["path"] for request in requests] == [
             "/manifest.json",
             "/manifest.json",
+            f"/{asset_names['app']}",
         ]
         assert (
             server.trust_bundle_path.read_text(encoding="ascii").count(

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -568,7 +568,8 @@ def test_release_qualification_covers_clean_launch_and_upgrade_depth() -> None:
     assert "prepare_portable_historical_install" in lifecycle_text
     assert '"--headless-install"' in historical_qualification_text
     assert "Download real historical installer" in workflow_text
-    assert '"SugarSubstitute-*-Windows-x64.exe"' in workflow_text
+    assert '"SugarSubstitute-*-Windows-x64*.exe"' in workflow_text
+    assert '"SugarSubstitute-*-Windows-x64.exe"' not in workflow_text
     assert '"SugarSubstitute-*-Linux-x86_64.AppImage"' in workflow_text
     assert '"SugarSubstitute-*-macOS-Apple-Silicon.dmg"' in workflow_text
     assert "Select-Object -Single" not in workflow_text

--- a/tools/ci/local_release_server.py
+++ b/tools/ci/local_release_server.py
@@ -25,9 +25,11 @@ import ssl
 import subprocess
 from threading import Lock, Thread
 import time
-from typing import Any, Self
+from typing import Any, Self, cast
 
 import certifi
+
+from launcher.sugarsubstitute_launcher.manifest import ReleaseAsset, ReleaseManifest
 
 LOCAL_RELEASE_PORT = 44_443
 LOCAL_RELEASE_BASE_URL = f"https://localhost:{LOCAL_RELEASE_PORT}"
@@ -49,6 +51,10 @@ class LocalReleaseServer:
         self.request_log_path = certificate_root / "requests.jsonl"
         self.request_log_path.unlink(missing_ok=True)
         self._request_log_lock = Lock()
+        self._qualification_manifest = _qualification_manifest_bytes(
+            manifest_path=self.release_root / "manifest.json",
+            release_root=self.release_root,
+        )
         self.certificate_path, key_path = _create_localhost_certificate(
             certificate_root
         )
@@ -94,6 +100,7 @@ class LocalReleaseServer:
         """Bind standard file serving to the exact candidate directory."""
 
         release_root = self.release_root
+        qualification_manifest = self._qualification_manifest
         request_log_path = self.request_log_path
         request_log_lock = self._request_log_lock
 
@@ -109,7 +116,7 @@ class LocalReleaseServer:
                 """Suppress routine local qualification request output."""
 
             def do_GET(self) -> None:
-                """Record candidate-channel access before serving exact bytes."""
+                """Record access and serve the loopback-qualified manifest view."""
 
                 with request_log_lock:
                     with request_log_path.open("a", encoding="utf-8") as output:
@@ -124,9 +131,53 @@ class LocalReleaseServer:
                             )
                             + "\n"
                         )
+                if self.path.partition("?")[0] == "/manifest.json":
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json; charset=utf-8")
+                    self.send_header("Content-Length", str(len(qualification_manifest)))
+                    self.end_headers()
+                    self.wfile.write(qualification_manifest)
+                    return
                 super().do_GET()
 
         return _Handler
+
+
+def _qualification_manifest_bytes(*, manifest_path: Path, release_root: Path) -> bytes:
+    """Build an in-memory manifest view that resolves staged assets locally."""
+
+    decoded: object = json.loads(manifest_path.read_text(encoding="utf-8"))
+    ReleaseManifest.from_json(decoded)
+    if not isinstance(decoded, dict):
+        raise ValueError("Candidate release manifest must be a JSON object.")
+    payload = cast(dict[str, object], decoded)
+    _rewrite_qualification_asset(payload.get("app"), release_root)
+    for collection_name in ("launchers", "installers"):
+        collection = payload.get(collection_name)
+        if not isinstance(collection, dict):
+            raise ValueError(
+                f"Candidate release manifest field must be an object: {collection_name}"
+            )
+        for asset_payload in collection.values():
+            _rewrite_qualification_asset(asset_payload, release_root)
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _rewrite_qualification_asset(asset_payload: object, release_root: Path) -> None:
+    """Point one present staged asset at the trusted loopback server."""
+
+    asset = ReleaseAsset.from_json(asset_payload)
+    if Path(asset.filename).name != asset.filename:
+        raise ValueError(
+            f"Candidate release asset filename must not contain a path: {asset.filename}"
+        )
+    asset_path = release_root / asset.filename
+    if not asset_path.is_file():
+        return
+    if not isinstance(asset_payload, dict):
+        raise ValueError("Candidate release asset must be a JSON object.")
+    mutable_payload = cast(dict[str, object], asset_payload)
+    mutable_payload["url"] = f"{LOCAL_RELEASE_BASE_URL}/{asset.filename}"
 
 
 def _create_localhost_certificate(certificate_root: Path) -> tuple[Path, Path]:


### PR DESCRIPTION
Fixes pre-publication Stable qualification without creating a temporary release. The local HTTPS qualification adapter now serves an in-memory manifest view that redirects staged assets to trusted loopback while leaving the staged manifest and artifact bytes unchanged. It also accepts both historical Windows installer naming generations.\n\nRegression coverage proves the served app, launcher, and installer URLs are local, exact staged bytes are downloaded, the source manifest remains unchanged, and the obsolete Windows-only glob cannot return.\n\nLocal verification: full Ruff format/lint, strict mypy, architecture governance, full parallel test partition, and all 129 isolated serial modules passed.