### PR TITLE
fix(comfy): prevent repeated connection reset errors

### DIFF
--- a/substitute/infrastructure/comfy/managed_launch_command.py
+++ b/substitute/infrastructure/comfy/managed_launch_command.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 
 from substitute.domain.comfy_manager import ComfyManagerRuntime
 from substitute.domain.onboarding import ComfyEndpoint
@@ -27,8 +28,15 @@ from sugarsubstitute_shared.windows_long_paths import (
     subprocess_path,
 )
 
-_LONG_WORKSPACE_BOOTSTRAP = (
+_WORKSPACE_BOOTSTRAP = (
     "import os, runpy, sys; "
+    "root = sys.argv.pop(1); script = sys.argv.pop(1); "
+    "os.chdir(root); sys.argv[0] = script; "
+    "runpy.run_path(script, run_name='__main__')"
+)
+_WINDOWS_WORKSPACE_BOOTSTRAP = (
+    "import asyncio, os, runpy, sys; "
+    "asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy()); "
     "root = sys.argv.pop(1); script = sys.argv.pop(1); "
     "os.chdir(root); sys.argv[0] = script; "
     "runpy.run_path(script, run_name='__main__')"
@@ -54,11 +62,20 @@ def build_managed_launch_command(
         *runtime_arguments,
         *manager_runtime.launch_arguments,
     )
+    if sys.platform == "win32":
+        return (
+            subprocess_path(venv_python),
+            "-c",
+            _WINDOWS_WORKSPACE_BOOTSTRAP,
+            subprocess_path(workspace),
+            subprocess_path(workspace / "main.py"),
+            *arguments,
+        )
     if exceeds_windows_legacy_path_limit(workspace):
         return (
             subprocess_path(venv_python),
             "-c",
-            _LONG_WORKSPACE_BOOTSTRAP,
+            _WORKSPACE_BOOTSTRAP,
             subprocess_path(workspace),
             subprocess_path(workspace / "main.py"),
             *arguments,

--- a/tests/infrastructure/comfy/managed_launch_command/test_windows_policy.py
+++ b/tests/infrastructure/comfy/managed_launch_command/test_windows_policy.py
@@ -1,0 +1,80 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Test Windows managed Comfy launch event-loop policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
+from substitute.domain.onboarding import ComfyEndpoint
+from substitute.infrastructure.comfy.managed_launch_command import (
+    build_managed_launch_command,
+)
+from substitute.infrastructure.process.hidden_process_runner import run_command
+
+pytestmark = pytest.mark.platforms("windows")
+
+
+def test_windows_managed_comfy_uses_selector_event_loop_policy(
+    tmp_path: Path,
+) -> None:
+    """Managed Comfy should absorb peer resets without Proactor tracebacks."""
+
+    workspace = tmp_path / "comfyui"
+    workspace.mkdir()
+    (workspace / "main.py").write_text(
+        "import asyncio\n"
+        "from pathlib import Path\n"
+        "Path('event-loop-policy.txt').write_text(\n"
+        "    type(asyncio.get_event_loop_policy()).__name__,\n"
+        "    encoding='utf-8',\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    command = build_managed_launch_command(
+        venv_python=Path(sys.executable),
+        endpoint=ComfyEndpoint(host="127.0.0.1", port=8188),
+        workspace=workspace,
+        manager_runtime=ComfyManagerRuntime(
+            kind=ComfyManagerKind.INTEGRATED,
+            workspace=workspace,
+            python_executable=Path(sys.executable),
+        ),
+        force_cpu_mode=False,
+    )
+
+    assert command[1] == "-c"
+    assert "WindowsSelectorEventLoopPolicy" in command[2]
+    assert command[3:5] == (str(workspace), str(workspace / "main.py"))
+    assert command[5:] == (
+        "--listen",
+        "127.0.0.1",
+        "--port",
+        "8188",
+        "--enable-manager",
+    )
+
+    result = run_command(command, cwd=workspace, check=True)
+
+    assert result.returncode == 0
+    assert (workspace / "event-loop-policy.txt").read_text(encoding="utf-8") == (
+        "WindowsSelectorEventLoopPolicy"
+    )


### PR DESCRIPTION
## Summary
- launch managed ComfyUI with the supported Windows selector event-loop policy
- prevent ordinary local peer disconnects from producing repeated WinError 10054 tracebacks
- preserve managed launch arguments and long-path behavior

## Verification
- reproduced headlessly with Photoshop connected to port 8188
- production managed launch emitted zero reset tracebacks across repeated five-second WebSocket timeouts
- full parallel, isolated, and serial test partitions pass
- format, lint, strict typing, architecture, and test governance pass