### PR TITLE
fix(startup): show the splash before application startup work

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -34,6 +34,8 @@ jobs:
         run: .\.venv\Scripts\python.exe tools\check_architecture.py
       - name: Check test governance
         run: .\.venv\Scripts\python.exe tools\check_test_governance.py
+      - name: Check splash-first startup
+        run: .\.venv\Scripts\python.exe -m tools.check_splash_first_startup
       - name: Check formatting
         run: .\.venv\Scripts\ruff.exe format --check .
       - name: Lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,12 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: splash-first-startup
+        name: Enforce splash-first startup
+        entry: python -m tools.check_splash_first_startup
+        language: system
+        pass_filenames: false
+        always_run: true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # v4.6.0

--- a/launcher/sugarsubstitute_launcher/app.py
+++ b/launcher/sugarsubstitute_launcher/app.py
@@ -14,104 +14,44 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Start the standalone launcher GUI."""
+"""Route the standalone launcher while keeping installed startup splash-first."""
 
 from __future__ import annotations
 
 import logging
-import os
 import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
-from launcher.sugarsubstitute_launcher.cli import parse_launcher_args
-from launcher.sugarsubstitute_launcher.candidate_update_launch import (
-    launch_prepared_update,
-)
-from launcher.sugarsubstitute_launcher.application.installation.composition import (
-    build_installation_workflow,
-)
-from launcher.sugarsubstitute_launcher.application.installation.release_source_policy import (
-    resolve_initial_install_release_source,
-)
-from launcher.sugarsubstitute_launcher.application_launch import (
-    enter_installed_application_launch,
-    installed_application_environment,
-)
-from launcher.sugarsubstitute_launcher.connectivity import ReleaseConnectivityVerifier
-from launcher.sugarsubstitute_launcher.config import LauncherConfig
-from launcher.sugarsubstitute_launcher.install_layout import (
-    InstallLayout,
-)
-from launcher.sugarsubstitute_launcher.headless_install import HeadlessInstallService
-from launcher.sugarsubstitute_launcher.logging_setup import configure_launcher_logging
-from launcher.sugarsubstitute_launcher.localization import (
-    build_launcher_localization_runtime,
-    resolve_launcher_locale,
-    seed_headless_locale_preference,
-)
-from launcher.sugarsubstitute_launcher.process import (
-    build_app_launch_command,
-    start_detached,
-    start_detached_handoff,
-)
-from launcher.sugarsubstitute_launcher.release_sources import (
-    GitHubReleaseSource,
-    ReleaseSource,
-    default_production_release_source,
-    release_source_from_config,
-)
-from launcher.sugarsubstitute_launcher.splash_session import (
-    append_splash_session_args,
-    start_launcher_splash_session,
-)
-from launcher.sugarsubstitute_launcher.startup_plan import (
-    LauncherStartupPlan,
-    resolve_startup_plan,
-    should_launch_installed_app,
-    should_show_repair,
-)
-from launcher.sugarsubstitute_launcher.update_orchestrator import (
-    LauncherUpdateOrchestrator,
-)
-from sugarsubstitute_shared.application_launch_guard import ApplicationLaunchGuard
-from sugarsubstitute_shared.installer_qualification import InstallerQualificationPlan
-from sugarsubstitute_shared.launcher_update.process import schedule_launcher_update
-from sugarsubstitute_shared.localization import format_locale_argument
+if TYPE_CHECKING:
+    from launcher.sugarsubstitute_launcher.cli import LauncherArguments
+    from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+    from launcher.sugarsubstitute_launcher.release_sources import ReleaseSource
+    from launcher.sugarsubstitute_launcher.startup_plan import LauncherStartupPlan
+    from sugarsubstitute_shared.application_launch_guard import ApplicationLaunchGuard
 
 
-_LOGGER = logging.getLogger(__name__)
-_PRE_LAUNCH_MANIFEST_TIMEOUT_SECONDS = 3.0
 LauncherMainWindow: Callable[..., Any] | None = None
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Create the Qt application and run the launcher window."""
+    """Route one launcher invocation and reveal installed startup immediately."""
+
+    from launcher.sugarsubstitute_launcher.cli import parse_launcher_args
 
     args = parse_launcher_args(sys.argv[1:] if argv is None else argv)
     if args.verify_release_connectivity:
-        ReleaseConnectivityVerifier().verify(
-            release_source=_explicit_release_source(args.manifest_url)
-        )
-        return 0
+        return _verify_release_connectivity(args)
     if args.headless_install:
-        if args.install_root is None:
-            raise ValueError("Headless installation requires an explicit install root.")
-        layout = InstallLayout.from_root(args.install_root)
-        configure_launcher_logging(layout=layout)
-        HeadlessInstallService(
-            workflow=build_installation_workflow(output_callback=_LOGGER.info)
-        ).install(
-            install_root=layout.root,
-            release_source=_initial_install_release_source(args.manifest_url),
-        )
-        seed_headless_locale_preference(
-            layout,
-            locale_override=args.locale_override,
-        )
-        return 0
-    startup_plan = resolve_startup_plan(
+        return _run_headless_install(args)
+
+    from launcher.sugarsubstitute_launcher.startup_plan import (
+        resolve_startup_candidate,
+        should_attempt_installed_app_launch,
+    )
+
+    startup_candidate = resolve_startup_candidate(
         explicit_install_root=args.install_root,
         executable_path=Path(sys.executable),
         frozen_support_path=_frozen_support_path(),
@@ -119,9 +59,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         native_executable_path=_native_frozen_executable_path(),
         working_directory_path=Path.cwd(),
     )
-    layout = startup_plan.layout
-    configure_launcher_logging(layout=layout)
-    _record_qualification_startup_route(startup_plan)
+    layout = startup_candidate.layout
+    from launcher.sugarsubstitute_launcher.localization import resolve_launcher_locale
+    from sugarsubstitute_shared.localization import format_locale_argument
+
     resolved_locale = resolve_launcher_locale(
         layout,
         locale_override=args.locale_override,
@@ -132,87 +73,196 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     app_launch_error: Exception | None = None
     launch_guard: ApplicationLaunchGuard | None = None
-    if should_launch_installed_app(args=args, startup_plan=startup_plan):
+    startup_plan: LauncherStartupPlan | None = None
+    if should_attempt_installed_app_launch(args=args, candidate=startup_candidate):
+        from launcher.sugarsubstitute_launcher.application_launch import (
+            enter_installed_application_launch,
+        )
+
         launch_guard = enter_installed_application_launch(layout)
         if launch_guard is None:
-            _LOGGER.info(
-                "Ignored launch request because SugarSubstitute is already running."
-            )
             return 0
+        from launcher.sugarsubstitute_launcher.splash_session import (
+            start_launcher_splash_session,
+        )
+
         splash_session = None
         try:
-            config = LauncherConfig.load(layout.config_path)
             splash_session = start_launcher_splash_session(
                 layout=layout,
                 locale_identifier=resolved_locale.effective_language.identifier,
             )
-            update_result = LauncherUpdateOrchestrator().run(
+            from launcher.sugarsubstitute_launcher.startup_plan import (
+                assess_startup_candidate,
+            )
+
+            startup_plan = assess_startup_candidate(startup_candidate)
+            _configure_normal_logging(startup_plan)
+            if not startup_plan.installed_config_valid:
+                raise ValueError(
+                    startup_plan.config_error or "Installed launcher config is invalid."
+                )
+            from launcher.sugarsubstitute_launcher.installed_app_handoff import (
+                complete_installed_app_handoff,
+            )
+
+            complete_installed_app_handoff(
                 layout=layout,
-                config=config,
-                release_source=create_normal_launch_release_source(config),
+                launch_guard=launch_guard,
+                locale_argument=locale_argument,
                 no_update_check=args.no_update_check,
-                progress=splash_session.client if splash_session is not None else None,
+                splash_session=splash_session,
             )
-            if update_result.launcher_update_request_path is not None:
-                if splash_session is not None:
-                    splash_session.client.close()
-                schedule_launcher_update(
-                    request_path=Path(update_result.launcher_update_request_path),
-                    runtime_python=layout.runtime_python,
-                    app_dir=layout.app_dir,
-                    relaunch=True,
-                    wait_pid=os.getpid(),
-                )
-                return 0
-            app_command = append_splash_session_args(
-                build_app_launch_command(
-                    layout=layout,
-                    extra_args=(locale_argument,),
-                ),
-                splash_session,
-            )
-            if update_result.pending_activation is not None:
-                launch_prepared_update(
-                    layout=layout,
-                    command=app_command,
-                    initial_guard=launch_guard,
-                    activation=update_result.pending_activation,
-                )
-            else:
-                start_detached(
-                    app_command,
-                    environment=installed_application_environment(
-                        launch_guard,
-                        remote_failure_reason=update_result.failure_reason,
-                    ),
-                )
             return 0
         except Exception as error:
             app_launch_error = error
-            _LOGGER.exception("Installed app launch failed; showing repair UI.")
+            _configure_launch_error_logging(
+                layout=layout,
+                startup_plan=startup_plan,
+            )
+            logging.getLogger(__name__).exception(
+                "Installed app launch failed; showing repair UI."
+            )
             if splash_session is not None:
                 try:
                     splash_session.client.close()
                 except OSError:
-                    _LOGGER.debug("Failed to close launcher splash after error.")
+                    logging.getLogger(__name__).debug(
+                        "Failed to close launcher splash after error."
+                    )
+    else:
+        from launcher.sugarsubstitute_launcher.startup_plan import (
+            assess_startup_candidate,
+        )
+
+        startup_plan = assess_startup_candidate(startup_candidate)
+        _configure_normal_logging(startup_plan)
+
+    if startup_plan is None:
+        from launcher.sugarsubstitute_launcher.startup_plan import (
+            assess_startup_candidate,
+        )
+
+        startup_plan = assess_startup_candidate(startup_candidate)
+
+    return _run_launcher_window(
+        args=args,
+        startup_plan=startup_plan,
+        app_launch_error=app_launch_error,
+        launch_guard=launch_guard,
+    )
+
+
+def _verify_release_connectivity(args: LauncherArguments) -> int:
+    """Run the explicit headless release-connectivity operation."""
+
+    from launcher.sugarsubstitute_launcher.connectivity import (
+        ReleaseConnectivityVerifier,
+    )
+
+    ReleaseConnectivityVerifier().verify(
+        release_source=_explicit_release_source(args.manifest_url)
+    )
+    return 0
+
+
+def _run_headless_install(args: LauncherArguments) -> int:
+    """Install launcher and app payload without constructing GUI state."""
+
+    if args.install_root is None:
+        raise ValueError("Headless installation requires an explicit install root.")
+    from launcher.sugarsubstitute_launcher.application.installation.composition import (
+        build_installation_workflow,
+    )
+    from launcher.sugarsubstitute_launcher.headless_install import (
+        HeadlessInstallService,
+    )
+    from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+    from launcher.sugarsubstitute_launcher.localization import (
+        seed_headless_locale_preference,
+    )
+    from launcher.sugarsubstitute_launcher.logging_setup import (
+        configure_launcher_logging,
+    )
+
+    layout = InstallLayout.from_root(args.install_root)
+    configure_launcher_logging(layout=layout)
+    logger = logging.getLogger(__name__)
+    HeadlessInstallService(
+        workflow=build_installation_workflow(output_callback=logger.info)
+    ).install(
+        install_root=layout.root,
+        release_source=_initial_install_release_source(args.manifest_url),
+    )
+    seed_headless_locale_preference(
+        layout,
+        locale_override=args.locale_override,
+    )
+    return 0
+
+
+def _configure_normal_logging(startup_plan: LauncherStartupPlan) -> None:
+    """Configure durable diagnostics after the installed splash boundary."""
+
+    from launcher.sugarsubstitute_launcher.logging_setup import (
+        configure_launcher_logging,
+    )
+
+    configure_launcher_logging(layout=startup_plan.layout)
+    _record_qualification_startup_route(startup_plan)
+
+
+def _configure_launch_error_logging(
+    *,
+    layout: InstallLayout,
+    startup_plan: LauncherStartupPlan | None,
+) -> None:
+    """Configure diagnostics even when startup assessment fails unexpectedly."""
+
+    if startup_plan is not None:
+        _configure_normal_logging(startup_plan)
+        return
+    from launcher.sugarsubstitute_launcher.logging_setup import (
+        configure_launcher_logging,
+    )
+
+    configure_launcher_logging(layout=layout)
+
+
+def _run_launcher_window(
+    *,
+    args: LauncherArguments,
+    startup_plan: LauncherStartupPlan,
+    app_launch_error: Exception | None,
+    launch_guard: ApplicationLaunchGuard | None,
+) -> int:
+    """Show setup or repair UI after installed launch routing is complete."""
 
     from PySide6.QtWidgets import QApplication
+
+    from launcher.sugarsubstitute_launcher.application.installation.composition import (
+        build_installation_workflow,
+    )
+    from launcher.sugarsubstitute_launcher.localization import (
+        build_launcher_localization_runtime,
+    )
+    from launcher.sugarsubstitute_launcher.process import start_detached_handoff
+    from launcher.sugarsubstitute_launcher.startup_plan import should_show_repair
 
     application = QApplication.instance()
     owns_application = application is None
     if application is None:
         application = QApplication(sys.argv[:1])
     application = cast(QApplication, application)
-
     build_launcher_localization_runtime(
         application,
-        layout=layout,
+        layout=startup_plan.layout,
         locale_override=args.locale_override,
     )
 
     try:
         window = _launcher_main_window_class()(
-            initial_layout=layout,
+            initial_layout=startup_plan.layout,
             continue_install=args.continue_install,
             repair=should_show_repair(
                 args=args,
@@ -246,6 +296,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 def _explicit_release_source(manifest_url: str | None) -> ReleaseSource:
     """Return the requested HTTPS source or the production release channel."""
 
+    from launcher.sugarsubstitute_launcher.release_sources import (
+        GitHubReleaseSource,
+        default_production_release_source,
+    )
+
     if manifest_url is None:
         return default_production_release_source()
     return GitHubReleaseSource(manifest_url)
@@ -253,6 +308,11 @@ def _explicit_release_source(manifest_url: str | None) -> ReleaseSource:
 
 def _initial_install_release_source(manifest_url: str | None) -> ReleaseSource:
     """Return an explicit test source or the installer-bound release source."""
+
+    from launcher.sugarsubstitute_launcher.application.installation.release_source_policy import (
+        resolve_initial_install_release_source,
+    )
+    from launcher.sugarsubstitute_launcher.release_sources import GitHubReleaseSource
 
     if manifest_url is not None:
         return GitHubReleaseSource(manifest_url)
@@ -272,15 +332,6 @@ def _launcher_main_window_class() -> Callable[..., Any]:
 
         LauncherMainWindow = ImportedLauncherMainWindow
     return LauncherMainWindow
-
-
-def create_normal_launch_release_source(config: LauncherConfig) -> ReleaseSource | None:
-    """Return the configured release source for normal launcher startup."""
-
-    return release_source_from_config(
-        config.release_source,
-        timeout_seconds=_PRE_LAUNCH_MANIFEST_TIMEOUT_SECONDS,
-    )
 
 
 def _frozen_support_path() -> Path | None:
@@ -316,10 +367,15 @@ def _record_qualification_startup_route(
 ) -> None:
     """Record packaged route evidence only for an authenticated CI chain."""
 
+    from sugarsubstitute_shared.installer_qualification import (
+        InstallerQualificationPlan,
+    )
+
+    logger = logging.getLogger(__name__)
     try:
         plan = InstallerQualificationPlan.from_environment()
     except ValueError as error:
-        _LOGGER.warning("Ignored invalid installer qualification plan: %s", error)
+        logger.warning("Ignored invalid installer qualification plan: %s", error)
         return
     if plan is None:
         return
@@ -337,4 +393,7 @@ def _record_qualification_startup_route(
             working_directory=str(Path.cwd()),
         )
     except OSError as error:
-        _LOGGER.warning("Could not record launcher startup route: %s", error)
+        logger.warning("Could not record launcher startup route: %s", error)
+
+
+__all__ = ["main"]

--- a/launcher/sugarsubstitute_launcher/installed_app_handoff.py
+++ b/launcher/sugarsubstitute_launcher/installed_app_handoff.py
@@ -1,0 +1,117 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Complete update and app-process handoff after splash visibility."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from launcher.sugarsubstitute_launcher.application_launch import (
+    installed_application_environment,
+)
+from launcher.sugarsubstitute_launcher.candidate_update_launch import (
+    launch_prepared_update,
+)
+from launcher.sugarsubstitute_launcher.config import LauncherConfig
+from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from launcher.sugarsubstitute_launcher.process import (
+    build_app_launch_command,
+    start_detached,
+)
+from launcher.sugarsubstitute_launcher.release_sources import (
+    ReleaseSource,
+    release_source_from_config,
+)
+from launcher.sugarsubstitute_launcher.splash_session import (
+    LauncherSplashSession,
+    append_splash_session_args,
+)
+from launcher.sugarsubstitute_launcher.update_orchestrator import (
+    LauncherUpdateOrchestrator,
+)
+from sugarsubstitute_shared.application_launch_guard import ApplicationLaunchGuard
+from sugarsubstitute_shared.launcher_update.process import schedule_launcher_update
+
+
+_PRE_LAUNCH_MANIFEST_TIMEOUT_SECONDS = 3.0
+
+
+def complete_installed_app_handoff(
+    *,
+    layout: InstallLayout,
+    launch_guard: ApplicationLaunchGuard,
+    locale_argument: str,
+    no_update_check: bool,
+    splash_session: LauncherSplashSession | None,
+) -> None:
+    """Run update policy and start the installed app behind its visible splash."""
+
+    config = LauncherConfig.load(layout.config_path)
+    update_result = LauncherUpdateOrchestrator().run(
+        layout=layout,
+        config=config,
+        release_source=_normal_launch_release_source(config),
+        no_update_check=no_update_check,
+        progress=splash_session.client if splash_session is not None else None,
+    )
+    if update_result.launcher_update_request_path is not None:
+        if splash_session is not None:
+            splash_session.client.close()
+        schedule_launcher_update(
+            request_path=Path(update_result.launcher_update_request_path),
+            runtime_python=layout.runtime_python,
+            app_dir=layout.app_dir,
+            relaunch=True,
+            wait_pid=os.getpid(),
+        )
+        return
+
+    app_command = append_splash_session_args(
+        build_app_launch_command(
+            layout=layout,
+            extra_args=(locale_argument,),
+        ),
+        splash_session,
+    )
+    if update_result.pending_activation is not None:
+        launch_prepared_update(
+            layout=layout,
+            command=app_command,
+            initial_guard=launch_guard,
+            activation=update_result.pending_activation,
+        )
+        return
+    start_detached(
+        app_command,
+        environment=installed_application_environment(
+            launch_guard,
+            remote_failure_reason=update_result.failure_reason,
+        ),
+    )
+
+
+def _normal_launch_release_source(config: LauncherConfig) -> ReleaseSource | None:
+    """Return the bounded release source used by post-splash update checks."""
+
+    return release_source_from_config(
+        config.release_source,
+        timeout_seconds=_PRE_LAUNCH_MANIFEST_TIMEOUT_SECONDS,
+    )
+
+
+__all__ = ["complete_installed_app_handoff"]

--- a/launcher/sugarsubstitute_launcher/localization.py
+++ b/launcher/sugarsubstitute_launcher/localization.py
@@ -29,6 +29,7 @@ from sugarsubstitute_shared.localization import (
     LocalizationPreferenceStore,
     ResolvedLocale,
     resolve_locale,
+    system_ui_languages,
 )
 
 if TYPE_CHECKING:
@@ -54,14 +55,12 @@ def resolve_launcher_locale(
     *,
     locale_override: str | None,
 ) -> ResolvedLocale:
-    """Resolve GUI and handoff language before a QApplication is required."""
-
-    from PySide6.QtCore import QLocale
+    """Resolve GUI and handoff language without importing the Qt runtime."""
 
     preference = _preference_store(layout).load()
     return resolve_locale(
         preference,
-        ui_languages=tuple(QLocale.system().uiLanguages()),
+        ui_languages=system_ui_languages(),
         process_override=locale_override,
     )
 

--- a/launcher/sugarsubstitute_launcher/startup_plan.py
+++ b/launcher/sugarsubstitute_launcher/startup_plan.py
@@ -47,6 +47,14 @@ class LauncherStartupPlan:
     config_error: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class LauncherStartupCandidate:
+    """Describe the minimal install candidate needed to start a splash."""
+
+    layout: InstallLayout
+    installed_config_found: bool
+
+
 def resolve_install_root(
     *,
     explicit_install_root: Path | None,
@@ -77,13 +85,36 @@ def resolve_startup_plan(
     native_executable_path: Path | None = None,
     working_directory_path: Path | None = None,
 ) -> LauncherStartupPlan:
-    """Resolve setup, installed, or repair behavior from package-owned paths."""
+    """Resolve and validate setup, installed, or repair startup state."""
+
+    return assess_startup_candidate(
+        resolve_startup_candidate(
+            explicit_install_root=explicit_install_root,
+            executable_path=executable_path,
+            frozen_support_path=frozen_support_path,
+            invocation_path=invocation_path,
+            native_executable_path=native_executable_path,
+            working_directory_path=working_directory_path,
+        )
+    )
+
+
+def resolve_startup_candidate(
+    *,
+    explicit_install_root: Path | None,
+    executable_path: Path,
+    frozen_support_path: Path | None = None,
+    invocation_path: Path | None = None,
+    native_executable_path: Path | None = None,
+    working_directory_path: Path | None = None,
+) -> LauncherStartupCandidate:
+    """Find a possible installed layout without reading its configuration."""
 
     if explicit_install_root is not None:
-        return LauncherStartupPlan(
-            layout=InstallLayout.from_root(explicit_install_root),
+        layout = InstallLayout.from_root(explicit_install_root)
+        return LauncherStartupCandidate(
+            layout=layout,
             installed_config_found=False,
-            installed_config_valid=True,
         )
 
     target = detect_launcher_target()
@@ -130,12 +161,42 @@ def resolve_startup_plan(
             continue
         checked_roots.add(candidate_layout.root)
         if candidate_layout.config_path.is_file():
-            return _resolve_installed_config_plan(candidate_layout)
+            return LauncherStartupCandidate(
+                layout=candidate_layout,
+                installed_config_found=True,
+            )
 
-    return LauncherStartupPlan(
+    return LauncherStartupCandidate(
         layout=InstallLayout.from_root(default_install_root(executable_path)),
         installed_config_found=False,
-        installed_config_valid=True,
+    )
+
+
+def assess_startup_candidate(
+    candidate: LauncherStartupCandidate,
+) -> LauncherStartupPlan:
+    """Validate one discovered candidate after its splash is visible."""
+
+    if not candidate.installed_config_found:
+        return LauncherStartupPlan(
+            layout=candidate.layout,
+            installed_config_found=False,
+            installed_config_valid=True,
+        )
+    return _resolve_installed_config_plan(candidate.layout)
+
+
+def should_attempt_installed_app_launch(
+    *,
+    args: LauncherArguments,
+    candidate: LauncherStartupCandidate,
+) -> bool:
+    """Return whether one candidate warrants immediate splash presentation."""
+
+    if args.continue_install or args.repair:
+        return False
+    return candidate.installed_config_found and is_installed_app_launchable(
+        candidate.layout
     )
 
 
@@ -207,7 +268,7 @@ def should_launch_installed_app(
     args: LauncherArguments,
     startup_plan: LauncherStartupPlan,
 ) -> bool:
-    """Return whether this launcher invocation should start the installed app."""
+    """Return whether validated startup state can launch the installed app."""
 
     if args.continue_install or args.repair:
         return False
@@ -244,10 +305,14 @@ def should_show_repair(
 
 
 __all__ = [
+    "LauncherStartupCandidate",
     "LauncherStartupPlan",
+    "assess_startup_candidate",
     "is_installed_app_launchable",
     "resolve_install_root",
+    "resolve_startup_candidate",
     "resolve_startup_plan",
+    "should_attempt_installed_app_launch",
     "should_launch_installed_app",
     "should_show_repair",
 ]

--- a/main.py
+++ b/main.py
@@ -21,17 +21,11 @@ from __future__ import annotations
 import sys
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QLocale
-
-from substitute.app.bootstrap.startup_timing import StartupTimingRecord
-from sugarsubstitute_shared.application_launch_guard import (
-    ApplicationLaunchGuard,
-    application_launch_install_root,
-    clear_inherited_application_launch_token,
-    inherited_application_launch_token,
-)
-from sugarsubstitute_shared.localization import resolve_early_startup_locale
+if TYPE_CHECKING:
+    from substitute.app.bootstrap.startup_timing import StartupTimingRecord
+    from sugarsubstitute_shared.application_launch_guard import ApplicationLaunchGuard
 
 
 _PROCESS_LAUNCH_GUARD: ApplicationLaunchGuard | None = None
@@ -41,12 +35,14 @@ def _record_elapsed(
     records: list[StartupTimingRecord],
     phase: str,
     started_at: float,
+    *,
+    record_type: type[StartupTimingRecord],
 ) -> float:
     """Append one pre-bootstrap timing record and return the current timestamp."""
 
     ended_at = time.perf_counter()
     records.append(
-        StartupTimingRecord(
+        record_type(
             phase=phase,
             elapsed_ms=max(0.0, (ended_at - started_at) * 1000.0),
         )
@@ -56,53 +52,54 @@ def _record_elapsed(
 
 def main() -> None:
     """Execute startup flow and exit with Qt event-loop code."""
+
+    phase_started_at = time.perf_counter()
     app_root = Path(__file__).resolve().parent
     if not _enter_application_launch_guard(argv=sys.argv, app_root=app_root):
         return
-    startup_records: list[StartupTimingRecord] = []
-    phase_started_at = time.perf_counter()
-    phase_started_at = _record_elapsed(
-        startup_records,
-        "entrypoint.resolve_app_root",
-        phase_started_at,
-    )
-    from substitute.app.bootstrap.env_file import load_env_file
-
-    load_env_file(app_root / ".env")
-    phase_started_at = _record_elapsed(
-        startup_records,
-        "entrypoint.load_env_file",
-        phase_started_at,
+    from sugarsubstitute_shared.localization import (
+        resolve_early_startup_locale,
+        system_ui_languages,
     )
     from substitute.app.bootstrap.early_launch_splash import start_early_launch_splash
 
-    phase_started_at = _record_elapsed(
-        startup_records,
-        "entrypoint.import_early_launch_splash",
-        phase_started_at,
-    )
     early_locale = resolve_early_startup_locale(
         sys.argv,
         app_root=app_root,
-        ui_languages=tuple(QLocale.system().uiLanguages()),
+        ui_languages=system_ui_languages(),
     )
     early_splash, cancel_relay = start_early_launch_splash(
         sys.argv,
         app_root,
         early_locale.effective_language.identifier,
     )
+
+    from substitute.app.bootstrap.startup_timing import StartupTimingRecord
+
+    startup_records: list[StartupTimingRecord] = []
     phase_started_at = _record_elapsed(
         startup_records,
         "entrypoint.start_early_launch_splash",
         phase_started_at,
+        record_type=StartupTimingRecord,
     )
     try:
+        from substitute.app.bootstrap.env_file import load_env_file
+
+        load_env_file(app_root / ".env")
+        phase_started_at = _record_elapsed(
+            startup_records,
+            "entrypoint.load_env_file",
+            phase_started_at,
+            record_type=StartupTimingRecord,
+        )
         from substitute.app.bootstrap.startup import run_application
 
         phase_started_at = _record_elapsed(
             startup_records,
             "entrypoint.import_startup",
             phase_started_at,
+            record_type=StartupTimingRecord,
         )
         exit_code = run_application(
             sys.argv,
@@ -121,6 +118,13 @@ def main() -> None:
 
 def _enter_application_launch_guard(*, argv: list[str], app_root: Path) -> bool:
     """Claim this application process before any splash can be created."""
+
+    from sugarsubstitute_shared.application_launch_guard import (
+        ApplicationLaunchGuard,
+        application_launch_install_root,
+        clear_inherited_application_launch_token,
+        inherited_application_launch_token,
+    )
 
     global _PROCESS_LAUNCH_GUARD
     install_root = application_launch_install_root(argv, app_root=app_root)

--- a/sugarsubstitute_shared/localization/__init__.py
+++ b/sugarsubstitute_shared/localization/__init__.py
@@ -48,6 +48,7 @@ from sugarsubstitute_shared.localization.resolution import (
     normalize_locale_tag,
     resolve_locale,
 )
+from sugarsubstitute_shared.localization.system_languages import system_ui_languages
 
 __all__ = [
     "ApplicationMessage",
@@ -70,4 +71,5 @@ __all__ = [
     "resolve_locale",
     "resolve_early_startup_locale",
     "render_source_application_text",
+    "system_ui_languages",
 ]

--- a/sugarsubstitute_shared/localization/system_languages.py
+++ b/sugarsubstitute_shared/localization/system_languages.py
@@ -1,0 +1,97 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Resolve operating-system UI languages without importing Qt."""
+
+from __future__ import annotations
+
+import ctypes
+import locale
+import os
+
+
+_MUI_LANGUAGE_NAME = 0x8
+
+
+def system_ui_languages() -> tuple[str, ...]:
+    """Return ordered UI-language candidates for splash-time localization."""
+
+    candidates = [
+        *_environment_language_candidates(),
+        *_windows_ui_language_candidates(),
+    ]
+    active_locale, _encoding = locale.getlocale()
+    if active_locale:
+        candidates.append(active_locale)
+    return _deduplicate(candidates)
+
+
+def _environment_language_candidates() -> tuple[str, ...]:
+    """Return POSIX locale preferences in their standard precedence order."""
+
+    language = os.environ.get("LANGUAGE", "")
+    candidates = [value for value in language.split(":") if value]
+    for variable_name in ("LC_ALL", "LC_MESSAGES", "LANG"):
+        value = os.environ.get(variable_name)
+        if value:
+            candidates.append(value)
+    return tuple(candidates)
+
+
+def _windows_ui_language_candidates() -> tuple[str, ...]:
+    """Return Windows preferred UI languages through the kernel locale API."""
+
+    if os.name != "nt":
+        return ()
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_languages = kernel32.GetUserPreferredUILanguages
+    language_count = ctypes.c_ulong()
+    buffer_size = ctypes.c_ulong()
+    if not get_languages(
+        _MUI_LANGUAGE_NAME,
+        ctypes.byref(language_count),
+        None,
+        ctypes.byref(buffer_size),
+    ):
+        return ()
+    buffer = ctypes.create_unicode_buffer(buffer_size.value)
+    if not get_languages(
+        _MUI_LANGUAGE_NAME,
+        ctypes.byref(language_count),
+        buffer,
+        ctypes.byref(buffer_size),
+    ):
+        return ()
+    buffer_value = "".join(buffer[: buffer_size.value])
+    return tuple(value for value in buffer_value.split("\0") if value)
+
+
+def _deduplicate(candidates: list[str]) -> tuple[str, ...]:
+    """Preserve candidate order while removing equivalent repeated values."""
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        normalized = candidate.strip()
+        identity = normalized.casefold()
+        if not normalized or identity in seen:
+            continue
+        seen.add(identity)
+        result.append(normalized)
+    return tuple(result)
+
+
+__all__ = ["system_ui_languages"]

--- a/tests/app/entrypoint/test_main.py
+++ b/tests/app/entrypoint/test_main.py
@@ -28,6 +28,8 @@ import pytest
 
 import main as app_entrypoint
 from substitute.app.bootstrap.startup_timing import StartupTimingRecord
+import sugarsubstitute_shared.application_launch_guard as launch_guard_module
+import sugarsubstitute_shared.localization as shared_localization
 from sugarsubstitute_shared.application_launch_guard import (
     APPLICATION_LAUNCH_TOKEN_ENV,
 )
@@ -98,32 +100,31 @@ def test_main_starts_early_splash_and_passes_it_to_bootstrap(
     monkeypatch.setitem(sys.modules, "substitute.app.bootstrap.startup", startup_module)
     monkeypatch.setattr(sys, "argv", argv)
     monkeypatch.setattr(
-        app_entrypoint,
+        shared_localization,
         "resolve_early_startup_locale",
         lambda *_args, **_kwargs: SimpleNamespace(
             effective_language=SimpleNamespace(identifier="ja")
         ),
     )
+    monkeypatch.setattr(shared_localization, "system_ui_languages", lambda: ("ja",))
 
     with pytest.raises(SystemExit) as exit_info:
         app_entrypoint.main()
 
     assert exit_info.value.code == 7
     assert calls == [
-        ("env", Path(app_entrypoint.__file__).resolve().parent / ".env"),
         ("splash_argv", argv),
         ("splash_root", Path(app_entrypoint.__file__).resolve().parent),
         ("splash_locale", "ja"),
+        ("env", Path(app_entrypoint.__file__).resolve().parent / ".env"),
         ("run_argv", argv),
         ("initial_splash", splash),
         ("cancel_connector", relay.connect),
         (
             "prebootstrap_phases",
             (
-                "entrypoint.resolve_app_root",
-                "entrypoint.load_env_file",
-                "entrypoint.import_early_launch_splash",
                 "entrypoint.start_early_launch_splash",
+                "entrypoint.load_env_file",
                 "entrypoint.import_startup",
             ),
         ),
@@ -187,14 +188,6 @@ def test_main_refuses_to_start_splash_when_launch_guard_is_held(
         "_enter_application_launch_guard",
         lambda **_kwargs: False,
     )
-    monkeypatch.setattr(
-        app_entrypoint,
-        "resolve_early_startup_locale",
-        lambda *_args, **_kwargs: pytest.fail(
-            "Rejected launches must stop before splash localization."
-        ),
-    )
-
     app_entrypoint.main()
 
 
@@ -219,7 +212,7 @@ def test_entrypoint_consumes_launch_authority_before_bootstrap(
         return guard
 
     monkeypatch.setattr(
-        app_entrypoint,
+        launch_guard_module,
         "ApplicationLaunchGuard",
         SimpleNamespace(enter=enter_guard),
     )

--- a/tests/crosscutting/startup_splash_contract/__init__.py
+++ b/tests/crosscutting/startup_splash_contract/__init__.py
@@ -1,0 +1,17 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Test splash-first executable startup governance."""

--- a/tests/crosscutting/startup_splash_contract/test_checker.py
+++ b/tests/crosscutting/startup_splash_contract/test_checker.py
@@ -1,0 +1,177 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Prove splash-first diagnostics distinguish startup control-flow paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import textwrap
+
+from tools.splash_first_governance import (
+    SplashFirstContract,
+    validate_contract_source,
+)
+
+
+_PATH = Path("launcher.py")
+_CONTRACT = SplashFirstContract(
+    relative_path=_PATH,
+    function_name="main",
+    boundary_call="show_splash",
+    allowed_module_import_roots=frozenset({"__future__", "sys"}),
+    allowed_pre_boundary_imports=frozenset({"safe.routing", "safe.splash"}),
+    allowed_pre_boundary_calls=frozenset(
+        {"parse_route", "resolve_layout", "show_splash"}
+    ),
+)
+
+
+def test_checker_accepts_only_reviewed_work_before_splash() -> None:
+    """Reviewed routing may precede visibility while application work follows it."""
+
+    source = _source(
+        """
+        import sys
+
+        def main():
+            from safe.routing import parse_route, resolve_layout
+            route = parse_route(sys.argv)
+            if route.headless:
+                from application.headless import run_headless
+                return run_headless()
+            layout = resolve_layout(route)
+            from safe.splash import show_splash
+            splash = show_splash(layout=layout)
+            from application.startup import perform_heavy_work
+            perform_heavy_work(splash)
+        """
+    )
+
+    assert validate_contract_source(source, contract=_CONTRACT, path=_PATH) == ()
+
+
+def test_checker_rejects_eager_project_imports() -> None:
+    """Module imports cannot silently move application composition before splash."""
+
+    source = _source(
+        """
+        from application.startup import perform_heavy_work
+
+        def main():
+            from safe.splash import show_splash
+            show_splash()
+            perform_heavy_work()
+        """
+    )
+
+    diagnostics = validate_contract_source(source, contract=_CONTRACT, path=_PATH)
+
+    assert [(item.code, item.line) for item in diagnostics] == [("SPLASH002", 2)]
+
+
+def test_checker_rejects_import_time_work() -> None:
+    """Module-level calls cannot bypass the protected entrypoint boundary."""
+
+    source = _source(
+        """
+        warm_application_cache()
+
+        def main():
+            from safe.splash import show_splash
+            show_splash()
+        """
+    )
+
+    diagnostics = validate_contract_source(source, contract=_CONTRACT, path=_PATH)
+
+    assert [(item.code, item.line) for item in diagnostics] == [("SPLASH005", 2)]
+    assert "warm_application_cache" in diagnostics[0].message
+
+
+def test_checker_rejects_unreviewed_calls_on_boundary_path() -> None:
+    """Filesystem, network, or composition calls added before visibility must fail."""
+
+    source = _source(
+        """
+        def main():
+            resolve_layout()
+            load_configuration()
+            from safe.splash import show_splash
+            show_splash()
+        """
+    )
+
+    diagnostics = validate_contract_source(source, contract=_CONTRACT, path=_PATH)
+
+    assert [(item.code, item.line) for item in diagnostics] == [("SPLASH004", 4)]
+    assert "load_configuration" in diagnostics[0].message
+
+
+def test_checker_ignores_work_confined_to_a_returning_non_splash_mode() -> None:
+    """Headless-only execution does not delay the installed splash route."""
+
+    source = _source(
+        """
+        def main():
+            if is_headless:
+                download_release()
+                return 0
+            resolve_layout()
+            from safe.splash import show_splash
+            show_splash()
+        """
+    )
+
+    assert validate_contract_source(source, contract=_CONTRACT, path=_PATH) == ()
+
+
+def test_checker_rejects_missing_or_duplicated_visibility_boundaries() -> None:
+    """A protected entrypoint must expose one unambiguous splash transition."""
+
+    missing = _source(
+        """
+        def main():
+            resolve_layout()
+        """
+    )
+    duplicated = _source(
+        """
+        def main():
+            show_splash()
+            show_splash()
+        """
+    )
+
+    missing_diagnostics = validate_contract_source(
+        missing,
+        contract=_CONTRACT,
+        path=_PATH,
+    )
+    duplicated_diagnostics = validate_contract_source(
+        duplicated,
+        contract=_CONTRACT,
+        path=_PATH,
+    )
+
+    assert [item.code for item in missing_diagnostics] == ["SPLASH001"]
+    assert [item.code for item in duplicated_diagnostics] == ["SPLASH001"]
+
+
+def _source(value: str) -> str:
+    """Return a left-aligned source fixture with stable line numbers."""
+
+    return textwrap.dedent(value)

--- a/tests/crosscutting/startup_splash_contract/test_repository_contract.py
+++ b/tests/crosscutting/startup_splash_contract/test_repository_contract.py
@@ -1,0 +1,31 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Apply splash-first analysis to the repository executable entrypoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.splash_first_governance import validate_repository
+
+
+def test_repository_executable_startup_is_splash_first() -> None:
+    """Every protected executable path must keep unreviewed work behind splash."""
+
+    repository_root = Path(__file__).resolve().parents[3]
+
+    assert validate_repository(repository_root) == ()

--- a/tests/launcher/application_launch/test_installed_entrypoint.py
+++ b/tests/launcher/application_launch/test_installed_entrypoint.py
@@ -25,6 +25,8 @@ from pathlib import Path
 import pytest
 
 from launcher.sugarsubstitute_launcher import app as launcher_app
+from launcher.sugarsubstitute_launcher import installed_app_handoff
+from launcher.sugarsubstitute_launcher import splash_session as splash_session_module
 from launcher.sugarsubstitute_launcher.config import LauncherConfig
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from launcher.sugarsubstitute_launcher.release_sources import GitHubReleaseSource
@@ -65,12 +67,6 @@ def test_launcher_main_repairs_moved_installed_exe_config(
 
     monkeypatch.setattr(sys, "executable", str(layout.executable_path))
     monkeypatch.setattr(launcher_app, "LauncherMainWindow", _FakeWindow)
-    monkeypatch.setattr(
-        launcher_app,
-        "start_detached",
-        lambda _command: pytest.fail("Invalid installed config must not launch app."),
-    )
-
     assert launcher_app.main(["--manifest-url", manifest_url]) == 0
     assert windows
     assert windows[0]["initial_layout"] == layout
@@ -122,12 +118,12 @@ def test_launcher_main_starts_app_from_installed_exe_parent(
     )
     monkeypatch.setenv(APPLICATION_LAUNCH_TOKEN_ENV, "inherited-poison-token")
     monkeypatch.setattr(
-        launcher_app,
+        splash_session_module,
         "start_launcher_splash_session",
         lambda *, layout, locale_identifier: None,
     )
     monkeypatch.setattr(
-        launcher_app,
+        installed_app_handoff,
         "start_detached",
         record_app_start,
     )
@@ -178,12 +174,12 @@ def test_frozen_launcher_main_uses_invoked_installed_bundle_path(
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "_MEIPASS", str(unrelated_bundle), raising=False)
     monkeypatch.setattr(
-        launcher_app,
+        splash_session_module,
         "start_launcher_splash_session",
         lambda *, layout, locale_identifier: None,
     )
     monkeypatch.setattr(
-        launcher_app,
+        installed_app_handoff,
         "start_detached",
         lambda command, *, environment: started_commands.append(list(command)),
     )

--- a/tests/launcher/application_launch/test_startup_plan.py
+++ b/tests/launcher/application_launch/test_startup_plan.py
@@ -33,6 +33,7 @@ from launcher.sugarsubstitute_launcher.install_layout import (
 from launcher.sugarsubstitute_launcher.startup_plan import (
     is_installed_app_launchable,
     resolve_install_root,
+    resolve_startup_candidate,
     resolve_startup_plan,
     should_launch_installed_app,
 )
@@ -41,6 +42,33 @@ from sugarsubstitute_shared.installer_qualification import (
     InstallerQualificationPlan,
 )
 from tests.launcher.support import write_launcher_executable
+
+
+def test_startup_candidate_does_not_read_installed_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Splash route discovery must defer config parsing until after visibility."""
+
+    layout = InstallLayout.from_root(tmp_path / "SugarSubstitute")
+    layout.config_path.parent.mkdir(parents=True)
+    layout.config_path.write_text("not-json", encoding="utf-8")
+    write_launcher_executable(layout)
+
+    def reject_config_load(_cls: type[LauncherConfig], _path: Path) -> LauncherConfig:
+        """Fail if candidate resolution crosses the post-splash boundary."""
+
+        pytest.fail("Startup candidate resolution must not load config.json.")
+
+    monkeypatch.setattr(LauncherConfig, "load", classmethod(reject_config_load))
+
+    candidate = resolve_startup_candidate(
+        explicit_install_root=None,
+        executable_path=layout.executable_path,
+    )
+
+    assert candidate.layout == layout
+    assert candidate.installed_config_found is True
 
 
 def test_launcher_resolves_installed_exe_parent_as_install_root(

--- a/tests/launcher/application_launch/test_update_handoff.py
+++ b/tests/launcher/application_launch/test_update_handoff.py
@@ -27,6 +27,8 @@ from unittest.mock import ANY
 import pytest
 
 from launcher.sugarsubstitute_launcher import app as launcher_app
+from launcher.sugarsubstitute_launcher import installed_app_handoff
+from launcher.sugarsubstitute_launcher import splash_session as splash_session_module
 from launcher.sugarsubstitute_launcher.config import (
     DEFAULT_RELEASE_MANIFEST_URL,
     LauncherConfig,
@@ -104,20 +106,31 @@ def test_launcher_main_runs_pre_launch_update_before_app_handoff(
                 failure_reason=failure_reason,
             )
 
+    def record_splash_start(**_kwargs: object) -> object:
+        """Record that visibility precedes logging, updates, and app handoff."""
+
+        calls.append("splash")
+        return splash_session
+
     monkeypatch.setattr(sys, "executable", str(layout.executable_path))
     monkeypatch.setenv(STARTUP_REMOTE_DEGRADED_ENV, "1")
     monkeypatch.setattr(
-        launcher_app,
+        installed_app_handoff,
         "LauncherUpdateOrchestrator",
         _FakeUpdateOrchestrator,
     )
     monkeypatch.setattr(
-        launcher_app,
+        splash_session_module,
         "start_launcher_splash_session",
-        lambda *, layout, locale_identifier: splash_session,
+        record_splash_start,
     )
     monkeypatch.setattr(
         launcher_app,
+        "_configure_normal_logging",
+        lambda _startup_plan: calls.append("logging"),
+    )
+    monkeypatch.setattr(
+        installed_app_handoff,
         "start_detached",
         record_app_start,
     )
@@ -129,6 +142,8 @@ def test_launcher_main_runs_pre_launch_update_before_app_handoff(
 
     assert launcher_app.main([]) == 0
     assert calls == [
+        "splash",
+        "logging",
         "update",
         "launch",
         subprocess_path(layout.runtime_python),
@@ -189,22 +204,22 @@ def test_launcher_main_hands_off_pending_launcher_update_instead_of_app(
 
     monkeypatch.setattr(sys, "executable", str(layout.executable_path))
     monkeypatch.setattr(
-        launcher_app,
+        installed_app_handoff,
         "LauncherUpdateOrchestrator",
         _FakeUpdateOrchestrator,
     )
     monkeypatch.setattr(
-        launcher_app,
+        splash_session_module,
         "start_launcher_splash_session",
         lambda *, layout, locale_identifier: splash_session,
     )
     monkeypatch.setattr(
-        launcher_app,
+        installed_app_handoff,
         "schedule_launcher_update",
         schedule_update,
     )
     monkeypatch.setattr(
-        launcher_app,
+        installed_app_handoff,
         "start_detached",
         lambda _command: pytest.fail("The old launcher must not start the app."),
     )

--- a/tests/launcher/headless_imports/test_app_import.py
+++ b/tests/launcher/headless_imports/test_app_import.py
@@ -27,8 +27,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-def test_launcher_app_import_succeeds_without_pyside6() -> None:
-    """Headless startup must not load Qt before selecting an execution mode."""
+def test_launcher_app_import_loads_only_the_splash_routing_surface() -> None:
+    """Importing the entrypoint must not eagerly load post-splash owners."""
 
     script = textwrap.dedent(
         """
@@ -46,6 +46,12 @@ def test_launcher_app_import_succeeds_without_pyside6() -> None:
             name == "PySide6" or name.startswith("PySide6.")
             for name in sys.modules
         )
+        forbidden_modules = {
+            "launcher.sugarsubstitute_launcher.config",
+            "launcher.sugarsubstitute_launcher.installed_app_handoff",
+            "launcher.sugarsubstitute_launcher.update_orchestrator",
+        }
+        assert forbidden_modules.isdisjoint(sys.modules)
         """
     )
 

--- a/tests/launcher/support.py
+++ b/tests/launcher/support.py
@@ -24,7 +24,7 @@ from typing import cast
 from PySide6.QtWidgets import QApplication
 from pytest import MonkeyPatch
 
-from launcher.sugarsubstitute_launcher import app as launcher_app
+from launcher.sugarsubstitute_launcher import localization as launcher_localization
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from sugarsubstitute_shared.localization import LanguagePreference, resolve_locale
 
@@ -43,12 +43,12 @@ def configure_deterministic_launcher_localization(monkeypatch: MonkeyPatch) -> N
 
     resolved = resolve_locale(LanguagePreference.explicit("en"), ui_languages=())
     monkeypatch.setattr(
-        launcher_app,
+        launcher_localization,
         "resolve_launcher_locale",
         lambda _layout, *, locale_override: resolved,
     )
     monkeypatch.setattr(
-        launcher_app,
+        launcher_localization,
         "build_launcher_localization_runtime",
         lambda _application, **_kwargs: SimpleNamespace(
             manager=object(),

--- a/tests/shared/localization/test_system_languages.py
+++ b/tests/shared/localization/test_system_languages.py
@@ -1,0 +1,74 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify Qt-free operating-system UI-language discovery."""
+
+from __future__ import annotations
+
+import locale
+import pytest
+
+from sugarsubstitute_shared.localization import system_languages
+
+
+def test_system_ui_languages_preserve_platform_precedence_without_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Splash localization should receive stable, ordered locale candidates."""
+
+    monkeypatch.setenv("LANGUAGE", "ja:es_ES:JA")
+    monkeypatch.setenv("LC_ALL", "ko_KR.UTF-8")
+    monkeypatch.setenv("LC_MESSAGES", "es_ES")
+    monkeypatch.setenv("LANG", "en_US.UTF-8")
+    monkeypatch.setattr(
+        system_languages,
+        "_windows_ui_language_candidates",
+        lambda: ("zh-CN", "ja"),
+    )
+    monkeypatch.setattr(locale, "getlocale", lambda: ("en_US", "UTF-8"))
+
+    assert system_languages.system_ui_languages() == (
+        "ja",
+        "es_ES",
+        "ko_KR.UTF-8",
+        "en_US.UTF-8",
+        "zh-CN",
+        "en_US",
+    )
+
+
+def test_system_ui_languages_tolerate_unconfigured_locale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty machine locale should leave resolver fallback authoritative."""
+
+    for variable_name in ("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"):
+        monkeypatch.delenv(variable_name, raising=False)
+    monkeypatch.setattr(
+        system_languages,
+        "_windows_ui_language_candidates",
+        lambda: (),
+    )
+    monkeypatch.setattr(locale, "getlocale", lambda: (None, None))
+
+    assert system_languages.system_ui_languages() == ()
+
+
+@pytest.mark.platforms("windows")
+def test_windows_ui_language_candidates_are_available() -> None:
+    """Windows startup should resolve at least one kernel-owned UI language."""
+
+    assert system_languages._windows_ui_language_candidates()

--- a/tools/check_splash_first_startup.py
+++ b/tools/check_splash_first_startup.py
@@ -1,0 +1,45 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Enforce splash-first startup across executable entrypoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.splash_first_governance import validate_repository
+
+
+def main() -> int:
+    """Print splash-first diagnostics and return the repository gate status."""
+
+    repository_root = Path(__file__).resolve().parents[1]
+    diagnostics = validate_repository(repository_root)
+    for diagnostic in diagnostics:
+        relative_path = diagnostic.path.relative_to(repository_root)
+        print(
+            f"{relative_path}:{diagnostic.line}: error {diagnostic.code}: "
+            f"{diagnostic.message}"
+        )
+    if diagnostics:
+        print(f"FAILED: Found {len(diagnostics)} splash-first startup violation(s).")
+        return 1
+    print("Splash-first startup contracts passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/splash_first_governance/__init__.py
+++ b/tools/splash_first_governance/__init__.py
@@ -1,0 +1,33 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Expose repository splash-first startup governance."""
+
+from tools.splash_first_governance.checker import (
+    SplashFirstContract,
+    SplashFirstDiagnostic,
+    repository_contracts,
+    validate_contract_source,
+    validate_repository,
+)
+
+__all__ = [
+    "SplashFirstContract",
+    "SplashFirstDiagnostic",
+    "repository_contracts",
+    "validate_contract_source",
+    "validate_repository",
+]

--- a/tools/splash_first_governance/checker.py
+++ b/tools/splash_first_governance/checker.py
@@ -1,0 +1,353 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Reject unreviewed executable work before launch-splash visibility."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.splash_first_governance.source_flow import (
+    call_name,
+    calls,
+    calls_without_nested_functions,
+    find_function,
+    imports,
+    nodes_on_boundary_path,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SplashFirstContract:
+    """Describe one executable function and its reviewed splash boundary."""
+
+    relative_path: Path
+    function_name: str
+    boundary_call: str
+    allowed_module_import_roots: frozenset[str]
+    allowed_pre_boundary_imports: frozenset[str]
+    allowed_pre_boundary_calls: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class SplashFirstDiagnostic:
+    """Identify one source location that violates splash-first startup."""
+
+    path: Path
+    line: int
+    code: str
+    message: str
+
+
+def repository_contracts() -> tuple[SplashFirstContract, ...]:
+    """Return the authoritative executable startup contracts."""
+
+    stdlib_roots = frozenset(
+        {
+            "__future__",
+            "collections",
+            "logging",
+            "os",
+            "pathlib",
+            "sys",
+            "time",
+            "typing",
+        }
+    )
+    return (
+        SplashFirstContract(
+            relative_path=Path("main.py"),
+            function_name="main",
+            boundary_call="start_early_launch_splash",
+            allowed_module_import_roots=stdlib_roots,
+            allowed_pre_boundary_imports=frozenset(
+                {
+                    "substitute.app.bootstrap.early_launch_splash",
+                    "sugarsubstitute_shared.localization",
+                }
+            ),
+            allowed_pre_boundary_calls=frozenset(
+                {
+                    "Path",
+                    "Path.resolve",
+                    "_enter_application_launch_guard",
+                    "resolve",
+                    "resolve_early_startup_locale",
+                    "start_early_launch_splash",
+                    "system_ui_languages",
+                    "time.perf_counter",
+                }
+            ),
+        ),
+        SplashFirstContract(
+            relative_path=Path("launcher/sugarsubstitute_launcher/app.py"),
+            function_name="main",
+            boundary_call="start_launcher_splash_session",
+            allowed_module_import_roots=stdlib_roots,
+            allowed_pre_boundary_imports=frozenset(
+                {
+                    "launcher.sugarsubstitute_launcher.application_launch",
+                    "launcher.sugarsubstitute_launcher.cli",
+                    "launcher.sugarsubstitute_launcher.localization",
+                    "launcher.sugarsubstitute_launcher.splash_session",
+                    "launcher.sugarsubstitute_launcher.startup_plan",
+                    "sugarsubstitute_shared.localization",
+                }
+            ),
+            allowed_pre_boundary_calls=frozenset(
+                {
+                    "Path",
+                    "Path.cwd",
+                    "_frozen_invocation_path",
+                    "_frozen_support_path",
+                    "_native_frozen_executable_path",
+                    "enter_installed_application_launch",
+                    "format_locale_argument",
+                    "parse_launcher_args",
+                    "resolve_launcher_locale",
+                    "resolve_startup_candidate",
+                    "should_attempt_installed_app_launch",
+                    "start_launcher_splash_session",
+                }
+            ),
+        ),
+    )
+
+
+def validate_repository(repository_root: Path) -> tuple[SplashFirstDiagnostic, ...]:
+    """Validate every executable contract against repository source."""
+
+    diagnostics: list[SplashFirstDiagnostic] = []
+    for contract in repository_contracts():
+        path = repository_root / contract.relative_path
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as error:
+            diagnostics.append(
+                SplashFirstDiagnostic(
+                    path=path,
+                    line=1,
+                    code="SPLASH001",
+                    message=f"cannot read protected startup source: {error}",
+                )
+            )
+            continue
+        diagnostics.extend(
+            validate_contract_source(source, contract=contract, path=path)
+        )
+    return tuple(diagnostics)
+
+
+def validate_contract_source(
+    source: str,
+    *,
+    contract: SplashFirstContract,
+    path: Path,
+) -> tuple[SplashFirstDiagnostic, ...]:
+    """Return deterministic diagnostics for one protected startup function."""
+
+    try:
+        module = ast.parse(source, filename=str(path))
+    except SyntaxError as error:
+        return (
+            SplashFirstDiagnostic(
+                path=path,
+                line=error.lineno or 1,
+                code="SPLASH001",
+                message=f"cannot parse protected startup source: {error.msg}",
+            ),
+        )
+
+    diagnostics = _module_import_diagnostics(module, contract=contract, path=path)
+    diagnostics.extend(
+        _module_execution_diagnostics(module, contract=contract, path=path)
+    )
+    function = find_function(module, contract.function_name)
+    if function is None:
+        diagnostics.append(
+            SplashFirstDiagnostic(
+                path=path,
+                line=1,
+                code="SPLASH001",
+                message=(
+                    f"protected startup function is missing: {contract.function_name}"
+                ),
+            )
+        )
+        return tuple(diagnostics)
+
+    boundary_calls = tuple(
+        call
+        for call in calls_without_nested_functions(function)
+        if call_name(call) == contract.boundary_call
+    )
+    if len(boundary_calls) != 1:
+        diagnostics.append(
+            SplashFirstDiagnostic(
+                path=path,
+                line=function.lineno,
+                code="SPLASH001",
+                message=(
+                    "protected startup function must contain exactly one "
+                    f"{contract.boundary_call}() visibility boundary; found "
+                    f"{len(boundary_calls)}"
+                ),
+            )
+        )
+        return tuple(diagnostics)
+
+    boundary = boundary_calls[0]
+    pre_boundary_nodes = nodes_on_boundary_path(function, boundary)
+    for imported_name, node in imports(pre_boundary_nodes):
+        if _matches_import(imported_name, contract.allowed_pre_boundary_imports):
+            continue
+        diagnostics.append(
+            SplashFirstDiagnostic(
+                path=path,
+                line=node.lineno,
+                code="SPLASH003",
+                message=(
+                    f"unreviewed pre-splash import {imported_name!r}; move it after "
+                    f"{contract.boundary_call}() or add an explicitly reviewed owner"
+                ),
+            )
+        )
+
+    for call in calls(pre_boundary_nodes):
+        if call is boundary:
+            continue
+        reviewed_call_name = call_name(call)
+        if reviewed_call_name in contract.allowed_pre_boundary_calls:
+            continue
+        diagnostics.append(
+            SplashFirstDiagnostic(
+                path=path,
+                line=call.lineno,
+                code="SPLASH004",
+                message=(
+                    "unreviewed pre-splash call "
+                    f"{reviewed_call_name or '<dynamic>'}(); "
+                    f"move it after {contract.boundary_call}()"
+                ),
+            )
+        )
+    return tuple(
+        sorted(diagnostics, key=lambda item: (item.line, item.code, item.message))
+    )
+
+
+def _module_import_diagnostics(
+    module: ast.Module,
+    *,
+    contract: SplashFirstContract,
+    path: Path,
+) -> list[SplashFirstDiagnostic]:
+    """Reject eager project and third-party imports in protected entry modules."""
+
+    diagnostics: list[SplashFirstDiagnostic] = []
+    for statement in module.body:
+        if not isinstance(statement, (ast.Import, ast.ImportFrom)):
+            continue
+        for imported_name, node in imports((statement,)):
+            root = imported_name.split(".", maxsplit=1)[0]
+            if root in contract.allowed_module_import_roots:
+                continue
+            diagnostics.append(
+                SplashFirstDiagnostic(
+                    path=path,
+                    line=node.lineno,
+                    code="SPLASH002",
+                    message=(
+                        f"eager import {imported_name!r} runs before splash routing; "
+                        "import it inside the owning post-splash path"
+                    ),
+                )
+            )
+    return diagnostics
+
+
+def _module_execution_diagnostics(
+    module: ast.Module,
+    *,
+    contract: SplashFirstContract,
+    path: Path,
+) -> list[SplashFirstDiagnostic]:
+    """Reject import-time calls outside the protected entrypoint function."""
+
+    diagnostics: list[SplashFirstDiagnostic] = []
+    for statement in module.body:
+        if isinstance(
+            statement,
+            (ast.Import, ast.ImportFrom, ast.FunctionDef, ast.AsyncFunctionDef),
+        ):
+            continue
+        if _is_type_checking_block(statement) or _is_main_dispatch(
+            statement,
+            function_name=contract.function_name,
+        ):
+            continue
+        for call in calls((statement,)):
+            diagnostics.append(
+                SplashFirstDiagnostic(
+                    path=path,
+                    line=call.lineno,
+                    code="SPLASH005",
+                    message=(
+                        f"import-time call {call_name(call) or '<dynamic>'}() runs "
+                        "before splash routing; move it inside the reviewed entrypoint"
+                    ),
+                )
+            )
+    return diagnostics
+
+
+def _is_type_checking_block(statement: ast.stmt) -> bool:
+    """Return whether one module statement is a static-only import block."""
+
+    return (
+        isinstance(statement, ast.If)
+        and isinstance(statement.test, ast.Name)
+        and (statement.test.id == "TYPE_CHECKING")
+    )
+
+
+def _is_main_dispatch(statement: ast.stmt, *, function_name: str) -> bool:
+    """Return whether one statement only dispatches the protected entrypoint."""
+
+    if not isinstance(statement, ast.If) or statement.orelse:
+        return False
+    statement_calls = tuple(calls(statement.body))
+    return len(statement_calls) == 1 and call_name(statement_calls[0]) == function_name
+
+
+def _matches_import(imported_name: str, allowed_names: frozenset[str]) -> bool:
+    """Return whether an import is the reviewed module or one of its children."""
+
+    return any(
+        imported_name == allowed or imported_name.startswith(f"{allowed}.")
+        for allowed in allowed_names
+    )
+
+
+__all__ = [
+    "SplashFirstContract",
+    "SplashFirstDiagnostic",
+    "repository_contracts",
+    "validate_contract_source",
+    "validate_repository",
+]

--- a/tools/splash_first_governance/source_flow.py
+++ b/tools/splash_first_governance/source_flow.py
@@ -1,0 +1,218 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Trace executable source that can run before a reviewed splash boundary."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable, Sequence
+
+
+def find_function(
+    module: ast.Module,
+    function_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Return one top-level protected function by exact name."""
+
+    for statement in module.body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            statement.name == function_name
+        ):
+            return statement
+    return None
+
+
+def calls_without_nested_functions(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> Iterable[ast.Call]:
+    """Yield calls owned directly by a function body."""
+
+    for statement in function.body:
+        yield from calls((statement,))
+
+
+def calls(nodes: Iterable[ast.AST]) -> Iterable[ast.Call]:
+    """Yield calls without descending into nested callable definitions."""
+
+    stack = list(nodes)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.Call):
+            yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def imports(
+    nodes: Iterable[ast.AST],
+) -> Iterable[tuple[str, ast.Import | ast.ImportFrom]]:
+    """Yield imported module names without entering nested callables."""
+
+    stack = list(nodes)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name, node
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            yield node.module, node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def call_name(call: ast.Call) -> str:
+    """Return the source-qualified name of one call target."""
+
+    return _expression_name(call.func)
+
+
+def nodes_on_boundary_path(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    boundary: ast.Call,
+) -> tuple[ast.AST, ...]:
+    """Return nodes that can execute before the boundary on its control-flow path."""
+
+    selected: list[ast.AST] = []
+    _collect_path_prefix(function.body, boundary=boundary, selected=selected)
+    selected.extend(boundary.args)
+    selected.extend(keyword.value for keyword in boundary.keywords)
+    selected.append(boundary)
+    return tuple(selected)
+
+
+def _expression_name(expression: ast.expr) -> str:
+    """Return a dotted name for a simple name or attribute expression."""
+
+    if isinstance(expression, ast.Name):
+        return expression.id
+    if isinstance(expression, ast.Attribute):
+        owner = _expression_name(expression.value)
+        return f"{owner}.{expression.attr}" if owner else expression.attr
+    return ""
+
+
+def _collect_path_prefix(
+    statements: Sequence[ast.stmt],
+    *,
+    boundary: ast.Call,
+    selected: list[ast.AST],
+) -> bool:
+    """Collect statements on the unique lexical path to a boundary call."""
+
+    for statement in statements:
+        if _contains_node(statement, boundary):
+            return _collect_inside_statement(
+                statement,
+                boundary=boundary,
+                selected=selected,
+            )
+        if isinstance(statement, ast.If) and _body_always_terminates(statement.body):
+            selected.append(statement.test)
+            selected.extend(statement.orelse)
+            continue
+        selected.append(statement)
+    return False
+
+
+def _collect_inside_statement(
+    statement: ast.stmt,
+    *,
+    boundary: ast.Call,
+    selected: list[ast.AST],
+) -> bool:
+    """Descend through the branch that contains the splash boundary."""
+
+    if isinstance(statement, ast.If):
+        selected.append(statement.test)
+        branch: Sequence[ast.stmt] = (
+            statement.body
+            if any(_contains_node(child, boundary) for child in statement.body)
+            else statement.orelse
+        )
+        return _collect_path_prefix(branch, boundary=boundary, selected=selected)
+    if isinstance(statement, (ast.For, ast.AsyncFor, ast.While)):
+        selected.append(
+            statement.target
+            if isinstance(statement, (ast.For, ast.AsyncFor))
+            else statement.test
+        )
+        if isinstance(statement, (ast.For, ast.AsyncFor)):
+            selected.append(statement.iter)
+        branch = (
+            statement.body
+            if any(_contains_node(child, boundary) for child in statement.body)
+            else statement.orelse
+        )
+        return _collect_path_prefix(branch, boundary=boundary, selected=selected)
+    if isinstance(statement, (ast.With, ast.AsyncWith)):
+        selected.extend(statement.items)
+        return _collect_path_prefix(
+            statement.body,
+            boundary=boundary,
+            selected=selected,
+        )
+    if isinstance(statement, ast.Try):
+        branches: tuple[Sequence[ast.stmt], ...] = (
+            statement.body,
+            statement.orelse,
+            statement.finalbody,
+            *(handler.body for handler in statement.handlers),
+        )
+        for branch in branches:
+            if any(_contains_node(child, boundary) for child in branch):
+                return _collect_path_prefix(
+                    branch,
+                    boundary=boundary,
+                    selected=selected,
+                )
+    selected.append(statement)
+    return True
+
+
+def _body_always_terminates(statements: Sequence[ast.stmt]) -> bool:
+    """Return whether a branch cannot continue to a following splash boundary."""
+
+    if not statements:
+        return False
+    terminal = statements[-1]
+    if isinstance(terminal, (ast.Return, ast.Raise)):
+        return True
+    if isinstance(terminal, ast.If):
+        return (
+            bool(terminal.orelse)
+            and _body_always_terminates(terminal.body)
+            and _body_always_terminates(terminal.orelse)
+        )
+    return False
+
+
+def _contains_node(root: ast.AST, target: ast.AST) -> bool:
+    """Return whether one AST node contains another by identity."""
+
+    return any(node is target for node in ast.walk(root))
+
+
+__all__ = [
+    "call_name",
+    "calls",
+    "calls_without_nested_functions",
+    "find_function",
+    "imports",
+    "nodes_on_boundary_path",
+]


### PR DESCRIPTION
## Summary
- establish one reviewed splash-first boundary for launcher and direct application startup
- defer configuration parsing, logging, update orchestration, and full bootstrap composition until the splash is visible
- enforce the boundary with control-flow-aware static analysis in pre-commit and CI
- resolve splash locale without eagerly importing Qt

## Verification
- packaged Windows launcher showed the native `Loading...` window before handoff on three consecutive double-click-path launches
- `ruff format .`
- `ruff check .`
- `mypy --strict substitute tests`
- full parallel test lane
- all 85 isolated test modules
- serial test lane
- architecture, test-governance, and splash-first gates