### PR TITLE
test(ci): stabilize native Qt execution boundaries

### DIFF
--- a/TEST_WAIVERS.toml
+++ b/TEST_WAIVERS.toml
@@ -1244,3 +1244,16 @@ fingerprint = "sha256:d6d558f1dd3776cf477b3e3c9719fd9a0fe4016afd7debdb0b8ae20a8e
 rationale = "This module proves real top-level window activation, mouse opening, native keyboard routing, and focus transfer through the production model picker. Separate xdist worker processes share one operating-system foreground focus owner and can therefore steal activation from each other; globally sequential execution preserves the native contract without retries, longer waits, synthetic focus injection, or weakened assertions. Twenty repeated exclusive Windows executions passed after the concurrent hosted failure demonstrated the resource boundary."
 issue = "chore:SS-TEST-WAIVER-C0274"
 review_by = 2026-12-15
+
+[[waivers]]
+id = "SS-TEST-WAIVER-C0275"
+owner = "Floating Output grid rehosting"
+kind = "classification"
+disposition = "process_isolated"
+rule = "ISOLATED001"
+candidates = ["ISOLATED001|tests/presentation/canvas/output/host/test_floating_grid_reflow.py|isolated-module"]
+paths = ["tests/presentation/canvas/output/host/test_floating_grid_reflow.py"]
+fingerprint = "sha256:9e6e1df86c427fee03c9d346fb2463dd1e9981436cff0aedb72e6d968213853a"
+rationale = "This real-shell Output owner moves the production canvas between docked and top-level floating hosts to prove identical physical grid topology and active-composition ownership. A complete Windows ordinary run timed out after the move only after 1,203 prior tests in a reused xdist worker, while five concurrent fresh-process runs passed. Its shell, canvas, floating window, outputs, and filesystem are test-local with no shared file, port, environment, subprocess, or cross-process resource; fresh-process isolation is sufficient, and serialization would be inappropriate."
+issue = "chore:SS-TEST-WAIVER-C0275"
+review_by = 2026-12-15

--- a/tests/app/bootstrap/application_startup/conftest.py
+++ b/tests/app/bootstrap/application_startup/conftest.py
@@ -1,0 +1,34 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Control external preflight state for application-startup scenarios."""
+
+from __future__ import annotations
+
+import pytest
+
+from substitute.app.bootstrap import default_comfy_preflight
+
+
+@pytest.fixture(autouse=True)
+def allow_default_comfy_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep startup-route tests independent of a host ComfyUI listener."""
+
+    monkeypatch.setattr(
+        default_comfy_preflight,
+        "negotiate_default_comfy_listener",
+        lambda **_kwargs: True,
+    )

--- a/tests/ci_test_policy.py
+++ b/tests/ci_test_policy.py
@@ -272,6 +272,10 @@ ISOLATED_TEST_MODULES = frozenset(
         # in one xdist process, while concurrent fresh processes are stable.
         "tests/presentation/canvas/output/real_shell/test_hierarchy_persistence.py",
         "tests/presentation/canvas/output/real_shell/test_workflow_lifecycle.py",
+        # This floating Output rehosting contract can stop receiving layout
+        # updates after prior native Qt work, while fresh processes preserve
+        # its docked-to-floating topology proof without a shared resource.
+        "tests/presentation/canvas/output/host/test_floating_grid_reflow.py",
         # This real-shell decoration-boundary owner requires a fresh native Qt
         # process after prior work, while concurrent fresh processes are stable.
         "tests/qualification/prompt_editor/real_shell/test_decoration_boundaries.py",


### PR DESCRIPTION
## Summary

- run the floating Output rehosting contract in the bounded fresh-process lane after a late Windows worker exposed stale Qt state
- isolate application-startup route tests from any real ComfyUI listener on the host default port
- retain full behavioral assertions and parallel execution for tests without shared resources

## Verification

- full ordinary parallel suite
- all 86 isolated modules
- serial lane
- architecture and test governance
- strict mypy, Ruff lint, and Ruff format
- five concurrent fresh-process runs for the affected floating-grid and startup-route contracts