### PR TITLE
fix(inputs): recover generation after Input surface changes

### DIFF
--- a/substitute/application/cubes/cube_stack_service.py
+++ b/substitute/application/cubes/cube_stack_service.py
@@ -25,11 +25,26 @@ from typing import Protocol
 from substitute.domain.workflow import StackManager
 
 
+class WorkflowCanvasStateProtocol(Protocol):
+    """Describe alias-keyed canvas state coupled to cube identity."""
+
+    def rename_section(self, old_section_key: str, new_section_key: str) -> bool:
+        """Migrate canvas identities owned by one renamed cube section."""
+
+
 class WorkflowStateProtocol(Protocol):
     """Describe workflow state shape synchronized by the cube stack service."""
 
     cubes: dict[str, Any]
     stack_order: list[str]
+
+
+class RenameWorkflowStateProtocol(WorkflowStateProtocol, Protocol):
+    """Describe workflow state participating in complete alias migration."""
+
+    @property
+    def canvas(self) -> WorkflowCanvasStateProtocol:
+        """Return alias-keyed canvas state owned by the workflow."""
 
 
 @dataclass(frozen=True)
@@ -164,7 +179,7 @@ class CubeStackService:
 
     def apply_cube_rename(
         self,
-        workflow: WorkflowStateProtocol,
+        workflow: RenameWorkflowStateProtocol,
         old_alias: str,
         requested_alias: str,
     ) -> CubeRenameResolution:
@@ -172,6 +187,7 @@ class CubeStackService:
 
         resolution = self.resolve_cube_rename(workflow, old_alias, requested_alias)
         manager = self._manager_for_workflow(workflow)
+        workflow.canvas.rename_section(old_alias, resolution.resolved_alias)
         manager.rename_cube(old_alias, resolution.resolved_alias)
         cube_state = workflow.cubes.pop(old_alias, None)
         if cube_state is not None:

--- a/substitute/application/workflows/input_canvas_authority_reconciliation_service.py
+++ b/substitute/application/workflows/input_canvas_authority_reconciliation_service.py
@@ -1,0 +1,117 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Repair persisted Input surfaces that no longer have graph authority."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from substitute.application.workflows.generation_input_image_selection_service import (
+    GenerationInputImageSelection,
+)
+from substitute.application.workflows.input_canvas_ports import (
+    InputCanvasStateServicePort,
+)
+from substitute.domain.workflow import WorkflowState
+from substitute.shared.logging.logger import get_logger, log_info, log_warning
+
+_LOGGER = get_logger(
+    "application.workflows.input_canvas_authority_reconciliation_service"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class InputCanvasAuthorityReconciliationReport:
+    """Describe stale Input surface state discovered and retired for one workflow."""
+
+    workflow_id: str
+    stale_input_keys: tuple[str, ...] = ()
+    removed_input_keys: tuple[str, ...] = ()
+
+    @property
+    def unresolved_input_keys(self) -> tuple[str, ...]:
+        """Return stale keys that could not be retired through the state owner."""
+
+        removed = set(self.removed_input_keys)
+        return tuple(key for key in self.stale_input_keys if key not in removed)
+
+
+class InputCanvasAuthorityReconciliationService:
+    """Retire invalid persisted surfaces through the authoritative canvas owner."""
+
+    def __init__(
+        self,
+        *,
+        select_generation_images: Callable[
+            [WorkflowState], GenerationInputImageSelection
+        ],
+        input_canvas_state_service: InputCanvasStateServicePort,
+    ) -> None:
+        """Bind graph authority inspection and complete canvas-state retirement."""
+
+        self._select_generation_images = select_generation_images
+        self._input_canvas_state_service = input_canvas_state_service
+
+    def reconcile(
+        self,
+        workflows: Mapping[str, WorkflowState],
+        workflow_id: str,
+    ) -> InputCanvasAuthorityReconciliationReport:
+        """Remove every persisted Input surface rejected by current graph authority."""
+
+        workflow = workflows.get(workflow_id)
+        if workflow is None:
+            return InputCanvasAuthorityReconciliationReport(workflow_id=workflow_id)
+        selection = self._select_generation_images(workflow)
+        stale_input_keys = selection.unresolved_input_keys
+        removed_input_keys = tuple(
+            input_key
+            for input_key in stale_input_keys
+            if self._input_canvas_state_service.drop_input_surface(
+                workflows,
+                workflow_id,
+                input_key,
+            )
+        )
+        report = InputCanvasAuthorityReconciliationReport(
+            workflow_id=workflow_id,
+            stale_input_keys=stale_input_keys,
+            removed_input_keys=removed_input_keys,
+        )
+        if removed_input_keys:
+            log_info(
+                _LOGGER,
+                "Retired stale Input canvas surfaces without graph authority",
+                workflow_id=workflow_id,
+                stale_input_keys=stale_input_keys,
+                removed_input_keys=removed_input_keys,
+            )
+        if report.unresolved_input_keys:
+            log_warning(
+                _LOGGER,
+                "Input canvas surfaces remained stale after authority reconciliation",
+                workflow_id=workflow_id,
+                unresolved_input_keys=report.unresolved_input_keys,
+            )
+        return report
+
+
+__all__ = [
+    "InputCanvasAuthorityReconciliationReport",
+    "InputCanvasAuthorityReconciliationService",
+]

--- a/substitute/domain/workflow/canvas_models.py
+++ b/substitute/domain/workflow/canvas_models.py
@@ -208,6 +208,89 @@ class WorkflowCanvasState:
 
         return self.image_entries.pop(input_key, None)
 
+    def rename_section(self, old_section_key: str, new_section_key: str) -> bool:
+        """Migrate every canvas identity owned by one renamed graph section."""
+
+        if old_section_key == new_section_key:
+            return False
+
+        def renamed_input_key(input_key: str) -> str:
+            """Return an image key with only the matching section replaced."""
+
+            prefix = f"{old_section_key}:"
+            return (
+                f"{new_section_key}:{input_key[len(prefix) :]}"
+                if input_key.startswith(prefix)
+                else input_key
+            )
+
+        def renamed_association_key(
+            association_key: MaskAssociationKey,
+        ) -> MaskAssociationKey:
+            """Return a mask key with only the matching section replaced."""
+
+            section_key, node_name = association_key
+            return (
+                (new_section_key, node_name)
+                if section_key == old_section_key
+                else association_key
+            )
+
+        renamed_image_keys = {
+            input_key: renamed_input_key(input_key) for input_key in self.image_entries
+        }
+        renamed_mask_keys = {
+            key: renamed_association_key(key) for key in self.mask_entries
+        }
+        renamed_collection_keys = {
+            key: renamed_association_key(key) for key in self.regional_mask_collections
+        }
+        renamed_opacity_keys = {
+            key: renamed_association_key(key) for key in self.mask_visual_opacities
+        }
+        for source_keys, replacements in (
+            (self.image_entries, renamed_image_keys),
+            (self.mask_entries, renamed_mask_keys),
+            (self.regional_mask_collections, renamed_collection_keys),
+            (self.mask_visual_opacities, renamed_opacity_keys),
+        ):
+            if any(
+                target != source and target in source_keys
+                for source, target in replacements.items()
+            ):
+                raise ValueError("Input canvas rename target identity already exists.")
+        changed = any(
+            source != target
+            for replacements in (
+                renamed_image_keys,
+                renamed_mask_keys,
+                renamed_collection_keys,
+                renamed_opacity_keys,
+            )
+            for source, target in replacements.items()
+        )
+        self.image_entries = {
+            target: replace(entry, input_key=target)
+            for source, entry in self.image_entries.items()
+            for target in (renamed_image_keys[source],)
+        }
+        self.mask_entries = {
+            target: replace(entry, association_key=target)
+            for source, entry in self.mask_entries.items()
+            for target in (renamed_mask_keys[source],)
+        }
+        self.regional_mask_collections = {
+            renamed_collection_keys[source]: collection
+            for source, collection in self.regional_mask_collections.items()
+        }
+        for association_key, collection in self.regional_mask_collections.items():
+            collection.association_key = association_key
+        self.mask_visual_opacities = {
+            renamed_opacity_keys[source]: opacity
+            for source, opacity in self.mask_visual_opacities.items()
+        }
+        return changed
+
     def image_ids(self) -> tuple[UUID, ...]:
         """Return Input document image identities owned by this workflow."""
 

--- a/substitute/presentation/shell/input_canvas_composition.py
+++ b/substitute/presentation/shell/input_canvas_composition.py
@@ -31,6 +31,9 @@ from substitute.application.workflows.generation_input_image_selection_service i
 from substitute.application.workflows.input_canvas_capability_service import (
     InputCanvasCapabilityService,
 )
+from substitute.application.workflows.input_canvas_authority_reconciliation_service import (
+    InputCanvasAuthorityReconciliationService,
+)
 from substitute.application.workflows.input_canvas_interaction_profile_service import (
     InputCanvasInteractionProfileService,
 )
@@ -138,6 +141,7 @@ class MainWindowInputCanvasComposition:
     """Hold Input-canvas collaborators composed after canvas widgets exist."""
 
     workflow_input_canvas_service: Any
+    input_canvas_authority_reconciliation_service: Any
     input_canvas_tool_controller: Any
     input_canvas_tool_profile_controller: Any
     input_shared_edge_resize_policy: InputSharedEdgeResizePolicy
@@ -355,6 +359,12 @@ def compose_input_canvas_controllers(shell: Any) -> MainWindowInputCanvasComposi
         input_canvas_plan_service=shell.input_canvas_plan_service,
         graph_section_service=shell.graph_section_service,
     )
+    input_canvas_authority_reconciliation_service = (
+        InputCanvasAuthorityReconciliationService(
+            select_generation_images=image_selection_service.select,
+            input_canvas_state_service=shell.input_canvas_state_service,
+        )
+    )
     input_generation_image_materializer = InputGenerationImageMaterializer(
         canvas_io_service=shell.canvas_io_service,
         association_service=image_association_service,
@@ -406,6 +416,9 @@ def compose_input_canvas_controllers(shell: Any) -> MainWindowInputCanvasComposi
     )
     composition = MainWindowInputCanvasComposition(
         workflow_input_canvas_service=workflow_input_canvas_service,
+        input_canvas_authority_reconciliation_service=(
+            input_canvas_authority_reconciliation_service
+        ),
         input_canvas_tool_controller=input_canvas_tool_controller,
         input_canvas_tool_profile_controller=input_canvas_tool_profile_controller,
         input_shared_edge_resize_policy=input_shared_edge_resize_policy,
@@ -429,6 +442,9 @@ def compose_input_canvas_controllers(shell: Any) -> MainWindowInputCanvasComposi
         synthetic_canvas_resolution_controller=synthetic_resolution_controller,
     )
     shell.workflow_input_canvas_service = composition.workflow_input_canvas_service
+    shell.input_canvas_authority_reconciliation_service = (
+        composition.input_canvas_authority_reconciliation_service
+    )
     shell.input_canvas_tool_controller = composition.input_canvas_tool_controller
     shell.input_canvas_tool_profile_controller = (
         composition.input_canvas_tool_profile_controller

--- a/substitute/presentation/shell/workspace_input_canvas_adapter.py
+++ b/substitute/presentation/shell/workspace_input_canvas_adapter.py
@@ -45,6 +45,23 @@ class WorkflowLookupProtocol(Protocol):
         """Return workflow state for one workflow id."""
 
 
+class InputCanvasAuthorityReportProtocol(Protocol):
+    """Describe retired stale Input surface identities."""
+
+    removed_input_keys: tuple[str, ...]
+
+
+class InputCanvasAuthorityReconciliationProtocol(Protocol):
+    """Describe stale Input surface reconciliation before generation."""
+
+    def reconcile(
+        self,
+        workflows: object,
+        workflow_id: str,
+    ) -> InputCanvasAuthorityReportProtocol:
+        """Retire persisted surfaces that current graph authority rejects."""
+
+
 ScheduleRehydrationStep = Callable[[Callable[[], None]], None]
 MaterializeLoadedCubeInputCanvas = Callable[[str, str], None]
 
@@ -152,9 +169,38 @@ def handle_input_mask_clicked_for_view(
     )
 
 
+def reconcile_input_canvas_authority_for_view(
+    canvas_view: object,
+) -> tuple[str, ...]:
+    """Retire stale Input surfaces through the composed application owner."""
+
+    service = getattr(
+        canvas_view, "input_canvas_authority_reconciliation_service", None
+    )
+    if service is None:
+        raise RuntimeError(
+            "InputCanvasAuthorityReconciliationService is required for Input canvas state."
+        )
+    session = getattr(canvas_view, "workflow_session_service", None)
+    workflows = getattr(session, "workflows", None)
+    workflow_id = str(getattr(session, "active_workflow_id", ""))
+    report = cast(InputCanvasAuthorityReconciliationProtocol, service).reconcile(
+        workflows,
+        workflow_id,
+    )
+    removed_input_keys = tuple(report.removed_input_keys)
+    if removed_input_keys:
+        shell_adapter = getattr(canvas_view, "input_canvas_shell_adapter", None)
+        mark_changed = getattr(shell_adapter, "mark_input_canvas_changed", None)
+        if callable(mark_changed):
+            mark_changed(workflow_id)
+    return removed_input_keys
+
+
 def reconcile_active_input_canvas_image_for_view(canvas_view: object) -> None:
     """Reconcile the active Input image before generation request capture."""
 
+    reconcile_input_canvas_authority_for_view(canvas_view)
     input_canvas_presenter_for_view(canvas_view).reconcile_active_input_canvas_image()
 
 
@@ -297,5 +343,6 @@ __all__ = [
     "materialize_loaded_cube_input_canvas_for_view",
     "reconcile_active_input_canvas_image_for_view",
     "refresh_active_mask_pickers_for_view",
+    "reconcile_input_canvas_authority_for_view",
     "rehydrate_duplicated_workflow_input_canvas",
 ]

--- a/tests/application/cubes/cube_stack/test_service.py
+++ b/tests/application/cubes/cube_stack/test_service.py
@@ -27,10 +27,16 @@ def test_apply_cube_rename_resolves_collisions_and_updates_workflow_state() -> N
     """Rename application should return the resolved alias and keep workflow state aligned."""
     old_cube_state = SimpleNamespace(alias="Old")
     taken_cube_state = SimpleNamespace(alias="Taken")
+    canvas_renames: list[tuple[str, str]] = []
     service = CubeStackService()
     workflow = SimpleNamespace(
         cubes={"Old": old_cube_state, "Taken": taken_cube_state},
         stack_order=["Old", "Taken"],
+        canvas=SimpleNamespace(
+            rename_section=lambda old_alias, new_alias: canvas_renames.append(
+                (old_alias, new_alias)
+            )
+        ),
     )
 
     resolution = service.apply_cube_rename(workflow, "Old", "Taken")
@@ -41,6 +47,7 @@ def test_apply_cube_rename_resolves_collisions_and_updates_workflow_state() -> N
     assert workflow.cubes["Taken 2"] is old_cube_state
     assert old_cube_state.alias == "Taken 2"
     assert workflow.stack_order == ["Taken 2", "Taken"]
+    assert canvas_renames == [("Old", "Taken 2")]
 
 
 def test_resolve_cube_rename_excludes_current_alias_from_collision_check() -> None:

--- a/tests/application/workflows/input_canvas/generation/test_authority_reconciliation.py
+++ b/tests/application/workflows/input_canvas/generation/test_authority_reconciliation.py
@@ -1,0 +1,167 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify repair of persisted Input surfaces that lost graph authority."""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from typing import cast
+from uuid import UUID, uuid4
+
+from substitute.application.workflows.generation_input_image_selection_service import (
+    GenerationInputImageSelection,
+    GenerationInputImageSelectionService,
+)
+from substitute.application.workflows.input_canvas_authority_reconciliation_service import (
+    InputCanvasAuthorityReconciliationService,
+)
+from substitute.application.workflows.input_canvas_plan_service import (
+    InputCanvasPlanService,
+)
+from substitute.domain.workflow import WorkflowState
+from substitute.presentation.canvas.input.input_generation_capture import (
+    InputGenerationCapture,
+)
+from substitute.presentation.canvas.input.input_generation_snapshot_service import (
+    InputGenerationSnapshotService,
+)
+from substitute.application.workflows.workflow_graph_section_service import (
+    WorkflowGraphSectionService,
+)
+from tests.application.workflows.input_canvas.fakes import (
+    _FakeInputCanvasStateService,
+)
+
+
+def test_reconciliation_drops_only_surfaces_rejected_by_graph_authority() -> None:
+    """Legacy stale entries must be retired without disturbing valid surfaces."""
+
+    valid_image_id = uuid4()
+    stale_image_id = uuid4()
+    stale_mask_id = uuid4()
+    workflow = WorkflowState()
+    workflow.canvas.bind_image("Valid:Image", valid_image_id)
+    workflow.canvas.bind_image("Removed:Image", stale_image_id)
+    workflow.canvas.bind_mask(("Removed", "Mask"), stale_mask_id, stale_image_id)
+    canvas_state = _FakeInputCanvasStateService(
+        image_id=valid_image_id,
+        mask_id=stale_mask_id,
+    )
+    service = InputCanvasAuthorityReconciliationService(
+        select_generation_images=lambda _workflow: GenerationInputImageSelection(
+            (valid_image_id,),
+            unresolved_input_keys=("Removed:Image",),
+        ),
+        input_canvas_state_service=canvas_state,
+    )
+
+    report = service.reconcile({"wf-a": workflow}, "wf-a")
+
+    assert report.workflow_id == "wf-a"
+    assert report.stale_input_keys == ("Removed:Image",)
+    assert report.removed_input_keys == ("Removed:Image",)
+    assert workflow.canvas.image_entry("Valid:Image") is not None
+    assert workflow.canvas.image_entry("Removed:Image") is None
+    assert workflow.canvas.mask_entry(("Removed", "Mask")) is None
+    assert canvas_state.dropped_associations == [("Removed", "Mask")]
+
+
+def test_reconciliation_of_missing_workflow_is_an_observable_noop() -> None:
+    """A stale workflow route must not invoke graph selection or mutate state."""
+
+    def unexpected_selection(_workflow: WorkflowState) -> GenerationInputImageSelection:
+        """Reject graph inspection when the requested workflow is absent."""
+
+        raise AssertionError("selection must not run")
+
+    service = InputCanvasAuthorityReconciliationService(
+        select_generation_images=unexpected_selection,
+        input_canvas_state_service=_FakeInputCanvasStateService(
+            image_id=uuid4(),
+            mask_id=uuid4(),
+        ),
+    )
+
+    report = service.reconcile({}, "missing")
+
+    assert report.workflow_id == "missing"
+    assert report.stale_input_keys == ()
+    assert report.removed_input_keys == ()
+
+
+def test_stale_surface_in_workflow_without_input_canvas_recovers_before_capture() -> (
+    None
+):
+    """The reported no-canvas failure must become an empty generation capture."""
+
+    stale_image_id = uuid4()
+    workflow = WorkflowState()
+    workflow.canvas.bind_image("Removed:Image", stale_image_id)
+    workflows = {"wf-a": workflow}
+
+    def unexpected_plan(*_args: object) -> object:
+        """Reject plan construction for a workflow with no graph sections."""
+
+        raise AssertionError("missing graph sections must not build plans")
+
+    selector = GenerationInputImageSelectionService(
+        input_canvas_plan_service=cast(
+            InputCanvasPlanService,
+            SimpleNamespace(build_plan=unexpected_plan),
+        ),
+        graph_section_service=WorkflowGraphSectionService(),
+    )
+    authority = InputCanvasAuthorityReconciliationService(
+        select_generation_images=selector.select,
+        input_canvas_state_service=_FakeInputCanvasStateService(
+            image_id=stale_image_id,
+            mask_id=uuid4(),
+        ),
+    )
+
+    report = authority.reconcile(workflows, "wf-a")
+
+    capture_requests: list[tuple[tuple[UUID, ...], tuple[UUID, ...]]] = []
+
+    def capture_inputs(
+        *,
+        image_ids: tuple[UUID, ...],
+        mask_ids: tuple[UUID, ...],
+    ) -> InputGenerationCapture:
+        """Record the post-recovery capture identities."""
+
+        capture_requests.append((image_ids, mask_ids))
+        return InputGenerationCapture(images={}, masks={})
+
+    copy_materializer = SimpleNamespace(
+        prepare_workflow=lambda **kwargs: copy.deepcopy(kwargs["workflow"])
+    )
+    snapshot_service = InputGenerationSnapshotService(
+        capture_inputs=capture_inputs,
+        select_generation_images=selector.select,
+        image_materializer=copy_materializer,
+        mask_materializer=copy_materializer,
+    )
+    prepared = snapshot_service.prepare_workflow(
+        workflow_id="wf-a",
+        workflow=workflow,
+    )
+
+    assert report.removed_input_keys == ("Removed:Image",)
+    assert isinstance(prepared, WorkflowState)
+    assert capture_requests == [((), ())]

--- a/tests/application/workflows/input_canvas/generation/test_snapshot_service.py
+++ b/tests/application/workflows/input_canvas/generation/test_snapshot_service.py
@@ -16,7 +16,9 @@
 
 """Prove exact image-and-mask external products at the generation barrier."""
 
+import copy
 from pathlib import Path
+from types import SimpleNamespace
 from uuid import UUID
 from uuid import uuid4
 
@@ -55,6 +57,39 @@ from tests.application.workflows.input_canvas.generation.snapshot_service_suppor
     _synthetic_workflow,
     _workflow,
 )
+
+
+def test_generation_without_input_canvas_captures_an_empty_document_bundle() -> None:
+    """A workflow with no Input surfaces must remain directly generatable."""
+
+    captured_requests: list[tuple[tuple[UUID, ...], tuple[UUID, ...]]] = []
+
+    def capture_inputs(
+        *,
+        image_ids: tuple[UUID, ...],
+        mask_ids: tuple[UUID, ...],
+    ) -> InputGenerationCapture:
+        """Record the empty capture boundary used by a text-only workflow."""
+
+        captured_requests.append((image_ids, mask_ids))
+        return InputGenerationCapture(images={}, masks={})
+
+    copy_materializer = SimpleNamespace(
+        prepare_workflow=lambda **kwargs: copy.deepcopy(kwargs["workflow"])
+    )
+    service = InputGenerationSnapshotService(
+        capture_inputs=capture_inputs,
+        select_generation_images=lambda _workflow: GenerationInputImageSelection(()),
+        image_materializer=copy_materializer,
+        mask_materializer=copy_materializer,
+    )
+    workflow = WorkflowState()
+
+    prepared = service.prepare_workflow(workflow_id="text-only", workflow=workflow)
+
+    assert isinstance(prepared, WorkflowState)
+    assert prepared is not workflow
+    assert captured_requests == [((), ())]
 
 
 def test_generation_materializes_one_coherent_bundle_without_mutating_authoring(

--- a/tests/domain/workflow/canvas/test_entries.py
+++ b/tests/domain/workflow/canvas/test_entries.py
@@ -77,6 +77,61 @@ def test_entry_identity_changes_require_explicit_replacement() -> None:
         canvas.bind_mask(("Cube", "load_mask"), uuid4(), image_id)
 
 
+def test_section_rename_migrates_every_alias_owned_canvas_identity() -> None:
+    """Renaming a cube must preserve its image, scalar mask, and regional state."""
+
+    image_id = uuid4()
+    mask_id = uuid4()
+    regional_mask_id = uuid4()
+    canvas = WorkflowCanvasState()
+    canvas.bind_image("Old:load_image", image_id)
+    canvas.bind_mask(("Old", "load_mask"), mask_id, image_id)
+    collection = canvas.ensure_regional_mask_collection(("Old", "regions"))
+    collection.add_region(image_id, mask_id=regional_mask_id)
+    canvas.set_mask_visual_opacity(("Old", "load_mask"), 0.25)
+
+    changed = canvas.rename_section("Old", "New")
+
+    assert changed is True
+    assert canvas.image_entry("Old:load_image") is None
+    assert canvas.image_entry("New:load_image") == InputCanvasImageEntry(
+        "New:load_image",
+        image_id,
+    )
+    assert canvas.mask_entry(("New", "load_mask")) == InputCanvasMaskEntry(
+        ("New", "load_mask"),
+        mask_id,
+        image_id,
+    )
+    assert canvas.regional_mask_collection(("Old", "regions")) is None
+    renamed_collection = canvas.regional_mask_collection(("New", "regions"))
+    assert renamed_collection is collection
+    assert renamed_collection.association_key == ("New", "regions")
+    assert canvas.mask_visual_opacities == {("New", "load_mask"): 0.25}
+
+
+def test_section_rename_rejects_target_identity_collisions_atomically() -> None:
+    """A stale target alias must not overwrite either canvas identity."""
+
+    old_image_id = uuid4()
+    target_image_id = uuid4()
+    canvas = WorkflowCanvasState()
+    canvas.bind_image("Old:load_image", old_image_id)
+    canvas.bind_image("New:load_image", target_image_id)
+
+    with pytest.raises(ValueError, match="target identity already exists"):
+        canvas.rename_section("Old", "New")
+
+    assert canvas.image_entry("Old:load_image") == InputCanvasImageEntry(
+        "Old:load_image",
+        old_image_id,
+    )
+    assert canvas.image_entry("New:load_image") == InputCanvasImageEntry(
+        "New:load_image",
+        target_image_id,
+    )
+
+
 def test_production_code_cannot_reintroduce_parallel_canvas_identity_maps() -> None:
     """Reject access to the deleted split image/mask ownership structures."""
 

--- a/tests/presentation/shell/generation/controller_facades/test_requests.py
+++ b/tests/presentation/shell/generation/controller_facades/test_requests.py
@@ -53,6 +53,9 @@ def _base_generation_view(
         ),
         _current_generate_mode="generate",
         get_active_workflow=lambda: workflow,
+        input_canvas_authority_reconciliation_service=SimpleNamespace(
+            reconcile=lambda *_args: SimpleNamespace(removed_input_keys=()),
+        ),
         input_canvas_shell_adapter=SimpleNamespace(
             resolve_workflow_name=lambda _workflow_id: "Recipe"
         ),

--- a/tests/presentation/shell/generation/snapshots/test_generation.py
+++ b/tests/presentation/shell/generation/snapshots/test_generation.py
@@ -72,6 +72,9 @@ def test_build_generation_snapshot_randomizes_before_serialization(
         ),
         _current_generate_mode="generate",
         get_active_workflow=lambda: workflow,
+        input_canvas_authority_reconciliation_service=SimpleNamespace(
+            reconcile=lambda *_args: SimpleNamespace(removed_input_keys=()),
+        ),
         input_canvas_shell_adapter=SimpleNamespace(
             resolve_workflow_name=lambda _workflow_id: "Recipe"
         ),
@@ -198,6 +201,9 @@ def test_build_generation_snapshot_stores_positive_prompt_preview(
         ),
         _current_generate_mode="generate",
         get_active_workflow=lambda: workflow,
+        input_canvas_authority_reconciliation_service=SimpleNamespace(
+            reconcile=lambda *_args: SimpleNamespace(removed_input_keys=()),
+        ),
         input_canvas_shell_adapter=SimpleNamespace(
             resolve_workflow_name=lambda _workflow_id: "Recipe"
         ),

--- a/tests/presentation/shell/generation/snapshots/test_queued_fallbacks.py
+++ b/tests/presentation/shell/generation/snapshots/test_queued_fallbacks.py
@@ -57,6 +57,9 @@ def test_build_queued_generation_snapshots_uses_single_snapshot_without_scenes(
         ),
         _current_generate_mode="generate",
         get_active_workflow=lambda: workflow,
+        input_canvas_authority_reconciliation_service=SimpleNamespace(
+            reconcile=lambda *_args: SimpleNamespace(removed_input_keys=()),
+        ),
         input_canvas_shell_adapter=SimpleNamespace(
             resolve_workflow_name=lambda _workflow_id: "Recipe"
         ),
@@ -186,6 +189,9 @@ def test_build_queued_generation_snapshots_uses_single_snapshot_for_one_scene(
         ),
         _current_generate_mode="generate",
         get_active_workflow=lambda: workflow,
+        input_canvas_authority_reconciliation_service=SimpleNamespace(
+            reconcile=lambda *_args: SimpleNamespace(removed_input_keys=()),
+        ),
         input_canvas_shell_adapter=SimpleNamespace(
             resolve_workflow_name=lambda _workflow_id: "Recipe"
         ),

--- a/tests/presentation/shell/generation/snapshots/test_queued_scenes.py
+++ b/tests/presentation/shell/generation/snapshots/test_queued_scenes.py
@@ -130,6 +130,9 @@ def test_build_queued_generation_snapshots_materializes_authority_order(
         ),
         _current_generate_mode="generate",
         get_active_workflow=lambda: workflow,
+        input_canvas_authority_reconciliation_service=SimpleNamespace(
+            reconcile=lambda *_args: SimpleNamespace(removed_input_keys=()),
+        ),
         input_canvas_shell_adapter=SimpleNamespace(
             resolve_workflow_name=lambda _workflow_id: "Recipe"
         ),

--- a/tests/presentation/shell/generation/snapshots/test_scene.py
+++ b/tests/presentation/shell/generation/snapshots/test_scene.py
@@ -133,6 +133,9 @@ def test_build_scene_generation_snapshot_materializes_selected_scene(
         ),
         _current_generate_mode="generate",
         get_active_workflow=lambda: workflow,
+        input_canvas_authority_reconciliation_service=SimpleNamespace(
+            reconcile=lambda *_args: SimpleNamespace(removed_input_keys=()),
+        ),
         input_canvas_shell_adapter=SimpleNamespace(
             resolve_workflow_name=lambda _workflow_id: "Recipe"
         ),

--- a/tests/presentation/shell/input_canvas/test_adapter.py
+++ b/tests/presentation/shell/input_canvas/test_adapter.py
@@ -34,6 +34,7 @@ from substitute.presentation.shell.workspace_input_canvas_adapter import (
     input_canvas_presenter_for_view,
     materialize_loaded_cube_input_canvas_for_view,
     reconcile_active_input_canvas_image_for_view,
+    reconcile_input_canvas_authority_for_view,
     refresh_active_mask_pickers_for_view,
     rehydrate_duplicated_workflow_input_canvas,
 )
@@ -99,9 +100,23 @@ def test_input_canvas_intents_delegate_to_presenter() -> None:
             ("materialize", args)
         ),
     )
+
+    def reconcile_authority(workflows: object, workflow_id: str) -> object:
+        """Record authority repair before presenter-level image reconciliation."""
+
+        calls.append(("authority", (workflows, workflow_id)))
+        return SimpleNamespace(removed_input_keys=())
+
     view = SimpleNamespace(
         input_canvas_presenter=presenter,
         input_node_interaction_controller=interaction_controller,
+        input_canvas_authority_reconciliation_service=SimpleNamespace(
+            reconcile=reconcile_authority
+        ),
+        workflow_session_service=SimpleNamespace(
+            workflows={"wf-a": object()},
+            active_workflow_id="wf-a",
+        ),
     )
 
     handle_input_image_changed_for_view(view, "CubeA", "ImageNode", "input.png")
@@ -121,9 +136,38 @@ def test_input_canvas_intents_delegate_to_presenter() -> None:
         ("mask_pickers", ()),
         ("mask_changed", ("CubeA", "MaskNode", "mask.png")),
         ("mask_clicked", ("CubeA", "MaskNode", "mask.png")),
+        ("authority", (view.workflow_session_service.workflows, "wf-a")),
         ("reconcile", ()),
         ("materialize", ("wf-a", "CubeA")),
     ]
+
+
+def test_authority_reconciliation_marks_recovered_canvas_state_changed() -> None:
+    """Recovered legacy state must participate in normal dirty-state persistence."""
+
+    marked: list[str] = []
+    workflows = {"wf-a": object()}
+    view = SimpleNamespace(
+        workflow_session_service=SimpleNamespace(
+            workflows=workflows,
+            active_workflow_id="wf-a",
+        ),
+        input_canvas_authority_reconciliation_service=SimpleNamespace(
+            reconcile=lambda supplied, workflow_id: SimpleNamespace(
+                removed_input_keys=("Removed:Image",)
+                if supplied is workflows and workflow_id == "wf-a"
+                else ()
+            )
+        ),
+        input_canvas_shell_adapter=SimpleNamespace(
+            mark_input_canvas_changed=marked.append
+        ),
+    )
+
+    removed = reconcile_input_canvas_authority_for_view(view)
+
+    assert removed == ("Removed:Image",)
+    assert marked == ["wf-a"]
 
 
 def test_rehydrate_duplicated_workflow_input_canvas_materializes_stack_order(

--- a/tests/presentation/shell/main_window/input_canvas/support.py
+++ b/tests/presentation/shell/main_window/input_canvas/support.py
@@ -400,6 +400,7 @@ class _InputCompositionShell:
         self._error_presenter = object()
         self.request_session_autosave = object()
         self.workflow_input_canvas_service: object | None = None
+        self.input_canvas_authority_reconciliation_service: object | None = None
         self.input_canvas_presenter: object | None = None
         self.input_node_interaction_controller: object | None = None
         self.input_document_change_observer: object | None = None

--- a/tests/presentation/shell/main_window/input_canvas/test_composition.py
+++ b/tests/presentation/shell/main_window/input_canvas/test_composition.py
@@ -161,6 +161,10 @@ def test_compose_input_canvas_controllers_assigns_presenter_services(
     assert (
         composition.workflow_input_canvas_service is shell.workflow_input_canvas_service
     )
+    assert (
+        composition.input_canvas_authority_reconciliation_service
+        is shell.input_canvas_authority_reconciliation_service
+    )
     assert composition.input_canvas_presenter is shell.input_canvas_presenter
     assert (
         composition.input_node_interaction_controller


### PR DESCRIPTION
Summary: Retires persisted Input canvas surfaces that no longer have graph authority before generation capture; keeps the generation snapshot barrier fail-closed; migrates alias-keyed image, mask, regional-mask, and opacity state when cubes are renamed; and preserves valid empty Input canvases. Regression coverage includes the reported removed-surface/no-canvas failure, empty capture, rename migration and collision safety, state-owner cleanup, dirty-state persistence, composition, and generation facade integration. Verification (Windows 11, repository .venv): ruff format; ruff check; mypy --strict substitute tests; architecture governance; test governance; full parallel pytest suite; all 85 isolated modules; serial module; git diff --check.