### PR TITLE
fix(updates): apply managed nodepack pins after app updates

### DIFF
--- a/launcher/sugarsubstitute_launcher/application_launch.py
+++ b/launcher/sugarsubstitute_launcher/application_launch.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from sugarsubstitute_shared.application_launch_guard import ApplicationLaunchGuard
+from sugarsubstitute_shared.application_runtime_mode import (
+    packaged_application_environment,
+)
 from sugarsubstitute_shared.startup_remote_access import StartupRemoteAccess
 
 
@@ -44,7 +47,9 @@ def installed_application_environment(
     remote_access = StartupRemoteAccess()
     if remote_failure_reason is not None:
         remote_access.degrade(reason=remote_failure_reason)
-    return remote_access.child_environment(launch_guard.initial_handoff_environment())
+    return packaged_application_environment(
+        remote_access.child_environment(launch_guard.initial_handoff_environment())
+    )
 
 
 __all__ = ["enter_installed_application_launch", "installed_application_environment"]

--- a/launcher/sugarsubstitute_launcher/candidate_update_launch.py
+++ b/launcher/sugarsubstitute_launcher/candidate_update_launch.py
@@ -32,6 +32,9 @@ from launcher.sugarsubstitute_launcher.application_readiness_supervisor import (
 )
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from launcher.sugarsubstitute_launcher.process import start_detached
+from sugarsubstitute_shared.application_runtime_mode import (
+    packaged_application_environment,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -96,7 +99,9 @@ def launch_prepared_update(
         process = readiness_supervisor.launch_until_ready(
             layout=layout,
             command=command,
-            environment=initial_guard.initial_handoff_environment(),
+            environment=packaged_application_environment(
+                initial_guard.initial_handoff_environment()
+            ),
         )
         try:
             activation.commit()
@@ -119,7 +124,9 @@ def launch_prepared_update(
         try:
             fallback_process_starter(
                 command,
-                environment=fallback_guard.initial_handoff_environment(),
+                environment=packaged_application_environment(
+                    fallback_guard.initial_handoff_environment()
+                ),
             )
         except BaseException:
             fallback_guard.release()

--- a/substitute/application/runtime_mode.py
+++ b/substitute/application/runtime_mode.py
@@ -23,6 +23,10 @@ import sys
 from dataclasses import dataclass
 from enum import Enum
 
+from sugarsubstitute_shared.application_runtime_mode import (
+    APPLICATION_RUNTIME_MODE_ENV,
+)
+
 
 class ApplicationRuntimeMode(Enum):
     """Identify whether Substitute is running from source or as a release build."""
@@ -41,7 +45,7 @@ class ApplicationRuntimeModeService:
     def from_environment(cls) -> "ApplicationRuntimeModeService":
         """Build the service from explicit environment or packaging evidence."""
 
-        configured = os.environ.get("SUBSTITUTE_RUNTIME_MODE", "").strip().lower()
+        configured = os.environ.get(APPLICATION_RUNTIME_MODE_ENV, "").strip().lower()
         if configured in {"release", "packaged"}:
             return cls(ApplicationRuntimeMode.RELEASE)
         if configured in {"development", "dev", "source"}:

--- a/sugarsubstitute_shared/application_runtime_mode.py
+++ b/sugarsubstitute_shared/application_runtime_mode.py
@@ -1,0 +1,42 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Share the installed-application runtime-mode handoff contract."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+APPLICATION_RUNTIME_MODE_ENV = "SUBSTITUTE_RUNTIME_MODE"
+PACKAGED_APPLICATION_RUNTIME_MODE = "release"
+
+
+def packaged_application_environment(
+    environment: Mapping[str, str],
+) -> dict[str, str]:
+    """Return an app-child environment with release policy enabled."""
+
+    child_environment = dict(environment)
+    child_environment[APPLICATION_RUNTIME_MODE_ENV] = PACKAGED_APPLICATION_RUNTIME_MODE
+    return child_environment
+
+
+__all__ = [
+    "APPLICATION_RUNTIME_MODE_ENV",
+    "PACKAGED_APPLICATION_RUNTIME_MODE",
+    "packaged_application_environment",
+]

--- a/tests/launcher/application_launch/test_update_handoff.py
+++ b/tests/launcher/application_launch/test_update_handoff.py
@@ -38,6 +38,10 @@ from launcher.sugarsubstitute_launcher.release_sources import GitHubReleaseSourc
 from sugarsubstitute_shared.application_launch_guard import (
     APPLICATION_LAUNCH_TOKEN_ENV,
 )
+from sugarsubstitute_shared.application_runtime_mode import (
+    APPLICATION_RUNTIME_MODE_ENV,
+    PACKAGED_APPLICATION_RUNTIME_MODE,
+)
 from sugarsubstitute_shared.startup_remote_access import (
     STARTUP_REMOTE_DEGRADED_ENV,
 )
@@ -154,6 +158,10 @@ def test_launcher_main_runs_pre_launch_update_before_app_handoff(
     ]
     assert len(child_environments) == 1
     assert APPLICATION_LAUNCH_TOKEN_ENV in child_environments[0]
+    assert (
+        child_environments[0][APPLICATION_RUNTIME_MODE_ENV]
+        == PACKAGED_APPLICATION_RUNTIME_MODE
+    )
     assert (
         child_environments[0].get(STARTUP_REMOTE_DEGRADED_ENV)
         == expected_degraded_value

--- a/tests/launcher/candidate_update/test_launch.py
+++ b/tests/launcher/candidate_update/test_launch.py
@@ -30,6 +30,10 @@ from launcher.sugarsubstitute_launcher.candidate_update_launch import (
     launch_prepared_update,
 )
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from sugarsubstitute_shared.application_runtime_mode import (
+    APPLICATION_RUNTIME_MODE_ENV,
+    PACKAGED_APPLICATION_RUNTIME_MODE,
+)
 
 
 class _Guard:
@@ -143,7 +147,12 @@ def test_ready_candidate_commits_without_fallback(tmp_path: Path) -> None:
     )
 
     assert activation.transitions == ["commit"]
-    assert supervisor.environments == [{"GUARD": "candidate"}]
+    assert supervisor.environments == [
+        {
+            "GUARD": "candidate",
+            APPLICATION_RUNTIME_MODE_ENV: PACKAGED_APPLICATION_RUNTIME_MODE,
+        }
+    ]
     assert guard.released is False
 
 
@@ -174,5 +183,11 @@ def test_failed_candidate_rolls_back_and_launches_previous_app(
     assert candidate_guard.released is True
     assert fallback_guard.released is False
     assert started == [
-        (["python", "main.py"], {"GUARD": "fallback"}),
+        (
+            ["python", "main.py"],
+            {
+                "GUARD": "fallback",
+                APPLICATION_RUNTIME_MODE_ENV: PACKAGED_APPLICATION_RUNTIME_MODE,
+            },
+        ),
     ]

--- a/tests/qualification/installer/test_historical_managed_configuration.py
+++ b/tests/qualification/installer/test_historical_managed_configuration.py
@@ -120,6 +120,17 @@ def test_existing_runtime_is_converged_before_readiness_is_recorded(
         "tools.ci.historical_managed_configuration.ensure_core_comfy_nodepacks",
         lambda *_args, **_kwargs: operations.append("nodepacks"),
     )
+
+    def _restore_historical_sugarcubes(**_kwargs: object) -> str:
+        """Record restoration and return the historical pin for setup evidence."""
+
+        operations.append("historical_sugarcubes")
+        return "0.11.0"
+
+    monkeypatch.setattr(
+        "tools.ci.historical_managed_configuration.restore_historical_sugarcubes",
+        _restore_historical_sugarcubes,
+    )
     monkeypatch.setattr(
         "tools.ci.historical_managed_configuration.run_sugarcubes_baseline_maintenance",
         lambda *_args, **_kwargs: operations.append("sugarcubes"),
@@ -172,6 +183,11 @@ def test_existing_runtime_is_converged_before_readiness_is_recorded(
         cache.close()
     assert payload["success"] is True
     assert payload["key"]["strategy"]["source"] == ("existing_qualification_runtime")
+    sugarcubes_key = next(
+        item for item in payload["key"]["core_nodepacks"] if item["id"] == "SugarCubes"
+    )
+    assert sugarcubes_key["required_version"] == "0.11.0"
+    assert sugarcubes_key["fallback_archive"].endswith("/v0.11.0.zip")
     expected_force_cpu_mode = sys.platform != "darwin"
     assert payload["request"]["force_cpu_mode"] is expected_force_cpu_mode
     assert payload["runtime_configuration"]["force_cpu_mode"] is expected_force_cpu_mode
@@ -190,6 +206,7 @@ def test_existing_runtime_is_converged_before_readiness_is_recorded(
         "environment",
         "manager",
         "nodepacks",
+        "historical_sugarcubes",
         "sugarcubes",
         "model_root",
         "validation",
@@ -215,6 +232,11 @@ def test_existing_runtime_is_converged_before_readiness_is_recorded(
         "HISTORICAL_MATERIALIZATION phase=manager state=completed",
         "HISTORICAL_MATERIALIZATION phase=core_nodepacks state=started",
         "HISTORICAL_MATERIALIZATION phase=core_nodepacks state=completed",
+        "HISTORICAL_MATERIALIZATION phase=historical_sugarcubes state=started",
+        (
+            "HISTORICAL_MATERIALIZATION phase=historical_sugarcubes "
+            "state=completed version=0.11.0"
+        ),
         "HISTORICAL_MATERIALIZATION phase=sugarcubes state=started",
         "HISTORICAL_MATERIALIZATION phase=sugarcubes state=completed",
         "HISTORICAL_MATERIALIZATION phase=model_root state=started",

--- a/tests/qualification/installer/test_historical_nodepack_fixture.py
+++ b/tests/qualification/installer/test_historical_nodepack_fixture.py
@@ -1,0 +1,147 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify historical SugarCubes qualification fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.ci.historical_nodepack_fixture import (
+    historical_sugarcubes_freshness_key,
+    read_historical_sugarcubes_version,
+    restore_historical_sugarcubes,
+)
+from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
+
+
+def test_historical_pin_is_read_from_the_installed_app_payload(tmp_path: Path) -> None:
+    """Qualification should derive history from the installed signed payload."""
+
+    contract = tmp_path / "app" / "substitute" / "domain" / "comfy_nodepacks.py"
+    contract.parent.mkdir(parents=True)
+    contract.write_text(
+        'SUBSTITUTE_BACKEND_REQUIRED_VERSION = "1.8.0"\n'
+        'SUGARCUBES_REQUIRED_VERSION = "0.11.0"\n',
+        encoding="utf-8",
+    )
+
+    assert read_historical_sugarcubes_version(tmp_path) == "0.11.0"
+
+
+def test_dynamic_historical_pin_is_rejected(tmp_path: Path) -> None:
+    """Qualification must not execute historical source to discover its pin."""
+
+    contract = tmp_path / "app" / "substitute" / "domain" / "comfy_nodepacks.py"
+    contract.parent.mkdir(parents=True)
+    contract.write_text(
+        "SUGARCUBES_REQUIRED_VERSION = load_version()\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InstallerLifecycleError, match="literal SugarCubes"):
+        read_historical_sugarcubes_version(tmp_path)
+
+
+def test_restore_uses_historical_release_and_requires_installed_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fixture should replace candidate SugarCubes with exact old source."""
+
+    contract = tmp_path / "install" / "app" / "substitute" / "domain"
+    contract.mkdir(parents=True)
+    (contract / "comfy_nodepacks.py").write_text(
+        'SUGARCUBES_REQUIRED_VERSION = "0.11.0"\n',
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "comfyui"
+    installed_manifest: list[object] = []
+    dependency_roots: list[Path] = []
+
+    def _install(self: object, **arguments: object) -> None:
+        """Record the historical manifest and materialize its inspected identity."""
+
+        del self
+        manifest = arguments["nodepack"]
+        installed_manifest.append(manifest)
+        target_path = arguments["target_path"]
+        assert isinstance(target_path, Path)
+        target_path.mkdir(parents=True)
+        (target_path / "pyproject.toml").write_text(
+            '[project]\nname = "SugarCubes"\nversion = "0.11.0"\n',
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(
+        "tools.ci.historical_nodepack_fixture."
+        "PinnedNodepackSourceInstaller.install_fallback",
+        _install,
+    )
+    monkeypatch.setattr(
+        "tools.ci.historical_nodepack_fixture.install_nodepack_python_dependencies",
+        lambda **arguments: dependency_roots.append(arguments["nodepack_root"]),
+    )
+
+    restored = restore_historical_sugarcubes(
+        install_root=tmp_path / "install",
+        workspace=workspace,
+        python_executable=workspace / "python.exe",
+        environment={},
+    )
+
+    assert restored == "0.11.0"
+    manifest = installed_manifest[0]
+    assert getattr(manifest, "required_version") == "0.11.0"
+    assert getattr(manifest, "fallback_archive_url").endswith("/v0.11.0.zip")
+    assert dependency_roots == [workspace / "custom_nodes" / "SugarCubes"]
+
+
+def test_freshness_evidence_records_the_historical_pin() -> None:
+    """Candidate startup must observe a version-policy change in saved evidence."""
+
+    candidate_key: dict[str, object] = {
+        "schema_version": 5,
+        "core_nodepacks": [
+            {
+                "id": "substitute-backend",
+                "required_version": "1.9.1",
+            },
+            {
+                "id": "SugarCubes",
+                "required_version": "0.12.0",
+                "fallback_archive": "https://example.test/v0.12.0.zip",
+            },
+        ],
+    }
+
+    historical_key = historical_sugarcubes_freshness_key(
+        candidate_key,
+        historical_version="0.11.0",
+    )
+
+    historical_nodepacks = historical_key["core_nodepacks"]
+    assert isinstance(historical_nodepacks, list)
+    historical_sugarcubes = next(
+        item
+        for item in historical_nodepacks
+        if isinstance(item, dict) and item.get("id") == "SugarCubes"
+    )
+    assert historical_sugarcubes["required_version"] == "0.11.0"
+    assert historical_sugarcubes["fallback_archive"].endswith("/v0.11.0.zip")
+    assert candidate_key["core_nodepacks"] != historical_key["core_nodepacks"]

--- a/tools/ci/historical_managed_configuration.py
+++ b/tools/ci/historical_managed_configuration.py
@@ -82,6 +82,10 @@ from tools.ci.comfy_probe_support import prepare_environment
 from tools.ci.comfy_source_checkout import prepare_checkout
 from tools.ci.comfy_support_matrix import COMFY_SUPPORT_MATRIX
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
+from tools.ci.historical_nodepack_fixture import (
+    historical_sugarcubes_freshness_key,
+    restore_historical_sugarcubes,
+)
 from tools.ci.owned_process_runner import run_owned_process
 
 
@@ -194,6 +198,7 @@ def _materialize_historical_managed_configuration(
     prepare_environment(repository_root, managed_workspace)
     _record_phase(progress_path, "python_environment", "completed")
     _prepare_qualified_existing_managed_workspace(
+        install_root=install_root,
         workspace=managed_workspace,
         model_root=managed_model_root,
         runtime_state_dir=installation.runtime_state_dir,
@@ -204,6 +209,7 @@ def _materialize_historical_managed_configuration(
 
 def _prepare_qualified_existing_managed_workspace(
     *,
+    install_root: Path,
     workspace: Path,
     model_root: Path,
     runtime_state_dir: Path,
@@ -226,6 +232,18 @@ def _prepare_qualified_existing_managed_workspace(
         env=environment,
     )
     _record_phase(progress_path, "core_nodepacks", "completed")
+    _record_phase(progress_path, "historical_sugarcubes", "started")
+    historical_sugarcubes_version = restore_historical_sugarcubes(
+        install_root=install_root,
+        workspace=workspace,
+        python_executable=python_executable,
+        environment=environment,
+    )
+    _record_phase(
+        progress_path,
+        "historical_sugarcubes",
+        f"completed version={historical_sugarcubes_version}",
+    )
     _record_phase(progress_path, "sugarcubes", "started")
     run_sugarcubes_baseline_maintenance(
         workspace,
@@ -266,7 +284,10 @@ def _prepare_qualified_existing_managed_workspace(
     FileManagedRuntimeConfigurationRepository(runtime_state_dir).save(
         runtime_configuration
     )
-    freshness_key = installed_setup_static_freshness_key(workspace)
+    freshness_key = historical_sugarcubes_freshness_key(
+        installed_setup_static_freshness_key(workspace),
+        historical_version=historical_sugarcubes_version,
+    )
     freshness_key["strategy"] = {
         "source": "existing_qualification_runtime",
         "target": target.value,

--- a/tools/ci/historical_nodepack_fixture.py
+++ b/tools/ci/historical_nodepack_fixture.py
@@ -1,0 +1,163 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Restore historical core-nodepack state for update qualification."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+
+from substitute.domain.comfy_nodepacks import CoreNodepackId
+from substitute.infrastructure.comfy.nodepack_installation_inspector import (
+    read_nodepack_project_identity,
+)
+from substitute.infrastructure.comfy.nodepack_manifest import CORE_COMFY_NODEPACKS
+from substitute.infrastructure.comfy.nodepack_python_dependencies import (
+    install_nodepack_python_dependencies,
+)
+from substitute.infrastructure.comfy.pinned_nodepack_source import (
+    PinnedNodepackSourceInstaller,
+)
+from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
+
+_SUGARCUBES_VERSION_NAME = "SUGARCUBES_REQUIRED_VERSION"
+_SUGARCUBES_RELEASE_ARCHIVE = (
+    "https://github.com/Artificial-Sweetener/SugarCubes/archive/refs/tags/"
+)
+
+
+def restore_historical_sugarcubes(
+    *,
+    install_root: Path,
+    workspace: Path,
+    python_executable: Path,
+    environment: Mapping[str, str],
+) -> str:
+    """Replace the candidate fixture with the historical app's SugarCubes pin."""
+
+    historical_version = read_historical_sugarcubes_version(install_root)
+    current_manifest = next(
+        nodepack
+        for nodepack in CORE_COMFY_NODEPACKS
+        if nodepack.nodepack_id is CoreNodepackId.SUGARCUBES
+    )
+    historical_manifest = replace(
+        current_manifest,
+        required_version=historical_version,
+        fallback_archive_url=(
+            f"{_SUGARCUBES_RELEASE_ARCHIVE}v{historical_version}.zip"
+        ),
+    )
+    target_path = workspace / historical_manifest.expected_folder
+    PinnedNodepackSourceInstaller().install_fallback(
+        target_path=target_path,
+        nodepack=historical_manifest,
+        on_log=None,
+        env=environment,
+    )
+    install_nodepack_python_dependencies(
+        python_executable=python_executable,
+        nodepack_root=target_path,
+        display_name=historical_manifest.display_name,
+        on_log=None,
+        env=environment,
+    )
+    _, installed_version, _ = read_nodepack_project_identity(
+        target_path / "pyproject.toml"
+    )
+    if installed_version != historical_version:
+        raise InstallerLifecycleError(
+            "Historical SugarCubes fixture did not match the installed app's pin: "
+            f"expected {historical_version}, got {installed_version}."
+        )
+    return historical_version
+
+
+def read_historical_sugarcubes_version(install_root: Path) -> str:
+    """Read the signed historical app payload's literal SugarCubes requirement."""
+
+    contract_path = (
+        install_root / "app" / "substitute" / "domain" / "comfy_nodepacks.py"
+    )
+    try:
+        module = ast.parse(contract_path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError) as error:
+        raise InstallerLifecycleError(
+            f"Historical nodepack contract is unreadable: {contract_path}."
+        ) from error
+    for statement in module.body:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = (
+            statement.targets
+            if isinstance(statement, ast.Assign)
+            else [statement.target]
+        )
+        if not any(
+            isinstance(target, ast.Name) and target.id == _SUGARCUBES_VERSION_NAME
+            for target in targets
+        ):
+            continue
+        value = statement.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            version = value.value.strip()
+            if version:
+                return version
+        break
+    raise InstallerLifecycleError(
+        "Historical app payload does not declare a literal SugarCubes requirement."
+    )
+
+
+def historical_sugarcubes_freshness_key(
+    freshness_key: Mapping[str, object],
+    *,
+    historical_version: str,
+) -> dict[str, object]:
+    """Return setup evidence that truthfully records the historical app pin."""
+
+    historical_key = deepcopy(dict(freshness_key))
+    raw_nodepacks = historical_key.get("core_nodepacks")
+    if not isinstance(raw_nodepacks, list):
+        raise InstallerLifecycleError(
+            "Historical managed setup key has no core-nodepack records."
+        )
+    sugarcubes_records = [
+        record
+        for record in raw_nodepacks
+        if isinstance(record, dict)
+        and record.get("id") == CoreNodepackId.SUGARCUBES.value
+    ]
+    if len(sugarcubes_records) != 1:
+        raise InstallerLifecycleError(
+            "Historical managed setup key must contain one SugarCubes record."
+        )
+    sugarcubes_records[0]["required_version"] = historical_version
+    sugarcubes_records[0]["fallback_archive"] = (
+        f"{_SUGARCUBES_RELEASE_ARCHIVE}v{historical_version}.zip"
+    )
+    return historical_key
+
+
+__all__ = [
+    "historical_sugarcubes_freshness_key",
+    "read_historical_sugarcubes_version",
+    "restore_historical_sugarcubes",
+]


### PR DESCRIPTION
## Summary
- mark every installed and candidate application launch as packaged release mode
- require managed compatibility recovery to apply the pinned SugarCubes version after app updates
- make historical-update qualification restore and record the historical app's own SugarCubes pin before launching the candidate

## Verification
- full ruff format and lint
- mypy --strict substitute tests
- architecture and test-governance gates
- full parallel suite
- all 85 isolated modules
- serial suite
- real local recovery from managed SugarCubes 0.11.0 to 0.12.0