### PR TITLE
fix(comfy): preserve managed runtime policy during recovery

### DIFF
--- a/ARCHITECTURE_DEBT.toml
+++ b/ARCHITECTURE_DEBT.toml
@@ -65,7 +65,7 @@ next_extraction = "Extract warmup and hydration task ownership from shell launch
 id = "SS-ARCH-006"
 owner = "startup managed-ready runtime"
 paths = ["substitute/app/bootstrap/startup_managed_ready_runtime.py"]
-fingerprint = "sha256:d20ca2a30a738ec78583bb93b7b0a2f3976260defa4925cedcd41217af567a7d"
+fingerprint = "sha256:6ee1868a18bc94c62d60d0d75111654c6be177869e85dc65a2f80e018872e8d9"
 issue = "chore:SS-ARCH-006"
 review_by = 2026-12-15
 responsibilities = [
@@ -1457,7 +1457,7 @@ next_extraction = "Extract native process/desktop control and historical evidenc
 id = "SS-ARCH-097"
 owner = "installer UI qualification"
 paths = ["tools/ci/installer_ui_qualification.py"]
-fingerprint = "sha256:9756144f09eba411f61a628b157e7071f6b45bfde562a76cc7fce5b707a876f4"
+fingerprint = "sha256:e45336aefb7e3c6689a7ab4960fea36f1bec280c72fa289f7e53496dd6b4c54b"
 issue = "chore:SS-ARCH-097"
 review_by = 2026-12-15
 responsibilities = [
@@ -1465,7 +1465,7 @@ responsibilities = [
   "current installer execution",
   "installed candidate launch",
   "shell and event-sequence verification",
-  "cross-platform process termination and diagnostics",
+  "cross-platform process termination",
   "readiness receipt and startup trace interpretation",
 ]
 next_extraction = "Extract installed-process lifecycle and evidence/trace verification from qualification workflow orchestration; durable installed-version evidence now has an independent owner."

--- a/ARCHITECTURE_WAIVERS.toml
+++ b/ARCHITECTURE_WAIVERS.toml
@@ -61,7 +61,7 @@ kind = "remediation"
 justification = "The assessed file mixes factory protocol declarations, ready-shell runtime resource graph composition, managed recovery and readiness binding, prompt editor and CuteCanvas warmup integration. Extract factory port declarations and feature-specific warmup adapters from runtime resource composition."
 issue = "chore:SS-ARCH-006"
 review_by = 2026-12-15
-max_lines = 1124
+max_lines = 1122
 next_limit = 910
 debt = "SS-ARCH-006"
 
@@ -1968,10 +1968,10 @@ owner = "installer UI qualification"
 rule = "STRUCT003"
 path = "tools/ci/installer_ui_qualification.py"
 kind = "remediation"
-justification = "The assessed file mixes qualification evidence preparation, current installer execution, installed candidate launch, shell and event-sequence verification, cross-platform process termination and diagnostics, readiness receipt and startup trace interpretation. Extract installed-process lifecycle and evidence/trace verification from qualification workflow orchestration; durable installed-version evidence now has an independent owner."
+justification = "The assessed file mixes qualification evidence preparation, current installer execution, installed candidate launch, shell and event-sequence verification, cross-platform process termination, readiness receipt and startup trace interpretation. Extract installed-process lifecycle and evidence/trace verification from qualification workflow orchestration; process identity diagnostics and durable installed-version evidence now have independent owners."
 issue = "chore:SS-ARCH-097"
 review_by = 2026-12-15
-max_lines = 688
+max_lines = 632
 next_limit = 558
 debt = "SS-ARCH-097"
 

--- a/substitute/app/bootstrap/managed_recovery_adapters.py
+++ b/substitute/app/bootstrap/managed_recovery_adapters.py
@@ -44,7 +44,10 @@ from substitute.application.comfy_startup_diagnostics.startup_failure_report_ser
 )
 from substitute.domain.comfy_startup_diagnostics import ComfyStartupIncident
 from substitute.domain.comfy_nodepacks import CoreNodepackId
-from substitute.domain.onboarding import InstallationContext
+from substitute.domain.onboarding import (
+    InstallationContext,
+    ManagedRuntimeConfiguration,
+)
 from substitute.domain.onboarding.models import (
     ComfyTargetConfiguration,
     ComfyTargetMode,
@@ -63,6 +66,9 @@ from substitute.infrastructure.comfy.nodepack_reconciliation import (
 )
 from substitute.infrastructure.comfy.sugarcubes_startup_maintenance import (
     attempt_sugarcubes_startup_maintenance,
+)
+from substitute.infrastructure.onboarding.file_managed_runtime_repository import (
+    FileManagedRuntimeConfigurationRepository,
 )
 from substitute.shared.logging.logger import get_logger, log_warning
 
@@ -213,6 +219,7 @@ def create_managed_recovery_startup_adapters(
 
 def create_managed_recovery_controller_adapters(
     *,
+    installation_context: InstallationContext,
     startup_resources: StartupResourceRegistry,
     execution_runtime: object,
     execution_dispatcher_factory: Callable[[], object],
@@ -229,9 +236,29 @@ def create_managed_recovery_controller_adapters(
             submitter,
         ),
         cleanup_state=cleanup_managed_recovery_state,
-        reconcile_owned_comfy_dependencies=reconcile_owned_comfy_dependencies,
+        reconcile_owned_comfy_dependencies=lambda target, nodepacks, emit_log: (
+            reconcile_owned_comfy_dependencies(
+                target,
+                nodepacks,
+                emit_log,
+                runtime_configuration=_load_managed_runtime_configuration(
+                    installation_context
+                ),
+            )
+        ),
         confirmed_termination_status=confirmed_managed_recovery_termination_status(),
     )
+
+
+def _load_managed_runtime_configuration(
+    context: InstallationContext,
+) -> ManagedRuntimeConfiguration | None:
+    """Load the active managed runtime selection for recovery."""
+
+    repository = FileManagedRuntimeConfigurationRepository(
+        context.installation.runtime_state_dir
+    )
+    return repository.load() if repository.exists() else None
 
 
 def create_managed_recovery_submitter(
@@ -266,6 +293,8 @@ def reconcile_owned_comfy_dependencies(
     target: ComfyTargetConfiguration,
     nodepacks: frozenset[CoreNodepackId],
     emit_log: RecoveryLogCallback,
+    *,
+    runtime_configuration: ManagedRuntimeConfiguration | None = None,
 ) -> None:
     """Reconcile Substitute-owned Comfy dependencies for one owned local target."""
 
@@ -281,7 +310,12 @@ def reconcile_owned_comfy_dependencies(
         )
 
     if target.mode is ComfyTargetMode.MANAGED_LOCAL:
-        reconcile_managed_local_owned_dependencies(workspace, nodepacks, emit_log)
+        reconcile_managed_local_owned_dependencies(
+            workspace,
+            nodepacks,
+            emit_log,
+            runtime_configuration=runtime_configuration,
+        )
         return
 
     binding = target.python_binding
@@ -299,11 +333,18 @@ def reconcile_managed_local_owned_dependencies(
     workspace: Path,
     nodepacks: frozenset[CoreNodepackId],
     emit_log: RecoveryLogCallback,
+    *,
+    runtime_configuration: ManagedRuntimeConfiguration | None,
 ) -> None:
     """Run full managed setup when Substitute owns the Comfy installation."""
 
+    selection = runtime_configuration or ManagedRuntimeConfiguration()
+
     ensure_managed_comfy_setup(
         workspace=workspace,
+        force_cpu_mode=selection.force_cpu_mode,
+        prefer_edge_torch=selection.prefer_edge_torch,
+        prefer_edge_comfy_channel=selection.prefer_edge_comfy_channel,
         repair_existing_runtime=True,
         refresh_core_nodepacks=nodepacks,
         on_status=emit_log,

--- a/substitute/app/bootstrap/startup_managed_ready_runtime.py
+++ b/substitute/app/bootstrap/startup_managed_ready_runtime.py
@@ -537,9 +537,6 @@ def create_startup_managed_ready_runtime_resources(
 ) -> StartupManagedReadyRuntimeResources:
     """Create runtime resources consumed by managed-ready startup orchestration."""
 
-    managed_compatibility_checker = (
-        managed_ready_ports.create_runtime_compatibility_checker()
-    )
     startup_diagnostics = managed_ready_ports.create_startup_diagnostics_collector()
     startup_ignore_repository = (
         managed_ready_ports.create_startup_diagnostics_ignore_repository(context)
@@ -557,7 +554,7 @@ def create_startup_managed_ready_runtime_resources(
     managed_startup_compatibility_assessor = (
         create_managed_startup_compatibility_assessor(
             comfy_state=comfy_state,
-            checker=managed_compatibility_checker,
+            checker=managed_ready_ports.create_runtime_compatibility_checker(),
             target=context.comfy_target,
         )
     )
@@ -1187,6 +1184,7 @@ def create_startup_managed_ready_runtime_resources(
         )
 
     managed_recovery_controller_adapters = create_managed_recovery_controller_adapters(
+        installation_context=context,
         startup_resources=startup_resources,
         execution_runtime=execution_runtime,
         execution_dispatcher_factory=execution_dispatcher_factory,

--- a/tests/app/bootstrap/managed_recovery/adapters/test_controller_ports.py
+++ b/tests/app/bootstrap/managed_recovery/adapters/test_controller_ports.py
@@ -17,15 +17,21 @@
 """Exercise one managed-recovery adapter behavior owner."""
 
 from __future__ import annotations
+from pathlib import Path
 from typing import Any, cast
 import pytest
 from substitute.app.bootstrap import managed_recovery_adapters
 from substitute.app.bootstrap.startup_resources import StartupResourceRegistry
+from substitute.domain.onboarding import ManagedRuntimeConfiguration
+from substitute.infrastructure.onboarding.file_managed_runtime_repository import (
+    FileManagedRuntimeConfigurationRepository,
+)
 
 from .support import (
     _ExecutionRuntime,
     _ManagedState,
     _Submitter,
+    _context,
 )
 
 
@@ -52,6 +58,7 @@ def test_create_managed_recovery_controller_adapters_groups_concrete_ports() -> 
     submitter = _Submitter()
     execution_runtime = _ExecutionRuntime(submitter)
     adapters = managed_recovery_adapters.create_managed_recovery_controller_adapters(
+        installation_context=cast(Any, object()),
         startup_resources=registry,
         execution_runtime=execution_runtime,
         execution_dispatcher_factory=lambda: object(),
@@ -75,13 +82,59 @@ def test_create_managed_recovery_controller_adapters_groups_concrete_ports() -> 
         adapters.cleanup_state
         is managed_recovery_adapters.cleanup_managed_recovery_state
     )
-    assert (
-        adapters.reconcile_owned_comfy_dependencies
-        is managed_recovery_adapters.reconcile_owned_comfy_dependencies
-    )
+    assert callable(adapters.reconcile_owned_comfy_dependencies)
     assert adapters.confirmed_termination_status == (
         managed_recovery_adapters.confirmed_managed_recovery_termination_status()
     )
+
+
+def test_controller_reconciliation_loads_active_runtime_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The controller adapter should load persisted managed runtime policy."""
+
+    context = _context(tmp_path)
+    selection = ManagedRuntimeConfiguration(
+        force_cpu_mode=True,
+        prefer_edge_torch=True,
+        prefer_edge_comfy_channel=True,
+    )
+    FileManagedRuntimeConfigurationRepository(
+        context.installation.runtime_state_dir
+    ).save(selection)
+    observed: list[ManagedRuntimeConfiguration | None] = []
+
+    def fake_reconcile(
+        _target: object,
+        _nodepacks: object,
+        _emit_log: object,
+        *,
+        runtime_configuration: ManagedRuntimeConfiguration | None = None,
+    ) -> None:
+        """Capture the runtime selection loaded by the controller adapter."""
+
+        observed.append(runtime_configuration)
+
+    monkeypatch.setattr(
+        managed_recovery_adapters,
+        "reconcile_owned_comfy_dependencies",
+        fake_reconcile,
+    )
+    adapters = managed_recovery_adapters.create_managed_recovery_controller_adapters(
+        installation_context=context,
+        startup_resources=StartupResourceRegistry(),
+        execution_runtime=_ExecutionRuntime(_Submitter()),
+        execution_dispatcher_factory=lambda: object(),
+    )
+
+    adapters.reconcile_owned_comfy_dependencies(
+        context.comfy_target,
+        frozenset(),
+        lambda _line: None,
+    )
+
+    assert observed == [selection]
 
 
 def test_cleanup_managed_recovery_state_uses_process_manager(

--- a/tests/app/bootstrap/managed_recovery/adapters/test_dependency_reconciliation.py
+++ b/tests/app/bootstrap/managed_recovery/adapters/test_dependency_reconciliation.py
@@ -25,6 +25,7 @@ from substitute.domain.comfy_nodepacks import CoreNodepackId
 from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
 from substitute.domain.onboarding import (
     ComfyTargetMode,
+    ManagedRuntimeConfiguration,
 )
 
 from .support import (
@@ -76,6 +77,42 @@ def test_reconcile_owned_dependencies_for_managed_target_runs_managed_setup(
         )
     ]
     assert logs == ["status", "log"]
+
+
+def test_managed_recovery_preserves_persisted_runtime_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Managed recovery should reuse the active runtime selection policy."""
+
+    observed: dict[str, object] = {}
+
+    def fake_setup(**kwargs: object) -> None:
+        """Capture the managed setup policy supplied by recovery."""
+
+        observed.update(kwargs)
+
+    monkeypatch.setattr(
+        managed_recovery_adapters,
+        "ensure_managed_comfy_setup",
+        fake_setup,
+    )
+    runtime_configuration = ManagedRuntimeConfiguration(
+        force_cpu_mode=True,
+        prefer_edge_torch=True,
+        prefer_edge_comfy_channel=True,
+    )
+
+    managed_recovery_adapters.reconcile_owned_comfy_dependencies(
+        _target(tmp_path, ComfyTargetMode.MANAGED_LOCAL),
+        frozenset({CoreNodepackId.SUGARCUBES}),
+        lambda _line: None,
+        runtime_configuration=runtime_configuration,
+    )
+
+    assert observed["force_cpu_mode"] is True
+    assert observed["prefer_edge_torch"] is True
+    assert observed["prefer_edge_comfy_channel"] is True
 
 
 def test_reconcile_owned_dependencies_for_attached_target_runs_nodepack_policy(

--- a/tests/qualification/installer/test_readiness_evidence.py
+++ b/tests/qualification/installer/test_readiness_evidence.py
@@ -30,10 +30,10 @@ import pytest
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
 from tools.ci import installer_ui_qualification
+from tools.ci.installer_process_diagnostics import process_tree_diagnostics
 from tools.ci.installer_ui_qualification import (
     InstalledCandidateLaunch,
     launch_installed_candidate,
-    process_tree_diagnostics,
 )
 
 
@@ -206,7 +206,7 @@ def test_stalled_process_diagnostics_expose_runtime_location(
             return "sleeping"
 
     monkeypatch.setattr(
-        "tools.ci.installer_ui_qualification.psutil.Process",
+        "tools.ci.installer_process_diagnostics.psutil.Process",
         lambda _pid: _Process(),
     )
 
@@ -219,3 +219,75 @@ def test_stalled_process_diagnostics_expose_runtime_location(
         "/installed/launcher-bin/libpython3.12.so",
     ]
     assert payload[0]["num_threads"] == 2
+
+
+def test_process_tree_diagnostics_tolerates_unavailable_memory_maps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Diagnostics should remain available where psutil omits memory maps."""
+
+    class _Process:
+        """Expose the portable psutil process surface used by diagnostics."""
+
+        pid = 123
+
+        def children(self, *, recursive: bool) -> list[_Process]:
+            """Return no child processes."""
+
+            assert recursive is True
+            return []
+
+        def cmdline(self) -> list[str]:
+            """Return one deterministic command line."""
+
+            return ["/installed/SugarSubstitute"]
+
+        def cpu_times(self) -> tuple[float, float, float, float]:
+            """Return bounded CPU counters."""
+
+            return (1.0, 2.0, 0.0, 0.0)
+
+        def cwd(self) -> str:
+            """Return the installation root."""
+
+            return "/installed"
+
+        def exe(self) -> str:
+            """Return the installed executable."""
+
+            return "/installed/SugarSubstitute"
+
+        def name(self) -> str:
+            """Return the process name."""
+
+            return "SugarSubstitute"
+
+        def num_threads(self) -> int:
+            """Return the process thread count."""
+
+            return 2
+
+        def open_files(self) -> list[SimpleNamespace]:
+            """Return no open files."""
+
+            return []
+
+        def ppid(self) -> int:
+            """Return a deterministic parent PID."""
+
+            return 45
+
+        def status(self) -> str:
+            """Return the current process status."""
+
+            return "sleeping"
+
+    monkeypatch.setattr(
+        "tools.ci.installer_process_diagnostics.psutil.Process",
+        lambda _pid: _Process(),
+    )
+
+    payload = json.loads(process_tree_diagnostics(123))
+
+    assert payload[0]["mapped_runtime_paths"] == []
+    assert payload[0]["status"] == "sleeping"

--- a/tools/ci/installer_process_diagnostics.py
+++ b/tools/ci/installer_process_diagnostics.py
@@ -1,0 +1,99 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Render portable process identity for installer qualification failures."""
+
+from __future__ import annotations
+
+import json
+
+import psutil  # type: ignore[import-untyped]
+
+
+def process_tree_diagnostics(pid: int) -> str:
+    """Render bounded non-secret identity for one qualification process tree."""
+
+    try:
+        root = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return f"<launcher process {pid} already exited>"
+    except psutil.AccessDenied:
+        return f"<launcher process {pid} could not be inspected>"
+    try:
+        processes = (root, *root.children(recursive=True))
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        processes = (root,)
+    records: list[dict[str, object]] = []
+    for process in processes:
+        try:
+            opened_files = [
+                str(open_file.path) for open_file in process.open_files()[:20]
+            ]
+            records.append(
+                {
+                    "cmdline": [str(argument) for argument in process.cmdline()],
+                    "cpu_times": [float(value) for value in process.cpu_times()[:4]],
+                    "cwd": str(process.cwd()),
+                    "exe": str(process.exe()),
+                    "mapped_runtime_paths": _mapped_runtime_paths(process),
+                    "name": str(process.name()),
+                    "num_threads": int(process.num_threads()),
+                    "open_files": opened_files,
+                    "pid": int(process.pid),
+                    "ppid": int(process.ppid()),
+                    "status": str(process.status()),
+                }
+            )
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            records.append({"pid": int(process.pid), "status": "unavailable"})
+    return json.dumps(records, indent=2, sort_keys=True)
+
+
+def _mapped_runtime_paths(process: psutil.Process) -> list[str]:
+    """Return relevant mappings when the host psutil build exposes them."""
+
+    if not hasattr(process, "memory_maps"):
+        return []
+    try:
+        return sorted(
+            {
+                str(memory_map.path)
+                for memory_map in process.memory_maps(grouped=True)
+                if _is_relevant_runtime_mapping(str(memory_map.path))
+            }
+        )[:60]
+    except (psutil.NoSuchProcess, psutil.AccessDenied, NotImplementedError):
+        return []
+
+
+def _is_relevant_runtime_mapping(path: str) -> bool:
+    """Return whether one mapped file identifies the frozen startup subsystem."""
+
+    normalized = path.casefold()
+    return any(
+        marker in normalized
+        for marker in (
+            "python",
+            "pyside",
+            "qt6",
+            "libqt",
+            "ssl",
+            "truststore",
+        )
+    )
+
+
+__all__ = ["process_tree_diagnostics"]

--- a/tools/ci/installer_ui_qualification.py
+++ b/tools/ci/installer_ui_qualification.py
@@ -45,6 +45,7 @@ from sugarsubstitute_shared.installer_qualification import (
     InstallerQualificationTarget,
 )
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
+from tools.ci.installer_process_diagnostics import process_tree_diagnostics
 from tools.ci.installed_version_evidence import wait_for_installed_version
 from tools.ci.managed_comfy_qualification import assert_real_managed_comfy
 
@@ -631,69 +632,6 @@ def installed_launch_has_progress(launch: InstalledCandidateLaunch) -> bool:
     return any(
         _path_signature(path) != baseline
         for path, baseline in launch.progress_baselines
-    )
-
-
-def process_tree_diagnostics(pid: int) -> str:
-    """Render bounded non-secret identity for one qualification process tree."""
-
-    try:
-        root = psutil.Process(pid)
-    except psutil.NoSuchProcess:
-        return f"<launcher process {pid} already exited>"
-    except psutil.AccessDenied:
-        return f"<launcher process {pid} could not be inspected>"
-    try:
-        processes = (root, *root.children(recursive=True))
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
-        processes = (root,)
-    records: list[dict[str, object]] = []
-    for process in processes:
-        try:
-            opened_files = [
-                str(open_file.path) for open_file in process.open_files()[:20]
-            ]
-            mapped_runtime_paths = sorted(
-                {
-                    str(memory_map.path)
-                    for memory_map in process.memory_maps(grouped=True)
-                    if _is_relevant_runtime_mapping(str(memory_map.path))
-                }
-            )[:60]
-            records.append(
-                {
-                    "cmdline": [str(argument) for argument in process.cmdline()],
-                    "cpu_times": [float(value) for value in process.cpu_times()[:4]],
-                    "cwd": str(process.cwd()),
-                    "exe": str(process.exe()),
-                    "mapped_runtime_paths": mapped_runtime_paths,
-                    "name": str(process.name()),
-                    "num_threads": int(process.num_threads()),
-                    "open_files": opened_files,
-                    "pid": int(process.pid),
-                    "ppid": int(process.ppid()),
-                    "status": str(process.status()),
-                }
-            )
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            records.append({"pid": int(process.pid), "status": "unavailable"})
-    return json.dumps(records, indent=2, sort_keys=True)
-
-
-def _is_relevant_runtime_mapping(path: str) -> bool:
-    """Return whether one mapped file identifies the frozen startup subsystem."""
-
-    normalized = path.casefold()
-    return any(
-        marker in normalized
-        for marker in (
-            "python",
-            "pyside",
-            "qt6",
-            "libqt",
-            "ssl",
-            "truststore",
-        )
     )
 
 


### PR DESCRIPTION
## Summary
- preserve the active managed Comfy CPU and edge-channel policy during startup dependency recovery
- prevent Linux CPU workspaces from being reclassified as unsupported fresh installs during repair
- keep installer qualification diagnostics portable when macOS psutil does not expose process memory maps
- extract process identity diagnostics into their own qualification owner and tighten the affected architecture remediation caps

## Regression proof
- controller composition loads persisted managed runtime state before recovery
- managed recovery forwards CPU, edge Torch, and edge Comfy selections
- process diagnostics remain usable without memory_maps

## Local qualification
- release dependency audit
- GPL license headers
- architecture governance
- test governance
- splash-first startup contracts
- repository-wide Ruff format and lint
- strict mypy across substitute and tests (5,586 source files)
- Base-Cubes input-asset contracts
- full parallel pytest population
- all 86 isolated modules
- the serial module
- every pre-commit hook

This PR targets canary. The existing canary-to-main promotion PR must remain unmerged until the corrected canary and every remote qualification workload pass.