### PR TITLE
fix(updates): restore reliable Windows automatic updates

### DIFF
--- a/.github/workflows/release-update-qualification.yml
+++ b/.github/workflows/release-update-qualification.yml
@@ -77,20 +77,6 @@ jobs:
       - name: Install Linux runtime dependencies
         if: matrix.platform == 'linux'
         uses: ./.github/actions/setup-linux-qt
-      - name: Download published candidate installer
-        if: inputs.candidate_tag != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: pwsh
-        run: |
-          $PSNativeCommandUseErrorActionPreference = $true
-          New-Item -ItemType Directory -Force build/candidate | Out-Null
-          $asset = switch ("${{ matrix.platform }}") {
-            "windows" { "SugarSubstitute-$env:CANDIDATE_VERSION-Windows-x64-Setup.exe" }
-            "linux" { "SugarSubstitute-$env:CANDIDATE_VERSION-Linux-x86_64.AppImage" }
-            "macos" { "SugarSubstitute-$env:CANDIDATE_VERSION-macOS-Apple-Silicon.dmg" }
-          }
-          gh release download $env:CANDIDATE_TAG --repo "${{ github.repository }}" --pattern $asset --dir build/candidate
       - name: Download temporary candidate channel
         if: inputs.candidate_artifact_name != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -99,25 +85,6 @@ jobs:
           path: build/candidate
           run-id: ${{ inputs.candidate_run_id != '' && inputs.candidate_run_id || github.run_id }}
           github-token: ${{ github.token }}
-      - name: Resolve real candidate installer
-        shell: pwsh
-        run: |
-          $PSNativeCommandUseErrorActionPreference = $true
-          $asset = switch ("${{ matrix.platform }}") {
-            "windows" { "SugarSubstitute-$env:CANDIDATE_VERSION-Windows-x64-Setup.exe" }
-            "linux" { "SugarSubstitute-$env:CANDIDATE_VERSION-Linux-x86_64.AppImage" }
-            "macos" { "SugarSubstitute-$env:CANDIDATE_VERSION-macOS-Apple-Silicon.dmg" }
-          }
-          $assetPath = (Resolve-Path (Join-Path build/candidate $asset)).Path
-          if ("${{ matrix.platform }}" -eq "linux") {
-            chmod +x $assetPath
-          }
-          if ("${{ matrix.platform }}" -eq "macos") {
-            New-Item -ItemType Directory -Force "${{ runner.temp }}/candidate-update-dmg" | Out-Null
-            hdiutil attach $assetPath -mountpoint "${{ runner.temp }}/candidate-update-dmg" -nobrowse
-            $assetPath = "${{ runner.temp }}/candidate-update-dmg/SugarSubstitute Setup.app/Contents/MacOS/SugarSubstitute Setup"
-          }
-          "CANDIDATE_INSTALLER=$assetPath" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Download real historical installer
         env:
           GH_TOKEN: ${{ github.token }}
@@ -178,11 +145,10 @@ jobs:
           $candidateSource = if ("${{ inputs.candidate_artifact_name }}" -ne "") {
             @("--candidate-release-root", "build/candidate")
           } else {
-            @()
+            @("--candidate-manifest-url", $env:EXPECTED_UPDATE_MANIFEST_URL)
           }
           $publishedChannel = if ("${{ inputs.candidate_tag }}" -ne "") {
             @(
-              "--candidate-channel", "${{ inputs.candidate_channel }}",
               "--expected-update-manifest-url", $env:EXPECTED_UPDATE_MANIFEST_URL
             )
           } else {
@@ -195,7 +161,6 @@ jobs:
           }
           python tools/ci/verify_installer_lifecycle.py upgrade `
             --historical-installer "$env:HISTORICAL_INSTALLER" `
-            --candidate-installer "$env:CANDIDATE_INSTALLER" `
             --install-root "${{ runner.temp }}/SugarSubstitute-${{ matrix.history.version }}" `
             --historical-manifest-url "https://github.com/${{ github.repository }}/releases/download/${{ matrix.history.tag }}/manifest.json" `
             @historicalSource `
@@ -203,6 +168,7 @@ jobs:
             --historical-published-at "${{ matrix.history.published_at }}" `
             --source-cache "${{ steps.comfy-source.outputs.cache-path }}" `
             @candidateSource `
+            --candidate-channel "${{ inputs.candidate_channel }}" `
             @publishedChannel `
             --timeout-seconds "$env:QUALIFICATION_TIMEOUT_SECONDS" `
             --candidate-version "$env:CANDIDATE_VERSION"
@@ -232,6 +198,3 @@ jobs:
       - name: Unmount historical DMG
         if: always() && matrix.platform == 'macos'
         run: hdiutil detach "${{ runner.temp }}/historical-dmg" || true
-      - name: Unmount candidate DMG
-        if: always() && matrix.platform == 'macos'
-        run: hdiutil detach "${{ runner.temp }}/candidate-update-dmg" || true

--- a/ARCHITECTURE_DEBT.toml
+++ b/ARCHITECTURE_DEBT.toml
@@ -1457,15 +1457,15 @@ next_extraction = "Extract native process/desktop control and historical evidenc
 id = "SS-ARCH-097"
 owner = "installer UI qualification"
 paths = ["tools/ci/installer_ui_qualification.py"]
-fingerprint = "sha256:b1fd775aa4d092ca4950a8fa0cacd5a08ce8deff6ffd80c59c4b3652f3b793e6"
+fingerprint = "sha256:9756144f09eba411f61a628b157e7071f6b45bfde562a76cc7fce5b707a876f4"
 issue = "chore:SS-ARCH-097"
 review_by = 2026-12-15
 responsibilities = [
   "qualification evidence preparation",
   "current installer execution",
   "installed candidate launch",
-  "shell, version, and event-sequence verification",
+  "shell and event-sequence verification",
   "cross-platform process termination and diagnostics",
   "readiness receipt and startup trace interpretation",
 ]
-next_extraction = "Extract installed-process lifecycle and evidence/trace verification from qualification workflow orchestration."
+next_extraction = "Extract installed-process lifecycle and evidence/trace verification from qualification workflow orchestration; durable installed-version evidence now has an independent owner."

--- a/ARCHITECTURE_WAIVERS.toml
+++ b/ARCHITECTURE_WAIVERS.toml
@@ -1979,10 +1979,10 @@ owner = "installer UI qualification"
 rule = "STRUCT003"
 path = "tools/ci/installer_ui_qualification.py"
 kind = "remediation"
-justification = "The assessed file mixes qualification evidence preparation, current installer execution, installed candidate launch, shell, version, and event-sequence verification, cross-platform process termination and diagnostics, readiness receipt and startup trace interpretation. Extract installed-process lifecycle and evidence/trace verification from qualification workflow orchestration."
+justification = "The assessed file mixes qualification evidence preparation, current installer execution, installed candidate launch, shell and event-sequence verification, cross-platform process termination and diagnostics, readiness receipt and startup trace interpretation. Extract installed-process lifecycle and evidence/trace verification from qualification workflow orchestration; durable installed-version evidence now has an independent owner."
 issue = "chore:SS-ARCH-097"
 review_by = 2026-12-15
-max_lines = 700
+max_lines = 688
 next_limit = 558
 debt = "SS-ARCH-097"
 

--- a/launcher/sugarsubstitute_launcher/application_readiness_supervisor.py
+++ b/launcher/sugarsubstitute_launcher/application_readiness_supervisor.py
@@ -196,7 +196,10 @@ class ApplicationReadinessSupervisor:
             raise ApplicationReadinessError(
                 "Application readiness receipt is invalid."
             ) from error
-        if receipt.token != expected_token or receipt.pid != expected_pid:
+        if receipt.token != expected_token or expected_pid not in {
+            receipt.pid,
+            receipt.parent_pid,
+        }:
             raise ApplicationReadinessError(
                 "Application readiness receipt did not match the launched process."
             )

--- a/launcher/sugarsubstitute_launcher/runtime_command.py
+++ b/launcher/sugarsubstitute_launcher/runtime_command.py
@@ -102,7 +102,15 @@ class SubprocessRuntimeCommandRunner:
                 if line:
                     captured_output.append(line)
                     if self._output_callback is not None:
-                        self._output_callback(line)
+                        try:
+                            self._output_callback(line)
+                        except OSError as error:
+                            _LOGGER.warning(
+                                "Runtime progress sink disconnected; continuing "
+                                "command | error_type=%s",
+                                type(error).__name__,
+                            )
+                            self._output_callback = None
 
         return_code = process.wait()
         if return_code != 0:

--- a/substitute/app/bootstrap/application_readiness.py
+++ b/substitute/app/bootstrap/application_readiness.py
@@ -82,6 +82,7 @@ def _write_readiness_receipt(
         pid=os.getpid(),
         token=readiness_token,
         surface=surface,
+        parent_pid=os.getppid(),
     ).to_json()
     try:
         temporary_path.write_text(

--- a/sugarsubstitute_shared/application_readiness.py
+++ b/sugarsubstitute_shared/application_readiness.py
@@ -25,8 +25,9 @@ from typing import Final
 
 READINESS_PATH_ENV: Final = "SUGAR_SUBSTITUTE_READINESS_PATH"
 READINESS_TOKEN_ENV: Final = "SUGAR_SUBSTITUTE_READINESS_TOKEN"
-READINESS_SCHEMA_VERSION: Final = 2
+READINESS_SCHEMA_VERSION: Final = 3
 _LEGACY_READINESS_SCHEMA_VERSION: Final = 1
+_SURFACE_READINESS_SCHEMA_VERSION: Final = 2
 
 
 class ApplicationReadinessSurface(str, Enum):
@@ -44,11 +45,13 @@ class ApplicationReadinessReceipt:
     pid: int
     token: str
     surface: ApplicationReadinessSurface
+    parent_pid: int | None
 
     def to_json(self) -> dict[str, object]:
         """Return the stable receipt representation."""
 
         return {
+            "parent_pid": self.parent_pid,
             "pid": self.pid,
             "schema_version": READINESS_SCHEMA_VERSION,
             "surface": self.surface.value,
@@ -67,7 +70,11 @@ class ApplicationReadinessReceipt:
         raw_surface = payload.get("surface")
         if (
             schema_version
-            not in {_LEGACY_READINESS_SCHEMA_VERSION, READINESS_SCHEMA_VERSION}
+            not in {
+                _LEGACY_READINESS_SCHEMA_VERSION,
+                _SURFACE_READINESS_SCHEMA_VERSION,
+                READINESS_SCHEMA_VERSION,
+            }
             or not isinstance(pid, int)
             or pid <= 0
             or not isinstance(token, str)
@@ -79,14 +86,27 @@ class ApplicationReadinessReceipt:
                 pid=pid,
                 token=token,
                 surface=ApplicationReadinessSurface.LEGACY_VISIBLE_SHELL,
+                parent_pid=None,
             )
         if not isinstance(raw_surface, str):
             raise ValueError("Application readiness receipt is invalid.")
+        parent_pid = payload.get("parent_pid")
+        if schema_version == READINESS_SCHEMA_VERSION and (
+            not isinstance(parent_pid, int) or parent_pid <= 0
+        ):
+            raise ValueError("Application readiness receipt is invalid.")
+        if schema_version != READINESS_SCHEMA_VERSION:
+            parent_pid = None
         try:
             surface = ApplicationReadinessSurface(raw_surface)
         except ValueError as error:
             raise ValueError("Application readiness receipt is invalid.") from error
-        return cls(pid=pid, token=token, surface=surface)
+        return cls(
+            pid=pid,
+            token=token,
+            surface=surface,
+            parent_pid=parent_pid,
+        )
 
 
 __all__ = [

--- a/tests/app/bootstrap/readiness/test_receipt_scheduling.py
+++ b/tests/app/bootstrap/readiness/test_receipt_scheduling.py
@@ -56,6 +56,7 @@ def test_readiness_receipt_is_queued_after_shell_reveal(
     callbacks[0]()
     payload = json.loads(readiness_path.read_text(encoding="utf-8"))
     assert payload == {
+        "parent_pid": os.getppid(),
         "pid": os.getpid(),
         "schema_version": application_readiness.READINESS_SCHEMA_VERSION,
         "surface": "main_shell",

--- a/tests/infrastructure/launcher/runtime/test_command_runner.py
+++ b/tests/infrastructure/launcher/runtime/test_command_runner.py
@@ -67,6 +67,36 @@ def test_subprocess_runtime_runner_replaces_invalid_output_bytes(
     assert output_lines == ["bad\ufffdbyte"]
 
 
+def test_subprocess_runtime_runner_survives_progress_sink_disconnect(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A closed splash connection must not abort a successful runtime update."""
+
+    callback_count = 0
+
+    def disconnected_progress_sink(_line: str) -> None:
+        """Model the launcher splash host closing during reconciliation."""
+
+        nonlocal callback_count
+        callback_count += 1
+        raise ConnectionResetError(10054, "closed")
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="launcher.sugarsubstitute_launcher.runtime_command",
+    ):
+        SubprocessRuntimeCommandRunner(disconnected_progress_sink).run(
+            [sys.executable, "-c", "print('first'); print('second')"],
+            cwd=tmp_path,
+            env=os.environ,
+        )
+
+    assert callback_count == 1
+    assert "Runtime progress sink disconnected" in caplog.text
+    assert "ConnectionResetError" in caplog.text
+
+
 def test_subprocess_runtime_runner_logs_captured_failure_output(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/launcher/application_readiness/test_supervisor.py
+++ b/tests/launcher/application_readiness/test_supervisor.py
@@ -22,6 +22,7 @@ from collections.abc import Callable, Mapping, Sequence
 import json
 from pathlib import Path
 import subprocess
+import sys
 
 import pytest
 
@@ -103,6 +104,7 @@ def test_supervisor_returns_only_after_matching_receipt(tmp_path: Path) -> None:
                     pid=process.pid,
                     token=environment[READINESS_TOKEN_ENV],
                     surface=ApplicationReadinessSurface.MAIN_SHELL,
+                    parent_pid=999,
                 ).to_json()
             ),
             encoding="utf-8",
@@ -145,6 +147,7 @@ def test_supervisor_preserves_outer_readiness_receipt(tmp_path: Path) -> None:
                     pid=process.pid,
                     token=environment[READINESS_TOKEN_ENV],
                     surface=ApplicationReadinessSurface.MAIN_SHELL,
+                    parent_pid=999,
                 ).to_json()
             ),
             encoding="utf-8",
@@ -194,6 +197,89 @@ def test_supervisor_rejects_partial_outer_readiness_contract(tmp_path: Path) -> 
     assert started is False
 
 
+def test_supervisor_accepts_shell_process_started_by_windows_venv_launcher(
+    tmp_path: Path,
+) -> None:
+    """A direct interpreter child may prove its virtualenv launcher became ready."""
+
+    receipt_path = tmp_path / "child-shell.json"
+    receipt_path.write_text(
+        json.dumps(
+            ApplicationReadinessReceipt(
+                pid=456,
+                parent_pid=123,
+                token="candidate-token",
+                surface=ApplicationReadinessSurface.MAIN_SHELL,
+            ).to_json()
+        ),
+        encoding="utf-8",
+    )
+
+    ApplicationReadinessSupervisor._validate_receipt(
+        receipt_path=receipt_path,
+        expected_token="candidate-token",
+        expected_pid=123,
+    )
+
+
+@pytest.mark.platforms("windows")
+def test_supervisor_accepts_real_windows_venv_redirector_process(
+    tmp_path: Path,
+) -> None:
+    """Exercise the distinct redirector and interpreter PIDs used in production."""
+
+    layout = InstallLayout.from_root(tmp_path / "install")
+    script = (
+        "import json, os, time; "
+        "from pathlib import Path; "
+        "from sugarsubstitute_shared.application_readiness import "
+        "ApplicationReadinessReceipt, ApplicationReadinessSurface, "
+        "READINESS_PATH_ENV, READINESS_TOKEN_ENV; "
+        "path = Path(os.environ[READINESS_PATH_ENV]); "
+        "path.parent.mkdir(parents=True, exist_ok=True); "
+        "path.write_text(json.dumps(ApplicationReadinessReceipt("
+        "pid=os.getpid(), parent_pid=os.getppid(), "
+        "token=os.environ[READINESS_TOKEN_ENV], "
+        "surface=ApplicationReadinessSurface.MAIN_SHELL).to_json()), "
+        "encoding='utf-8'); "
+        "time.sleep(2)"
+    )
+
+    process = ApplicationReadinessSupervisor(timeout_seconds=5).launch_until_ready(
+        layout=layout,
+        command=[sys.executable, "-c", script],
+        environment={},
+    )
+    receipt_path = layout.launcher_dir / "readiness" / "candidate.json"
+
+    assert not receipt_path.exists()
+    assert process.wait(timeout=5) == 0
+
+
+def test_supervisor_rejects_unrelated_receipt_process_chain(tmp_path: Path) -> None:
+    """A matching private token cannot authorize an unrelated process chain."""
+
+    receipt_path = tmp_path / "unrelated-shell.json"
+    receipt_path.write_text(
+        json.dumps(
+            ApplicationReadinessReceipt(
+                pid=456,
+                parent_pid=455,
+                token="candidate-token",
+                surface=ApplicationReadinessSurface.MAIN_SHELL,
+            ).to_json()
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ApplicationReadinessError, match="launched process"):
+        ApplicationReadinessSupervisor._validate_receipt(
+            receipt_path=receipt_path,
+            expected_token="candidate-token",
+            expected_pid=123,
+        )
+
+
 def test_supervisor_rejects_onboarding_as_candidate_readiness(tmp_path: Path) -> None:
     """Candidate activation must require the real main shell."""
 
@@ -204,6 +290,7 @@ def test_supervisor_rejects_onboarding_as_candidate_readiness(tmp_path: Path) ->
                 pid=123,
                 token="candidate-token",
                 surface=ApplicationReadinessSurface.ONBOARDING,
+                parent_pid=999,
             ).to_json()
         ),
         encoding="utf-8",

--- a/tests/launcher/candidate_update/test_manifest.py
+++ b/tests/launcher/candidate_update/test_manifest.py
@@ -37,9 +37,10 @@ def test_lifecycle_candidate_manifest_preserves_release_source_contract(
     LauncherConfig.from_layout(layout=layout).save(layout.config_path)
     candidate_manifest_url = "https://localhost:44443/manifest.json"
 
-    set_update_manifest(layout.root, candidate_manifest_url)
+    set_update_manifest(layout.root, candidate_manifest_url, channel="canary")
 
     updated_config = LauncherConfig.load(layout.config_path)
     assert updated_config.release_source is not None
     assert updated_config.release_source.kind == RELEASE_SOURCE_KIND_GITHUB
     assert updated_config.release_source.manifest_url == candidate_manifest_url
+    assert updated_config.channel == "canary"

--- a/tests/qualification/installer/test_candidate_upgrade.py
+++ b/tests/qualification/installer/test_candidate_upgrade.py
@@ -20,13 +20,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import socket
 import subprocess
 from types import SimpleNamespace
 from typing import cast
 
 import pytest
 
+from launcher.sugarsubstitute_launcher.config import LauncherConfig
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from sugarsubstitute_shared.application_readiness import (
     ApplicationReadinessReceipt,
@@ -44,7 +44,7 @@ from tools.ci.verify_installer_lifecycle import (
     _CandidateReleaseSource,
     _parse_args,
     _verify_candidate_evidence,
-    _verify_candidate_installer_update,
+    _verify_candidate_auto_update,
 )
 
 
@@ -56,8 +56,6 @@ def test_upgrade_cli_accepts_one_shared_installer_chain_timeout() -> None:
             "upgrade",
             "--historical-installer",
             "historical-installer",
-            "--candidate-installer",
-            "candidate-installer",
             "--install-root",
             "installed",
             "--historical-manifest-url",
@@ -72,6 +70,8 @@ def test_upgrade_cli_accepts_one_shared_installer_chain_timeout() -> None:
             "https://example.test/candidate.json",
             "--candidate-version",
             "9999.0.93",
+            "--candidate-channel",
+            "canary",
             "--timeout-seconds",
             "1200",
         ]
@@ -81,59 +81,16 @@ def test_upgrade_cli_accepts_one_shared_installer_chain_timeout() -> None:
     assert arguments.source_cache == Path("source-cache")
 
 
-def test_candidate_installer_updates_history_before_its_only_launch(
+def test_candidate_update_uses_historical_launcher_before_verification(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Portable history must update before its only installed-app launch."""
+    """Qualification must let the historical launcher consume the candidate feed."""
 
     install_root = tmp_path / "installed"
     layout = InstallLayout.from_root(install_root)
-    layout.config_path.parent.mkdir(parents=True)
-    layout.config_path.write_text(
-        json.dumps(
-            {
-                "release_source": {
-                    "kind": "github_release_manifest",
-                    "manifest_url": "https://example.test/history.json",
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
+    LauncherConfig.from_layout(layout=layout).save(layout.config_path)
     events: list[tuple[str, str]] = []
-    endpoint_port: int | None = None
-
-    def update_once(
-        *,
-        installer_path: Path,
-        install_root: Path,
-        manifest_url: str,
-        timeout_seconds: float,
-        environment: dict[str, str],
-    ) -> None:
-        """Record the real candidate-installer update boundary."""
-
-        assert installer_path == candidate_installer
-        del timeout_seconds, environment
-        assert endpoint_port is not None
-        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            with pytest.raises(OSError):
-                listener.bind(("127.0.0.1", endpoint_port))
-        finally:
-            listener.close()
-        payload = json.loads(
-            InstallLayout.from_root(install_root).config_path.read_text(
-                encoding="utf-8"
-            )
-        )
-        payload["release_source"]["manifest_url"] = manifest_url
-        InstallLayout.from_root(install_root).config_path.write_text(
-            json.dumps(payload),
-            encoding="utf-8",
-        )
-        events.append(("update", manifest_url))
 
     def launch_once(
         *,
@@ -144,9 +101,6 @@ def test_candidate_installer_updates_history_before_its_only_launch(
         """Record the manifest visible to the only installed launch."""
 
         del environment, progress_paths
-        assert endpoint_port is not None
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
-            listener.bind(("127.0.0.1", endpoint_port))
         payload = json.loads(
             InstallLayout.from_root(install_root).config_path.read_text(
                 encoding="utf-8"
@@ -161,14 +115,6 @@ def test_candidate_installer_updates_history_before_its_only_launch(
         del arguments
         events.append(("verify", "9999.0.109"))
 
-    monkeypatch.setattr(
-        "tools.ci.verify_installer_lifecycle.install_candidate_over_historical_install",
-        update_once,
-    )
-    monkeypatch.setattr(
-        "tools.ci.verify_installer_lifecycle.assert_installed_version",
-        lambda *_args, **_kwargs: None,
-    )
     monkeypatch.setattr(
         "tools.ci.verify_installer_lifecycle."
         "assert_historical_installed_launch_contract",
@@ -187,16 +133,14 @@ def test_candidate_installer_updates_history_before_its_only_launch(
         lambda _install_root: None,
     )
 
-    candidate_installer = tmp_path / "candidate-installer"
     with LoopbackPortLease.acquire() as endpoint_lease:
-        endpoint_port = endpoint_lease.port
-        _verify_candidate_installer_update(
-            candidate_installer_path=candidate_installer,
+        _verify_candidate_auto_update(
             install_root=install_root,
             historical_version="0.20.1",
             candidate_version="9999.0.109",
             candidate_manifest_url="https://example.test/candidate.json",
             candidate_release_root=None,
+            candidate_channel="canary",
             endpoint_lease=endpoint_lease,
             managed_workspace=install_root / "comfyui",
             managed_model_root=install_root / "qualified-models",
@@ -205,7 +149,6 @@ def test_candidate_installer_updates_history_before_its_only_launch(
         )
 
     assert events == [
-        ("update", "https://example.test/candidate.json"),
         ("launch", "https://example.test/candidate.json"),
         ("verify", "9999.0.109"),
     ]
@@ -276,6 +219,7 @@ def test_managed_backend_is_verified_before_live_shell_cleanup(
     )
     receipt = ApplicationReadinessReceipt(
         pid=456,
+        parent_pid=123,
         token=evidence.token,
         surface=ApplicationReadinessSurface.MAIN_SHELL,
     )
@@ -287,8 +231,8 @@ def test_managed_backend_is_verified_before_live_shell_cleanup(
     )
     monkeypatch.setattr(
         installer_ui_qualification,
-        "assert_installed_version",
-        lambda *_arguments: events.append("version"),
+        "wait_for_installed_version",
+        lambda **_arguments: events.append("version"),
     )
     monkeypatch.setattr(
         installer_ui_qualification,
@@ -423,6 +367,7 @@ def test_completion_action_pid_must_match_readiness_receipt(
     )
     receipt = ApplicationReadinessReceipt(
         pid=456,
+        parent_pid=123,
         token=evidence.token,
         surface=ApplicationReadinessSurface.MAIN_SHELL,
     )

--- a/tests/qualification/installer/test_historical_upgrade.py
+++ b/tests/qualification/installer/test_historical_upgrade.py
@@ -34,7 +34,6 @@ from tools.ci.drive_windows_installer import (
     _wait_for_onboarding_window,
 )
 from tools.ci.historical_install_qualification import (
-    install_candidate_over_historical_install,
     prepare_portable_historical_install,
 )
 
@@ -106,45 +105,6 @@ def test_portable_historical_path_runs_the_complete_installer_contract(
     assert len(setup_requests) == 1
     assert setup_requests[0][:2] == (workspace, model_root)
     assert 0.0 < setup_requests[0][2] <= 60.0
-
-
-def test_update_uses_real_candidate_installer_over_historical_state(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Updates must execute the candidate installer's real pipeline."""
-
-    commands: list[list[str]] = []
-
-    def _run(command: list[str], **_kwargs: object) -> object:
-        """Capture the update invocation and report success."""
-
-        commands.append(command)
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr(
-        "tools.ci.historical_install_qualification.run_owned_process",
-        _run,
-    )
-    installer = tmp_path / "candidate-installer"
-    install_root = tmp_path / "installed"
-
-    install_candidate_over_historical_install(
-        installer_path=installer,
-        install_root=install_root,
-        manifest_url="https://example.test/candidate/manifest.json",
-        timeout_seconds=60.0,
-        environment={"QUALIFICATION": "1"},
-    )
-
-    assert commands == [
-        [
-            str(installer.resolve()),
-            "--headless-install",
-            f"--install-root={install_root.resolve()}",
-            "--manifest-url=https://example.test/candidate/manifest.json",
-        ]
-    ]
 
 
 def test_portable_historical_install_preserves_one_deadline_through_materialization(

--- a/tests/qualification/installer/test_installed_version_evidence.py
+++ b/tests/qualification/installer/test_installed_version_evidence.py
@@ -1,0 +1,56 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Qualify durable installed-version evidence after candidate readiness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from launcher.sugarsubstitute_launcher.update_state import LauncherUpdateState
+from tools.ci.installed_version_evidence import wait_for_installed_version
+
+
+def test_version_wait_survives_receipt_before_activation_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shell receipt may arrive immediately before durable state is committed."""
+
+    layout = InstallLayout.from_root(tmp_path / "installed")
+    version_path = layout.app_dir / "substitute" / "_version.py"
+    version_path.parent.mkdir(parents=True)
+    version_path.write_text('__version__ = "2.0.0"\n', encoding="utf-8")
+    LauncherUpdateState(installed_app_version="1.0.0").save(layout.state_path)
+
+    def commit_during_wait(_seconds: float) -> None:
+        """Model the supervisor committing after the app publishes readiness."""
+
+        LauncherUpdateState(installed_app_version="2.0.0").save(layout.state_path)
+
+    monkeypatch.setattr(
+        "tools.ci.installed_version_evidence.time.sleep",
+        commit_during_wait,
+    )
+
+    wait_for_installed_version(
+        install_root=layout.root,
+        expected_version="2.0.0",
+        timeout_seconds=1.0,
+    )

--- a/tests/qualification/release/workflow/test_qualification.py
+++ b/tests/qualification/release/workflow/test_qualification.py
@@ -237,7 +237,8 @@ def test_release_qualification_covers_clean_launch_and_upgrade_depth() -> None:
         PROJECT_ROOT / "tools" / "ci" / "historical_install_qualification.py"
     ).read_text(encoding="utf-8")
     assert "run_current_installer_ui" in lifecycle_text
-    assert "install_candidate_over_historical_install" in lifecycle_text
+    assert "set_update_manifest" in lifecycle_text
+    assert "install_candidate_over_historical_install" not in lifecycle_text
     assert "INSTALLER_QUALIFICATION_PLAN_ENV" in ui_qualification_text
     current_installer_path = ui_qualification_text.split(
         "def run_current_installer_ui", maxsplit=1
@@ -257,8 +258,10 @@ def test_release_qualification_covers_clean_launch_and_upgrade_depth() -> None:
         "QT_QPA_PLATFORM: ${{ matrix.platform == 'macos' && 'cocoa' || 'offscreen' }}"
     ) in update_text
     assert '"--historical-release-root"' in update_text
-    assert '--candidate-installer "$env:CANDIDATE_INSTALLER"' in update_text
-    assert "CANDIDATE_INSTALLER=" in update_text
+    assert '--candidate-installer "$env:CANDIDATE_INSTALLER"' not in update_text
+    assert "CANDIDATE_INSTALLER=" not in update_text
+    assert '"--candidate-manifest-url"' in update_text
+    assert '--candidate-channel "${{ inputs.candidate_channel }}"' in update_text
     assert "Build version-pinned historical Windows setup" not in update_text
     assert "SugarSubstitute-Local-Test-Installer" not in update_text
 

--- a/tests/shared/application_readiness/test_receipt.py
+++ b/tests/shared/application_readiness/test_receipt.py
@@ -34,3 +34,39 @@ def test_legacy_readiness_receipt_remains_parseable_but_not_main_shell() -> None
 
     assert READINESS_SCHEMA_VERSION > 1
     assert receipt.surface is ApplicationReadinessSurface.LEGACY_VISIBLE_SHELL
+    assert receipt.parent_pid is None
+
+
+def test_schema_two_readiness_receipt_remains_parseable_without_parent() -> None:
+    """Retain prior main-shell evidence while withholding descendant identity."""
+
+    receipt = ApplicationReadinessReceipt.from_json(
+        {
+            "pid": 123,
+            "schema_version": 2,
+            "surface": "main_shell",
+            "token": "legacy-token",
+        }
+    )
+
+    assert receipt.surface is ApplicationReadinessSurface.MAIN_SHELL
+    assert receipt.parent_pid is None
+
+
+def test_current_readiness_receipt_requires_a_positive_parent_pid() -> None:
+    """Reject current process-chain evidence without a valid direct parent."""
+
+    try:
+        ApplicationReadinessReceipt.from_json(
+            {
+                "parent_pid": None,
+                "pid": 123,
+                "schema_version": READINESS_SCHEMA_VERSION,
+                "surface": "main_shell",
+                "token": "launch-token",
+            }
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Current readiness evidence accepted no parent PID.")

--- a/tools/ci/historical_install_qualification.py
+++ b/tools/ci/historical_install_qualification.py
@@ -82,36 +82,6 @@ def prepare_portable_historical_install(
     )
 
 
-def install_candidate_over_historical_install(
-    *,
-    installer_path: Path,
-    install_root: Path,
-    manifest_url: str | None,
-    timeout_seconds: float,
-    environment: dict[str, str],
-) -> None:
-    """Install candidate bytes over one completed historical installation."""
-
-    command = [
-        str(installer_path.resolve()),
-        "--headless-install",
-        f"--install-root={install_root.resolve()}",
-    ]
-    if manifest_url is not None:
-        command.append(f"--manifest-url={manifest_url}")
-    result = run_owned_process(
-        command,
-        cwd=installer_path.resolve().parent,
-        environment=environment,
-        timeout_seconds=timeout_seconds,
-    )
-    if result.returncode != 0:
-        raise InstallerLifecycleError(
-            f"Candidate installer update exited with {result.returncode}.\n"
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
-
-
 def seed_historical_user_configuration(
     *,
     install_root: Path,
@@ -199,7 +169,6 @@ def _remaining_timeout(deadline: float, *, phase: str) -> float:
 
 __all__ = [
     "assert_historical_user_configuration_preserved",
-    "install_candidate_over_historical_install",
     "prepare_portable_historical_install",
     "seed_historical_user_configuration",
 ]

--- a/tools/ci/installed_version_evidence.py
+++ b/tools/ci/installed_version_evidence.py
@@ -1,0 +1,70 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify the durable application version committed by an installed launcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import time
+
+from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from launcher.sugarsubstitute_launcher.update_state import LauncherUpdateState
+from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
+
+
+def assert_installed_version(install_root: Path, expected_version: str) -> None:
+    """Require launcher state and app source to identify the expected release."""
+
+    layout = InstallLayout.from_root(install_root)
+    state = LauncherUpdateState.load(layout.state_path)
+    if state.installed_app_version != expected_version:
+        raise InstallerLifecycleError(
+            "Launcher state version mismatch: "
+            f"{state.installed_app_version} != {expected_version}."
+        )
+    expected_line = f'__version__ = "{expected_version}"'
+    version_path = layout.app_dir / "substitute" / "_version.py"
+    if expected_line not in version_path.read_text(encoding="utf-8"):
+        raise InstallerLifecycleError(
+            f"Installed app source does not identify version {expected_version}."
+        )
+
+
+def wait_for_installed_version(
+    *,
+    install_root: Path,
+    expected_version: str,
+    timeout_seconds: float,
+) -> None:
+    """Wait until candidate readiness has been committed to durable update state."""
+
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            assert_installed_version(install_root, expected_version)
+        except (InstallerLifecycleError, OSError) as error:
+            last_error = error
+            time.sleep(0.05)
+            continue
+        return
+    raise InstallerLifecycleError(
+        f"Installed update did not commit version {expected_version}."
+    ) from last_error
+
+
+__all__ = ["assert_installed_version", "wait_for_installed_version"]

--- a/tools/ci/installer_ui_qualification.py
+++ b/tools/ci/installer_ui_qualification.py
@@ -33,7 +33,6 @@ from launcher.sugarsubstitute_launcher.install_layout import (
     InstallLayout,
     default_install_root,
 )
-from launcher.sugarsubstitute_launcher.update_state import LauncherUpdateState
 from sugarsubstitute_shared.application_readiness import (
     READINESS_PATH_ENV,
     READINESS_TOKEN_ENV,
@@ -46,6 +45,7 @@ from sugarsubstitute_shared.installer_qualification import (
     InstallerQualificationTarget,
 )
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
+from tools.ci.installed_version_evidence import wait_for_installed_version
 from tools.ci.managed_comfy_qualification import assert_real_managed_comfy
 
 _INSTALL_TIMEOUT_SECONDS = 3_600.0
@@ -297,15 +297,15 @@ def verify_main_shell_evidence(
     """Require UI events, installed version, splash sequence, and main shell."""
 
     receipt: ApplicationReadinessReceipt | None = None
+    verification_timeout = (
+        evidence.plan.timeout_seconds if timeout_seconds is None else timeout_seconds
+    )
+    verification_deadline = time.monotonic() + verification_timeout
     try:
         receipt = _wait_for_readiness_receipt(
             readiness_path=evidence.readiness_path,
             token=evidence.token,
-            timeout_seconds=(
-                evidence.plan.timeout_seconds
-                if timeout_seconds is None
-                else timeout_seconds
-            ),
+            timeout_seconds=verification_timeout,
             candidate_launch=candidate_launch,
             trace_path=evidence.trace_path,
             diagnostic_paths=_evidence_diagnostic_paths(
@@ -320,7 +320,11 @@ def verify_main_shell_evidence(
                 "The completion action and readiness receipt identified different "
                 f"main-shell processes: {expected_main_pid} != {receipt.pid}."
             )
-        assert_installed_version(install_root, expected_version)
+        wait_for_installed_version(
+            install_root=install_root,
+            expected_version=expected_version,
+            timeout_seconds=max(0.0, verification_deadline - time.monotonic()),
+        )
         if required_qualification_events:
             assert_qualification_event_sequence(
                 evidence.event_log_path,
@@ -339,24 +343,6 @@ def verify_main_shell_evidence(
             terminate_verified_process(receipt.pid)
         if candidate_launch is not None and candidate_launch.process.poll() is None:
             terminate_verified_process(candidate_launch.process.pid)
-
-
-def assert_installed_version(install_root: Path, expected_version: str) -> None:
-    """Require both launcher state and app source to identify the expected release."""
-
-    layout = InstallLayout.from_root(install_root)
-    state = LauncherUpdateState.load(layout.state_path)
-    if state.installed_app_version != expected_version:
-        raise InstallerLifecycleError(
-            "Launcher state version mismatch: "
-            f"{state.installed_app_version} != {expected_version}."
-        )
-    expected_line = f'__version__ = "{expected_version}"'
-    version_path = layout.app_dir / "substitute" / "_version.py"
-    if expected_line not in version_path.read_text(encoding="utf-8"):
-        raise InstallerLifecycleError(
-            f"Installed app source does not identify version {expected_version}."
-        )
 
 
 def assert_qualification_event_sequence(
@@ -783,7 +769,6 @@ def _windows_process_exists(pid: int) -> bool:
 __all__ = [
     "InstalledCandidateLaunch",
     "InstallerQualificationEvidence",
-    "assert_installed_version",
     "assert_qualification_event_sequence",
     "assert_startup_trace_sequence",
     "diagnostic_tail",

--- a/tools/ci/verify_installer_lifecycle.py
+++ b/tools/ci/verify_installer_lifecycle.py
@@ -43,7 +43,6 @@ from tools.ci.comfy_source_cache import (  # noqa: E402
 )
 from tools.ci.historical_install_qualification import (  # noqa: E402
     assert_historical_user_configuration_preserved,
-    install_candidate_over_historical_install,
     prepare_portable_historical_install,
     seed_historical_user_configuration,
 )
@@ -58,12 +57,12 @@ from tools.ci.external_comfy_readiness_server import (  # noqa: E402
 from tools.ci.installer_ui_qualification import (  # noqa: E402
     InstalledCandidateLaunch,
     InstallerQualificationEvidence,
-    assert_installed_version,
     launch_installed_candidate,
     prepare_qualification_evidence,
     run_current_installer_ui,
     verify_main_shell_evidence,
 )
+from tools.ci.installed_version_evidence import assert_installed_version  # noqa: E402
 from tools.ci.local_release_server import LocalReleaseServer  # noqa: E402
 from tools.ci.loopback_port_lease import LoopbackPortLease  # noqa: E402
 from tools.ci.managed_comfy_qualification import terminate_owned_managed_comfy  # noqa: E402
@@ -175,14 +174,13 @@ def verify_clean_install(
 def verify_upgrade(
     *,
     historical_installer_path: Path,
-    candidate_installer_path: Path,
     install_root: Path,
     historical_manifest_url: str,
     historical_version: str,
     historical_published_at: str,
     candidate_manifest_url: str | None,
     candidate_version: str,
-    candidate_channel: str | None = None,
+    candidate_channel: str,
     expected_update_manifest_url: str | None = None,
     candidate_release_root: Path | None = None,
     historical_release_root: Path | None = None,
@@ -234,8 +232,7 @@ def verify_upgrade(
             managed_workspace=managed_workspace,
             managed_model_root=managed_model_root,
         )
-        _verify_candidate_installer_update(
-            candidate_installer_path=candidate_installer_path,
+        _verify_candidate_auto_update(
             install_root=install_root,
             historical_version=historical_version,
             candidate_version=candidate_version,
@@ -258,13 +255,12 @@ def verify_upgrade(
     )
 
 
-def _verify_candidate_installer_update(
+def _verify_candidate_auto_update(
     *,
-    candidate_installer_path: Path,
     install_root: Path,
     historical_version: str,
     candidate_version: str,
-    candidate_channel: str | None = None,
+    candidate_channel: str,
     expected_update_manifest_url: str | None = None,
     candidate_manifest_url: str | None,
     candidate_release_root: Path | None,
@@ -274,7 +270,7 @@ def _verify_candidate_installer_update(
     preservation_marker: Path,
     timeout_seconds: float,
 ) -> None:
-    """Launch once after candidate activation and require the real main shell."""
+    """Drive the historical installed launcher through its production updater."""
 
     qualification_deadline = time.monotonic() + timeout_seconds
     with _candidate_release_source(
@@ -283,6 +279,8 @@ def _verify_candidate_installer_update(
         certificate_root=install_root.parent / ".candidate-certificate",
     ) as candidate_source:
         try:
+            if candidate_source.manifest_url is None:
+                raise InstallerLifecycleError("Candidate update manifest is missing.")
             evidence = prepare_qualification_evidence(
                 install_root=install_root,
                 expected_version=candidate_version,
@@ -294,21 +292,10 @@ def _verify_candidate_installer_update(
                 ),
             )
             _trust_candidate_source(evidence.environment, candidate_source)
-            install_candidate_over_historical_install(
-                installer_path=candidate_installer_path,
+            set_update_manifest(
                 install_root=install_root,
                 manifest_url=candidate_source.manifest_url,
-                timeout_seconds=_remaining_qualification_timeout(
-                    qualification_deadline,
-                    phase="candidate installer update",
-                ),
-                environment=evidence.environment,
-            )
-            assert_installed_version(install_root, candidate_version)
-            assert_installed_release_channel(
-                install_root=install_root,
-                expected_channel=candidate_channel,
-                expected_update_manifest_url=expected_update_manifest_url,
+                channel=candidate_channel,
             )
             assert_historical_installed_launch_contract(install_root)
             endpoint_lease.release_for_handoff()
@@ -330,6 +317,13 @@ def _verify_candidate_installer_update(
                 timeout_seconds=_remaining_qualification_timeout(
                     qualification_deadline,
                     phase="candidate main-shell readiness",
+                ),
+            )
+            assert_installed_release_channel(
+                install_root=install_root,
+                expected_channel=candidate_channel,
+                expected_update_manifest_url=(
+                    expected_update_manifest_url or candidate_source.manifest_url
                 ),
             )
         finally:
@@ -384,8 +378,13 @@ def _trust_candidate_source(
         environment["UV_SYSTEM_CERTS"] = "true"
 
 
-def set_update_manifest(install_root: Path, manifest_url: str) -> None:
-    """Point a historical installation at the exact candidate manifest."""
+def set_update_manifest(
+    install_root: Path,
+    manifest_url: str,
+    *,
+    channel: str,
+) -> None:
+    """Point a historical installation at the exact candidate update channel."""
 
     layout = InstallLayout.from_root(install_root)
     payload = json.loads(layout.config_path.read_text(encoding="utf-8"))
@@ -395,6 +394,7 @@ def set_update_manifest(install_root: Path, manifest_url: str) -> None:
         "kind": RELEASE_SOURCE_KIND_GITHUB,
         "manifest_url": manifest_url,
     }
+    payload["channel"] = channel
     layout.config_path.write_text(
         json.dumps(payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -483,7 +483,6 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     upgrade = subparsers.add_parser("upgrade")
     upgrade.add_argument("--historical-installer", type=Path, required=True)
-    upgrade.add_argument("--candidate-installer", type=Path, required=True)
     upgrade.add_argument("--install-root", type=Path, required=True)
     upgrade.add_argument("--historical-manifest-url", required=True)
     upgrade.add_argument("--historical-release-root", type=Path)
@@ -493,7 +492,7 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     upgrade.add_argument("--candidate-manifest-url")
     upgrade.add_argument("--candidate-release-root", type=Path)
     upgrade.add_argument("--candidate-version", required=True)
-    upgrade.add_argument("--candidate-channel")
+    upgrade.add_argument("--candidate-channel", required=True)
     upgrade.add_argument("--expected-update-manifest-url")
     upgrade.add_argument(
         "--timeout-seconds",
@@ -520,7 +519,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         verify_upgrade(
             historical_installer_path=args.historical_installer,
-            candidate_installer_path=args.candidate_installer,
             install_root=args.install_root,
             historical_manifest_url=args.historical_manifest_url,
             historical_version=args.historical_version,


### PR DESCRIPTION
## Summary\n- accept readiness from the real application process behind the Windows virtual-environment redirector\n- keep update execution alive when the splash IPC connection closes\n- make release qualification drive the historical install through the production manifest-based automatic updater\n\n## Local verification\n- full parallel test suite\n- all 85 isolated test modules\n- serial test module\n- ruff format and lint\n- mypy strict\n- architecture and test governance