### PR TITLE
fix(release): preserve Stable version resolution during publication

### DIFF
--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout publication source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: ${{ github.ref_name == 'main' && 0 || 1 }}
+          fetch-depth: 0
           fetch-tags: ${{ github.ref_name == 'main' }}
 
       - name: Set up exact publication Node toolchain

--- a/tests/qualification/release/workflow/test_release_train.py
+++ b/tests/qualification/release/workflow/test_release_train.py
@@ -76,6 +76,18 @@ def test_canary_isolated_release_train_contract() -> None:
     assert dependabot_text.count("target-branch: canary") == 3
 
 
+def test_publication_resolves_the_stable_version_from_complete_history() -> None:
+    """Keep final Stable version resolution backed by every release commit."""
+
+    publication_text = workflow_text("release-publication.yml")
+
+    checkout = publication_text.split(
+        "      - name: Checkout publication source", maxsplit=1
+    )[1].split("\n\n", maxsplit=1)[0]
+    assert "          fetch-depth: 0" in checkout
+    assert "&& 0 || 1" not in checkout
+
+
 def test_release_version_script_embeds_canary_channel(tmp_path: Path) -> None:
     """Native Canary installers must receive immutable build-channel metadata."""
 


### PR DESCRIPTION
## Summary
- check out complete repository history before final Stable semantic-version validation
- prevent GitHub Actions' falsy numeric zero from silently selecting a shallow checkout
- add a release-workflow regression contract for complete publication history

## Failure evidence
Stable qualification passed, and every qualified asset checksum passed, but publication resolved an empty version because `actions/checkout` used `--depth=1`. The previous expression `condition && 0 || 1` evaluates to `1` when the intended result is numeric zero.

## Verification
- focused release workflow tests
- Ruff format and lint
- strict mypy (5,588 files)
- architecture governance
- test governance
- full parallel test suite
- all 86 isolated test modules
- serial test module