### PR TITLE
Promote Canary publication fix to Main

### DIFF
--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout publication source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: ${{ github.ref_name == 'main' && 0 || 1 }}
+          fetch-depth: 0
           fetch-tags: ${{ github.ref_name == 'main' }}
 
       - name: Set up exact publication Node toolchain

--- a/tests/qualification/release/workflow/test_release_train.py
+++ b/tests/qualification/release/workflow/test_release_train.py
@@ -76,6 +76,18 @@ def test_canary_isolated_release_train_contract() -> None:
     assert dependabot_text.count("target-branch: canary") == 3
 
 
+def test_publication_resolves_the_stable_version_from_complete_history() -> None:
+    """Keep final Stable version resolution backed by every release commit."""
+
+    publication_text = workflow_text("release-publication.yml")
+
+    checkout = publication_text.split(
+        "      - name: Checkout publication source", maxsplit=1
+    )[1].split("\n\n", maxsplit=1)[0]
+    assert "          fetch-depth: 0" in checkout
+    assert "&& 0 || 1" not in checkout
+
+
 def test_release_version_script_embeds_canary_channel(tmp_path: Path) -> None:
     """Native Canary installers must receive immutable build-channel metadata."""
 


### PR DESCRIPTION
## Differences from Main
- checks out complete repository history before final Stable semantic-version validation
- prevents GitHub Actions' falsy numeric zero from silently selecting a shallow checkout
- adds regression coverage requiring complete publication history

## Why this promotion is required
The Stable candidate passed all current-install, historical-update, and checksum qualifications. Publication then failed because the final version resolver saw only a depth-1 checkout and returned an empty version. Canary 0.22.0.213 has published successfully from this fix.

## Verification
- Canary release 0.22.0.213 published successfully from the exact Canary head
- focused release workflow regression test
- Ruff format and lint
- strict mypy (5,588 files)
- architecture governance
- test governance
- full parallel test suite
- all 86 isolated test modules
- serial test module