### PR TITLE
fix(launcher): prevent false repair prompts after successful updates

### DIFF
--- a/launcher/sugarsubstitute_launcher/app.py
+++ b/launcher/sugarsubstitute_launcher/app.py
@@ -123,11 +123,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                     startup_plan.config_error or "Installed launcher config is invalid."
                 )
             from launcher.sugarsubstitute_launcher.installed_app_handoff import (
-                InstalledAppHandoffResult,
                 complete_installed_app_handoff,
             )
 
-            handoff_result = complete_installed_app_handoff(
+            complete_installed_app_handoff(
                 layout=layout,
                 launch_guard=launch_guard,
                 locale_argument=locale_argument,
@@ -135,13 +134,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 splash_session=splash_session,
                 launch_session=launch_session,
             )
-            if (
-                handoff_result is InstalledAppHandoffResult.APPLICATION_STARTED
-                and not launch_session.wait_for_application_owner()
-            ):
-                raise RuntimeError(
-                    "The launched application did not acquire native instance ownership."
-                )
             launch_session.release()
             return 0
         except Exception as error:

--- a/launcher/sugarsubstitute_launcher/application_launch.py
+++ b/launcher/sugarsubstitute_launcher/application_launch.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import time
 from typing import Self
 
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
@@ -75,16 +74,6 @@ class InstalledApplicationLaunchSession:
             return
         self._invocation_lease = None
         invocation_lease.release()
-
-    def wait_for_application_owner(self, *, timeout_seconds: float = 30.0) -> bool:
-        """Keep launcher serialization until the child owns its native lease."""
-
-        deadline = time.monotonic() + max(0.0, timeout_seconds)
-        while time.monotonic() < deadline:
-            if ApplicationInstanceLease.owner_exists(self._layout.root):
-                return True
-            time.sleep(0.025)
-        return ApplicationInstanceLease.owner_exists(self._layout.root)
 
 
 def begin_installed_application_launch(

--- a/launcher/sugarsubstitute_launcher/installed_app_handoff.py
+++ b/launcher/sugarsubstitute_launcher/installed_app_handoff.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-from enum import Enum
 import os
 from pathlib import Path
 
@@ -53,13 +52,6 @@ from sugarsubstitute_shared.launcher_update.process import schedule_launcher_upd
 _PRE_LAUNCH_MANIFEST_TIMEOUT_SECONDS = 3.0
 
 
-class InstalledAppHandoffResult(str, Enum):
-    """Describe which process now owns continuation after launcher work."""
-
-    APPLICATION_STARTED = "application_started"
-    LAUNCHER_UPDATE_SCHEDULED = "launcher_update_scheduled"
-
-
 def complete_installed_app_handoff(
     *,
     layout: InstallLayout,
@@ -68,7 +60,7 @@ def complete_installed_app_handoff(
     no_update_check: bool,
     splash_session: LauncherSplashSession | None,
     launch_session: InstalledApplicationLaunchSession,
-) -> InstalledAppHandoffResult:
+) -> None:
     """Run update policy and start the installed app behind its visible splash."""
 
     config = LauncherConfig.load(layout.config_path)
@@ -89,7 +81,7 @@ def complete_installed_app_handoff(
             relaunch=True,
             wait_pid=os.getpid(),
         )
-        return InstalledAppHandoffResult.LAUNCHER_UPDATE_SCHEDULED
+        return
 
     app_command = append_splash_session_args(
         build_app_launch_command(
@@ -110,7 +102,7 @@ def complete_installed_app_handoff(
             activation=update_result.pending_activation,
             fallback_guard_factory=lambda _layout: launch_session.claim_application(),
         )
-        return InstalledAppHandoffResult.APPLICATION_STARTED
+        return
     start_detached(
         app_command,
         environment=installed_application_environment(
@@ -118,7 +110,6 @@ def complete_installed_app_handoff(
             remote_failure_reason=update_result.failure_reason,
         ),
     )
-    return InstalledAppHandoffResult.APPLICATION_STARTED
 
 
 def _normal_launch_release_source(config: LauncherConfig) -> ReleaseSource | None:
@@ -130,4 +121,4 @@ def _normal_launch_release_source(config: LauncherConfig) -> ReleaseSource | Non
     )
 
 
-__all__ = ["InstalledAppHandoffResult", "complete_installed_app_handoff"]
+__all__ = ["complete_installed_app_handoff"]

--- a/tests/launcher/application_launch/test_installed_entrypoint.py
+++ b/tests/launcher/application_launch/test_installed_entrypoint.py
@@ -136,7 +136,10 @@ def test_launcher_main_starts_app_from_installed_exe_parent(
     monkeypatch.setattr(
         InstalledApplicationLaunchSession,
         "wait_for_application_owner",
-        lambda self: True,
+        lambda self: pytest.fail(
+            "A completed handoff must not be reclassified through a late lease probe."
+        ),
+        raising=False,
     )
     monkeypatch.setattr(
         launcher_app,
@@ -287,7 +290,10 @@ def test_frozen_launcher_main_uses_invoked_installed_bundle_path(
     monkeypatch.setattr(
         InstalledApplicationLaunchSession,
         "wait_for_application_owner",
-        lambda self: True,
+        lambda self: pytest.fail(
+            "A completed handoff must not be reclassified through a late lease probe."
+        ),
+        raising=False,
     )
     monkeypatch.setattr(
         launcher_app,

--- a/tests/launcher/application_launch/test_update_handoff.py
+++ b/tests/launcher/application_launch/test_update_handoff.py
@@ -23,6 +23,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import ANY
+from unittest.mock import Mock
 
 import pytest
 
@@ -38,6 +39,9 @@ from launcher.sugarsubstitute_launcher.config import (
 )
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from launcher.sugarsubstitute_launcher.release_sources import GitHubReleaseSource
+from launcher.sugarsubstitute_launcher.update_activation import (
+    PendingUpdateActivation,
+)
 from sugarsubstitute_shared.application_launch_guard import (
     APPLICATION_LAUNCH_TOKEN_ENV,
 )
@@ -144,7 +148,10 @@ def test_launcher_main_runs_pre_launch_update_before_app_handoff(
     monkeypatch.setattr(
         InstalledApplicationLaunchSession,
         "wait_for_application_owner",
-        lambda self: True,
+        lambda self: pytest.fail(
+            "A completed handoff must not be reclassified through a late lease probe."
+        ),
+        raising=False,
     )
     monkeypatch.setattr(
         launcher_app,
@@ -174,6 +181,81 @@ def test_launcher_main_runs_pre_launch_update_before_app_handoff(
         child_environments[0].get(STARTUP_REMOTE_DEGRADED_ENV)
         == expected_degraded_value
     )
+
+
+def test_launcher_accepts_completed_candidate_handoff_without_late_lease_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A proven update must not become a launcher repair after its handoff."""
+
+    from launcher.sugarsubstitute_launcher.update_orchestrator import (
+        PreLaunchUpdateResult,
+    )
+
+    layout = InstallLayout.from_root(tmp_path / "SugarSubstitute")
+    LauncherConfig.from_layout(layout=layout).save(layout.config_path)
+    write_launcher_executable(layout)
+    layout.app_entrypoint.parent.mkdir(parents=True, exist_ok=True)
+    layout.app_entrypoint.write_text("", encoding="utf-8")
+    layout.runtime_python.parent.mkdir(parents=True, exist_ok=True)
+    layout.runtime_python.write_text("", encoding="utf-8")
+    activation = Mock(spec=PendingUpdateActivation)
+    candidate_launches: list[dict[str, object]] = []
+
+    class _PreparedUpdateOrchestrator:
+        """Return an application update awaiting candidate activation."""
+
+        def run(self, **_kwargs: object) -> PreLaunchUpdateResult:
+            """Return one prepared update to the installed handoff owner."""
+
+            return PreLaunchUpdateResult(
+                checked_manifest=True,
+                installed_update=True,
+                pending_activation=activation,
+                attempted_version="0.22.1",
+            )
+
+    def record_candidate_launch(**kwargs: object) -> None:
+        """Represent a candidate whose visible-shell proof already completed."""
+
+        candidate_launches.append(kwargs)
+
+    monkeypatch.setattr(sys, "executable", str(layout.executable_path))
+    monkeypatch.setattr(
+        installed_app_handoff,
+        "LauncherUpdateOrchestrator",
+        _PreparedUpdateOrchestrator,
+    )
+    monkeypatch.setattr(
+        installed_app_handoff,
+        "launch_prepared_update",
+        record_candidate_launch,
+    )
+    monkeypatch.setattr(
+        splash_session_module,
+        "start_launcher_splash_session",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        InstalledApplicationLaunchSession,
+        "wait_for_application_owner",
+        lambda self: pytest.fail(
+            "A completed candidate must not be reclassified by a late lease probe."
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        launcher_app,
+        "LauncherMainWindow",
+        lambda **_kwargs: pytest.fail("A proven candidate must not open repair UI."),
+    )
+
+    assert launcher_app.main([]) == 0
+    assert len(candidate_launches) == 1
+    assert candidate_launches[0]["layout"] == layout
+    assert candidate_launches[0]["attempted_version"] == "0.22.1"
+    assert candidate_launches[0]["activation"] is activation
 
 
 def test_launcher_main_hands_off_pending_launcher_update_instead_of_app(


### PR DESCRIPTION
## Outcome

- accepts a completed installed-app or candidate-update handoff without reclassifying it through a late native-lease probe
- prevents the launcher from opening repair UI after the candidate launch path has already proved the application shell
- adds regression coverage that fails if the removed late probe or repair window returns

## Verification

- focused launcher tests: 62 passed, 1 skipped
- packaged single-instance qualification: passed cold start, rapid duplicate invocation, duplicate suppression, graceful replacement, malformed-lock recovery, and crash recovery
- packaged HTTPS update qualification: passed
- full parallel, isolated, and serial test suites: passed
- Ruff format/lint, mypy strict, architecture, and test governance: passed
- post-branch focused regression: 9 passed