### PR TITLE
fix(canvas): preserve generated images through memory contention

### DIFF
--- a/requirements-toolchain.lock
+++ b/requirements-toolchain.lock
@@ -671,9 +671,9 @@ cuda-pathfinder==1.7.0 ; python_full_version < '3.15' and sys_platform == 'linux
 cuda-toolkit==13.0.3.0 ; sys_platform == 'linux' \
     --hash=sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f
     # via torch
-cutecanvas==1.0.3 \
-    --hash=sha256:066b60c9fb08a30c61666a34eebe666c2a4cc4324d00f447ad60c765e16ed02f \
-    --hash=sha256:8eb05fcc9cffeabc82e7f287a853c2f36d5460718c322a911d0182709f199565
+cutecanvas==1.0.6 \
+    --hash=sha256:5a819da67149c363c19880a4b1f6c6ebdecca66134bebf29511cdd2ae4d45953 \
+    --hash=sha256:d8c72ce8bb568a3b9cc32441d78b7a7c925d1dfd932854ffb8f1a3d4a0d88557
     # via -r requirements.txt
 cyclonedx-python-lib==11.12.0 \
     --hash=sha256:0e807521a921a5c3cb8ce1153f8a61d29eedfe76a46aac2796b7c6b573391a54 \
@@ -695,11 +695,11 @@ execnet==2.1.2 \
     --hash=sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd \
     --hash=sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec
     # via pytest-xdist
-ferrastra==1.0.1 \
-    --hash=sha256:15cbca08a9cce71c9e5c50057623655b732b9d90becfbea7346313ce3638cfd2 \
-    --hash=sha256:405cef49f23999029544086a263045d7d2c857024b8254d8f1ef7365ec44b100 \
-    --hash=sha256:436b9665cb33da14480603e121054867052c29bde2d42118c83780b080e3f9a2 \
-    --hash=sha256:fe29c538ccba90d6381986c1ac2ca25050d04fc7939e2e8ea1f6bac59d507ae2
+ferrastra==1.0.2 \
+    --hash=sha256:5177757ce511771703eb5eb941533bd6003589256c7c5adf7e92381b74a03a2c \
+    --hash=sha256:91257d41bd8a4d88b6cf5c42eee610d640dd960ed03a4bae1def5b090ed31619 \
+    --hash=sha256:b62fb18ef3993f45221d232bbcf20df9c6271a9d6c3de028ecb0f39ee0148b37 \
+    --hash=sha256:b909eeaf814c563d8f58d37d2d848ef4c1523fb8c5dbe17696b39f690727861c
     # via
     #   -r requirements.txt
     #   cutecanvas
@@ -3935,9 +3935,9 @@ pyyaml==6.0.3 \
     #   huggingface-hub
     #   pre-commit
     #   timm
-qpane==3.0.2 \
-    --hash=sha256:b5964c47acc8142ac4e076fd3949dbb9471c7e29062123a235f1cfbaafead877 \
-    --hash=sha256:c4e2f732be8748f44e170769f35e60751154337a287e2f7c2eb2d1411c7164ec
+qpane==3.0.4 \
+    --hash=sha256:72712817c8734d2b7a305d3e8585efd3212dad5cdd469964707fd58884730b8b \
+    --hash=sha256:7441e7d42a78c0a20916e8b26e0dbec699003f167c33893a500343f3d150c292
     # via
     #   -r requirements.txt
     #   cutecanvas

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@
 PySide6==6.11.1
 PySide6-Fluent-Widgets[full]==1.11.3
 PySideSix-Frameless-Window==0.8.2
-ferrastra==1.0.1
-qpane==3.0.2
-cutecanvas[sam]==1.0.3
+ferrastra==1.0.2
+qpane==3.0.4
+cutecanvas[sam]==1.0.6
 
 # Networking and IO
 requests==2.34.2

--- a/substitute/presentation/shell/output_image_commit_pipeline.py
+++ b/substitute/presentation/shell/output_image_commit_pipeline.py
@@ -61,6 +61,11 @@ class PreparedOutputImage:
     request: OutputImageCommitRequest
     image: QImage
 
+    def __post_init__(self) -> None:
+        """Reject any prepared result that cannot present authoritative pixels."""
+        if not isinstance(self.image, QImage) or self.image.isNull():
+            raise ValueError("prepared output image must contain valid pixels")
+
 
 @dataclass(frozen=True, slots=True)
 class FailedOutputImagePreparation:

--- a/substitute/presentation/shell/output_image_commit_queue.py
+++ b/substitute/presentation/shell/output_image_commit_queue.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Callable
 
-from PySide6.QtCore import QObject, QTimer
+from PySide6.QtCore import QObject, QTimer, Signal
 
 from substitute.application.workflows.output_canvas_state_service import (
     OutputImageRegistrationResult,
@@ -42,6 +42,8 @@ from substitute.presentation.ui_load_activity import (
 class PreparedOutputCommitQueue(QObject):
     """Commit prepared outputs in bounded GUI-thread batches."""
 
+    capacity_available = Signal()
+
     def __init__(
         self,
         *,
@@ -53,6 +55,7 @@ class PreparedOutputCommitQueue(QObject):
         parent: QObject | None = None,
         interval_ms: int = 0,
         batch_size: int = 1,
+        max_prepared: int = 2,
         output_activity_marker: Callable[[str], None] | None = None,
     ) -> None:
         """Initialize FIFO commit queues and a GUI-thread drain timer."""
@@ -67,6 +70,7 @@ class PreparedOutputCommitQueue(QObject):
         self._prepared: deque[PreparedOutputImage] = deque()
         self._failed: deque[FailedOutputImagePreparation] = deque()
         self._batch_size = max(1, int(batch_size))
+        self._max_prepared = max(1, int(max_prepared))
         self._timer = QTimer(self)
         self._timer.setSingleShot(True)
         self._timer.setInterval(max(0, int(interval_ms)))
@@ -75,6 +79,8 @@ class PreparedOutputCommitQueue(QObject):
     def enqueue_prepared(self, output: PreparedOutputImage) -> None:
         """Queue one prepared output for GUI-thread commit."""
 
+        if not self.available_prepared_slots():
+            raise RuntimeError("prepared output queue capacity was not reserved")
         self._prepared.append(output)
         self._schedule()
 
@@ -104,6 +110,7 @@ class PreparedOutputCommitQueue(QObject):
                     registered_image_id=result.projection_intent.registered_image_id,
                 )
             committed += 1
+            self.capacity_available.emit()
         if self._failed or self._prepared:
             self._schedule()
         if failed_pending_before or prepared_pending_before:
@@ -113,6 +120,10 @@ class PreparedOutputCommitQueue(QObject):
         """Return total queued prepared and failed outputs."""
 
         return len(self._prepared) + len(self._failed)
+
+    def available_prepared_slots(self) -> int:
+        """Return decoded-image slots available for dispatcher reservation."""
+        return max(0, self._max_prepared - len(self._prepared))
 
     def _schedule(self) -> None:
         """Start the commit timer if it is idle."""

--- a/substitute/presentation/shell/output_image_pipeline.py
+++ b/substitute/presentation/shell/output_image_pipeline.py
@@ -147,6 +147,12 @@ class OutputImagePipeline(QObject):
             self._commit_queue.enqueue_prepared
         )
         self._preparation_dispatcher.failed.connect(self._commit_queue.enqueue_failed)
+        self._commit_queue.capacity_available.connect(
+            self._preparation_dispatcher.resume
+        )
+        self._preparation_dispatcher.set_prepared_capacity(
+            self._commit_queue.available_prepared_slots
+        )
         self._connect_canvas_route_changes()
 
     def _project_active_output_projection(

--- a/substitute/presentation/shell/output_image_preparation_dispatcher.py
+++ b/substitute/presentation/shell/output_image_preparation_dispatcher.py
@@ -110,6 +110,8 @@ class OutputImagePreparationDispatcher(QObject):
         self._request_ids = count(1)
         self._close_submitter = close_submitter
         self._queued_preparations: deque[_QueuedOutputPreparation] = deque()
+        self._prepared_capacity: Callable[[], int] | None = None
+        self._inflight_preparations = 0
         self._is_shutdown = False
         self._task_scope = TaskScope(
             submitter=submitter,
@@ -155,6 +157,15 @@ class OutputImagePreparationDispatcher(QObject):
         )
         self._drain_queued_preparations()
 
+    def set_prepared_capacity(self, capacity: Callable[[], int]) -> None:
+        """Install decoded-output capacity and resume safely retained work."""
+        self._prepared_capacity = capacity
+        self._drain_queued_preparations()
+
+    def resume(self) -> None:
+        """Resume retained preparation after a decoded output is committed."""
+        self._drain_queued_preparations()
+
     def shutdown(self) -> None:
         """Cancel pending preparation work and release dispatcher ownership."""
 
@@ -174,6 +185,11 @@ class OutputImagePreparationDispatcher(QObject):
         if self._is_shutdown:
             return
         while self._queued_preparations:
+            if (
+                self._prepared_capacity is not None
+                and self._inflight_preparations >= self._prepared_capacity()
+            ):
+                return
             queued = self._queued_preparations.popleft()
             try:
                 handle = self._task_scope.submit(queued.task_request)
@@ -184,6 +200,7 @@ class OutputImagePreparationDispatcher(QObject):
             except Exception as error:
                 self._publish_submission_failure(queued.commit_request, error)
                 continue
+            self._inflight_preparations += 1
 
             def publish_outcome(
                 outcome: TaskOutcome[
@@ -238,6 +255,7 @@ class OutputImagePreparationDispatcher(QObject):
     ) -> None:
         """Publish one settled output and admit retained work immediately."""
 
+        self._inflight_preparations = max(0, self._inflight_preparations - 1)
         self._publish_outcome(outcome, request)
         self._drain_queued_preparations()
 
@@ -271,8 +289,9 @@ def prepare_output_image(
     request: OutputImageCommitRequest,
     *,
     loader: OutputImageLoader,
+    detach: Callable[[QImage], QImage] | None = None,
 ) -> PreparedOutputImage | FailedOutputImagePreparation:
-    """Load and detach one output image without touching widgets."""
+    """Load and transactionally detach one output image without touching widgets."""
 
     started_at = perf_counter()
     try:
@@ -298,7 +317,22 @@ def prepare_output_image(
                 detail="Image decoder returned no image data.",
             )
 
-        detached = image.copy()
+        detached = image.copy() if detach is None else detach(image)
+        if detached.isNull():
+            log_warning(
+                _LOGGER,
+                "Failed to prepare output image because pixel detachment was rejected",
+                workflow_id=request.workflow_id,
+                node_id=request.node_id,
+                path=request.file_path,
+                source_key=request.source_key,
+                scene_key=request.scene_key,
+            )
+            return FailedOutputImagePreparation(
+                request=request,
+                message=app_text("Failed to load generated image."),
+                detail="Image pixel allocation was rejected by the operating system.",
+            )
         log_timing(
             _LOGGER,
             "Prepared output image",

--- a/tests/crosscutting/dependencies/test_cutecanvas_contract.py
+++ b/tests/crosscutting/dependencies/test_cutecanvas_contract.py
@@ -54,9 +54,9 @@ def test_runtime_requirements_pin_the_complete_canvas_stack() -> None:
 
     requirements = (_ROOT / "requirements.txt").read_text(encoding="utf-8")
 
-    assert "cutecanvas[sam]==1.0.3" in requirements
-    assert "qpane==3.0.2" in requirements
-    assert "ferrastra==1.0.1" in requirements
+    assert "cutecanvas[sam]==1.0.6" in requirements
+    assert "qpane==3.0.4" in requirements
+    assert "ferrastra==1.0.2" in requirements
 
 
 def test_cutecanvas_exposes_the_required_edit_session_facade() -> None:

--- a/tests/presentation/canvas/output/real_shell/test_grid_reflow.py
+++ b/tests/presentation/canvas/output/real_shell/test_grid_reflow.py
@@ -95,6 +95,7 @@ def test_five_landscape_tiles_reflow_across_wide_square_and_tall_extents(
             ),
         )
     harness.wait_for_output_count("alpha", 5)
+    harness.wait_until(lambda: len(harness.fingerprint().grid_target_frames) == 5)
     observed: list[tuple[int, int] | None] = []
     for width, height in ((1400.0, 450.0), (800.0, 800.0), (450.0, 1400.0)):
         previous_snapshot = harness.shell.output_canvas.workspace.gridSnapshot()

--- a/tests/presentation/shell/output_image_commit_queue/test_queue.py
+++ b/tests/presentation/shell/output_image_commit_queue/test_queue.py
@@ -144,6 +144,39 @@ def test_commit_queue_prioritizes_failed_preparation_within_batch_bound() -> Non
     assert queue.pending_count() == 0
 
 
+def test_commit_queue_reports_capacity_only_after_decoded_pixels_leave() -> None:
+    """The decode dispatcher must receive capacity after a prepared image commits."""
+
+    _app()
+
+    def ignore_projection(_workflow_id: str, _image_id: object = None) -> None:
+        """Ignore projection while exercising decoded-image capacity."""
+
+    scheduler = CanvasProjectionScheduler(
+        project_workflow=ignore_projection,
+        active_workflow_id=lambda: "wf",
+        output_canvas_visible=lambda: True,
+    )
+    queue = PreparedOutputCommitQueue(
+        commit_prepared=lambda _prepared: None,
+        handle_failure=lambda _failure: None,
+        projection_scheduler=scheduler,
+        max_prepared=1,
+    )
+    capacity_events: list[int] = []
+    queue.capacity_available.connect(
+        lambda: capacity_events.append(queue.available_prepared_slots())
+    )
+    queue.enqueue_prepared(_prepared("first"))
+
+    assert queue.available_prepared_slots() == 0
+
+    queue.drain_once()
+
+    assert queue.available_prepared_slots() == 1
+    assert capacity_events == [1]
+
+
 def _prepared(node_id: str) -> PreparedOutputImage:
     """Return a prepared output DTO for commit queue tests."""
 

--- a/tests/presentation/shell/output_pipeline/support.py
+++ b/tests/presentation/shell/output_pipeline/support.py
@@ -22,36 +22,75 @@ from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
-
 from substitute.presentation.shell.output_image_commit_pipeline import (
     OutputImageCommitRequest,
 )
 
 
 class SignalSpy:
-    def __init__(self) -> None:
-        self.callbacks: list[Callable[[str], None]] = []
+    """Capture signal connections behind a minimal Qt-like boundary."""
 
-    def connect(self, callback: Callable[[str], None]) -> None:
+    def __init__(self) -> None:
+        """Initialize an empty callback collection."""
+
+        self.callbacks: list[Callable[..., None]] = []
+
+    def connect(self, callback: Callable[..., None]) -> None:
+        """Capture one callback connection."""
+
         self.callbacks.append(callback)
 
 
 class PreparationDispatcherSpy:
+    """Capture output preparation and capacity coordination."""
+
     def __init__(self) -> None:
+        """Initialize signals, submissions, and capacity state."""
+
         self.prepared = SignalSpy()
         self.failed = SignalSpy()
         self.submitted: list[OutputImageCommitRequest] = []
+        self.prepared_capacity: Callable[[], int] | None = None
+        self.resume_count = 0
 
     def submit(self, request: OutputImageCommitRequest) -> None:
+        """Capture one output preparation request."""
+
         self.submitted.append(request)
+
+    def set_prepared_capacity(self, capacity: Callable[[], int]) -> None:
+        """Capture the decoded-output admission boundary."""
+
+        self.prepared_capacity = capacity
+
+    def resume(self) -> None:
+        """Record that prepared capacity became available."""
+
+        self.resume_count += 1
 
 
 class CommitQueueSpy:
+    """Expose the bounded commit-queue collaboration contract."""
+
+    def __init__(self) -> None:
+        """Initialize the capacity signal used to resume decoding."""
+
+        self.capacity_available = SignalSpy()
+
     def enqueue_prepared(self, output: object) -> None:
+        """Accept one prepared output."""
+
         _ = output
 
     def enqueue_failed(self, failure: object) -> None:
+        """Accept one failed output preparation."""
+
         _ = failure
+
+    def available_prepared_slots(self) -> int:
+        """Return deterministic decoded-output capacity."""
+
+        return 2
 
 
 class ProjectionSchedulerSpy:

--- a/tests/presentation/shell/output_pipeline/test_commit_scheduling.py
+++ b/tests/presentation/shell/output_pipeline/test_commit_scheduling.py
@@ -37,8 +37,33 @@ from tests.presentation.shell.output_pipeline.support import (
     PreparationDispatcherSpy,
     CommitQueueSpy,
     ProjectionCoordinatorSpy,
+    build_pipeline_shell_dependencies,
     noop_project_workflow,
 )
+
+
+def test_pipeline_coordinates_decoded_output_capacity() -> None:
+    """Connect commit capacity to retained preparation admission."""
+
+    dispatcher = PreparationDispatcherSpy()
+    commit_queue = CommitQueueSpy()
+    dependencies = build_pipeline_shell_dependencies()
+    dependencies["preparation_dispatcher"] = dispatcher
+    dependencies["commit_queue"] = commit_queue
+
+    OutputImagePipeline(
+        **dependencies,
+        canvas_host=SimpleNamespace(),
+        projection_scheduler=CanvasProjectionScheduler(
+            project_workflow=noop_project_workflow,
+            active_workflow_id=lambda: "wf",
+            output_canvas_visible=lambda: True,
+        ),
+    )
+
+    assert dispatcher.prepared_capacity is not None
+    assert dispatcher.prepared_capacity() == 2
+    assert commit_queue.capacity_available.callbacks == [dispatcher.resume]
 
 
 def test_pipeline_legacy_submit_preserves_explicit_fallback_metadata() -> None:

--- a/tests/presentation/shell/output_pipeline/test_preparation.py
+++ b/tests/presentation/shell/output_pipeline/test_preparation.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TypeVar
 
+import pytest
 from PySide6.QtCore import QEventLoop, QTimer
 from PySide6.QtGui import QImage
 
@@ -39,7 +40,7 @@ from substitute.presentation.shell.output_image_preparation_dispatcher import (
     OutputImagePreparationDispatcher,
     prepare_output_image,
 )
-from tests.support.execution import ImmediateTaskSubmitter
+from tests.support.execution import ImmediateTaskSubmitter, QueuedTaskSubmitter
 from tests.support.qt.lifecycle import destroy_qt_object, ensure_qt_application
 
 TResult = TypeVar("TResult")
@@ -125,6 +126,34 @@ def test_prepare_output_image_converts_null_load_to_failure() -> None:
     assert result.request.file_path == Path("E:/missing.png")
 
 
+def test_prepare_output_image_converts_failed_detachment_to_failure() -> None:
+    """Allocation failure must not publish a prepared output containing null pixels."""
+
+    image = QImage(32, 16, QImage.Format.Format_ARGB32)
+    image.fill(1)
+
+    result = prepare_output_image(
+        _request(Path("E:/contended.png")),
+        loader=_Loader(image),
+        detach=lambda _image: QImage(),
+    )
+
+    assert isinstance(result, FailedOutputImagePreparation)
+    assert result.request.file_path == Path("E:/contended.png")
+    assert result.detail is not None
+    assert "allocation was rejected" in result.detail
+
+
+def test_prepared_output_contract_rejects_null_pixels() -> None:
+    """No caller may bypass preparation and publish a null output payload."""
+
+    with pytest.raises(ValueError, match="must contain valid pixels"):
+        PreparedOutputImage(
+            request=_request(Path("E:/null.png")),
+            image=QImage(),
+        )
+
+
 def test_dispatcher_retries_saturation_without_dropping_output() -> None:
     """Temporary lane saturation should retain and eventually prepare the output."""
 
@@ -165,6 +194,46 @@ def test_dispatcher_retries_saturation_without_dropping_output() -> None:
     assert prepared[0].request.file_path == Path("E:/retained.png")
     assert failed == []
 
+    dispatcher.shutdown()
+    destroy_qt_object(dispatcher)
+
+
+def test_dispatcher_retains_encoded_requests_until_decoded_capacity_returns() -> None:
+    """Prepared pixels must remain bounded without dropping queued Comfy outputs."""
+
+    ensure_qt_application()
+    submitter = QueuedTaskSubmitter()
+    capacity = {"slots": 1}
+    dispatcher = OutputImagePreparationDispatcher(
+        loader=_Loader(QImage(8, 8, QImage.Format.Format_ARGB32)),
+        submitter=submitter,
+    )
+    dispatcher.set_prepared_capacity(lambda: capacity["slots"])
+
+    def occupy_decoded_slot(_prepared: PreparedOutputImage) -> None:
+        """Model the commit queue retaining one decoded image."""
+        capacity["slots"] = 0
+
+    dispatcher.prepared.connect(occupy_decoded_slot)
+    dispatcher.submit(_request(Path("E:/first.png")))
+    dispatcher.submit(_request(Path("E:/second.png")))
+    dispatcher.submit(_request(Path("E:/third.png")))
+
+    assert len(submitter.handles) == 1
+    first = submitter.handles[0]
+    first.complete_success(
+        PreparedOutputImage(
+            request=_request(Path("E:/first.png")),
+            image=QImage(8, 8, QImage.Format.Format_ARGB32),
+        )
+    )
+
+    assert len(submitter.handles) == 1
+
+    capacity["slots"] = 1
+    dispatcher.resume()
+
+    assert len(submitter.handles) == 2
     dispatcher.shutdown()
     destroy_qt_object(dispatcher)
 

--- a/tests/qualification/release/payload/test_builder.py
+++ b/tests/qualification/release/payload/test_builder.py
@@ -466,9 +466,9 @@ def test_project_requirements_pin_cutecanvas_as_the_canvas_boundary() -> None:
 
     requirements = (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8")
 
-    assert "cutecanvas[sam]==1.0.3" in requirements
-    assert "qpane==3.0.2" in requirements
-    assert "ferrastra==1.0.1" in requirements
+    assert "cutecanvas[sam]==1.0.6" in requirements
+    assert "qpane==3.0.4" in requirements
+    assert "ferrastra==1.0.2" in requirements
 
 
 def _write_fixture_repo(tmp_path: Path) -> Path:


### PR DESCRIPTION
## Summary
- preserve completed output-image frames while memory is contended
- backpressure decode preparation to bounded commit capacity instead of discarding user-visible work
- consume the released Ferrastra 1.0.2, QPane 3.0.4, and CuteCanvas 1.0.6 continuity stack

## Verification
- focused output-pipeline and dependency tests
- Ruff format and lint
- mypy --strict
- architecture and test-governance gates
- full parallel test lane
- all 85 isolated test modules
- required serial test module
- repository commit hook