### PR TITLE
build(comfy): require SugarCubes 0.12.0

### DIFF
--- a/substitute/domain/comfy_nodepacks.py
+++ b/substitute/domain/comfy_nodepacks.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from enum import Enum
 
 SUBSTITUTE_BACKEND_REQUIRED_VERSION = "1.9.1"
-SUGARCUBES_REQUIRED_VERSION = "0.11.0"
+SUGARCUBES_REQUIRED_VERSION = "0.12.0"
 
 
 class CoreNodepackId(str, Enum):

--- a/tests/application/backend_compatibility/test_service.py
+++ b/tests/application/backend_compatibility/test_service.py
@@ -72,14 +72,14 @@ def test_compatibility_blocks_sugarcubes_before_required_release() -> None:
 
     assert result.status is RuntimeCompatibilityStatus.SUGARCUBES_TOO_OLD
     assert result.repairable is True
-    assert result.required_sugarcubes_version == "0.11.0"
+    assert result.required_sugarcubes_version == "0.12.0"
 
 
 def test_compatibility_blocks_newer_patch_versions() -> None:
     """Exact pins should reject versions newer than this application build requires."""
 
     backend_result = _service(_capabilities(extension_version="1.9.2")).assess()
-    sugarcubes_result = _service(_capabilities(sugar_cubes_version="0.11.1")).assess()
+    sugarcubes_result = _service(_capabilities(sugar_cubes_version="0.12.1")).assess()
 
     assert backend_result.status is RuntimeCompatibilityStatus.BACKEND_TOO_NEW
     assert sugarcubes_result.status is RuntimeCompatibilityStatus.SUGARCUBES_TOO_NEW
@@ -139,7 +139,7 @@ def _service(
 def _capabilities(
     *,
     extension_version: str = "1.9.1",
-    sugar_cubes_version: str = "0.11.0",
+    sugar_cubes_version: str = "0.12.0",
     sugarcubes_available: bool = True,
     features: tuple[str, ...] = (
         "cube-library",

--- a/tests/infrastructure/comfy/nodepacks/test_manifest.py
+++ b/tests/infrastructure/comfy/nodepacks/test_manifest.py
@@ -99,10 +99,10 @@ def test_core_nodepack_manifest_contains_expected_install_identities() -> None:
     assert by_project["SugarCubes"].local_source_environment_variable == (
         "SUGARSUBSTITUTE_SUGARCUBES_SOURCE"
     )
-    assert by_project["SugarCubes"].required_version == "0.11.0"
+    assert by_project["SugarCubes"].required_version == "0.12.0"
     assert by_project["SugarCubes"].fallback_archive_url == (
         "https://github.com/Artificial-Sweetener/SugarCubes/archive/refs/tags/"
-        "v0.11.0.zip"
+        "v0.12.0.zip"
     )
     assert by_project["SugarCubes"].expected_folder == (
         Path("custom_nodes") / "SugarCubes"


### PR DESCRIPTION
Pins the managed SugarCubes nodepack to the newly published 0.12.0 release and updates exact-version compatibility and fallback archive coverage. Full local format, lint, strict typing, architecture, test-governance, parallel, isolated, and serial gates pass on Windows.