### PR TITLE
fix(startup): publish readiness when the main shell appears

### DIFF
--- a/substitute/app/bootstrap/ready_shell_reveal.py
+++ b/substitute/app/bootstrap/ready_shell_reveal.py
@@ -109,6 +109,7 @@ def reveal_ready_shell_main_window(
     set_current_shell(revealed_shell_frame)
     startup_timer.mark("main_shell_shown")
     trace_mark("main_shell.shown", **dict(trace_fields()))
+    schedule_readiness_receipt()
     update_backend_state("ready" if comfy_http_ready else "starting")
     log_info(
         _LOGGER,
@@ -118,7 +119,6 @@ def reveal_ready_shell_main_window(
     connect_restore_finalized_warmups()
     request_startup_diagnostics_update()
     schedule_post_show_hydration()
-    schedule_readiness_receipt()
     return ReadyShellRevealResult(
         shell_frame=revealed_shell_frame,
         splash=active_splash,

--- a/tests/app/bootstrap/ready_shell/reveal/test_task.py
+++ b/tests/app/bootstrap/ready_shell/reveal/test_task.py
@@ -88,6 +88,12 @@ def test_reveal_ready_shell_main_window_sequences_post_show_work(
         calls.append("show")
         return shown_shell_frame
 
+    def schedule_readiness_receipt() -> bool:
+        """Record readiness scheduling at the visible-shell boundary."""
+
+        calls.append("schedule_readiness")
+        return True
+
     result = ready_shell_reveal.reveal_ready_shell_main_window(
         splash=_CloseSplash(calls),
         shell_frame=shell_frame,
@@ -103,6 +109,7 @@ def test_reveal_ready_shell_main_window_sequences_post_show_work(
         request_startup_diagnostics_update=lambda: calls.append("diagnostics"),
         schedule_post_show_hydration=lambda: calls.append("schedule_hydration"),
         trace_fields=lambda: {"route": "ready"},
+        schedule_readiness_receipt=schedule_readiness_receipt,
     )
 
     assert result.shell_frame is shown_shell_frame
@@ -121,6 +128,7 @@ def test_reveal_ready_shell_main_window_sequences_post_show_work(
         "phase:end:startup.show_main_window",
         "set_current",
         "mark:main_shell_shown",
+        "schedule_readiness",
         "backend:ready",
         "connect_warmups",
         "diagnostics",


### PR DESCRIPTION
## Summary

This promotes the canary-tested startup-readiness correction into Stable.

### Differences from `main`
- publishes the authenticated main-shell readiness receipt immediately after the visible shell is shown
- prevents post-show hydration or diagnostics from delaying installer qualification after the splash closes
- adds regression coverage that locks readiness scheduling ahead of post-show work

### Failure corrected
Stable run 33292807095 proved installation, onboarding, splash closure, and `main_shell.shown`, but macOS post-show hydration ran before the queued receipt could replace the onboarding receipt. The clean-install job timed out and correctly blocked release publication.

### Verification already completed
- full local format, lint, architecture, test governance, and strict typing
- full local parallel, isolated, and serial suites
- PR #129 cross-platform tests and Comfy compatibility checks before merge to `canary`