### PR TITLE
fix(previews): restore streaming cube placeholders across outputs

### DIFF
--- a/ARCHITECTURE_DEBT.toml
+++ b/ARCHITECTURE_DEBT.toml
@@ -155,7 +155,7 @@ next_extraction = "Extract error payload interpretation and report rendering fro
 id = "SS-ARCH-012"
 owner = "generation execution"
 paths = ["substitute/application/generation/generation_service.py"]
-  fingerprint = "sha256:84ed569380e0cdb7b9beba0edb3522327f069446c3f8b97a9cc29a2380807955"
+fingerprint = "sha256:e1617b467131c16717570f3d420484db5dcdff4c05ad4e5e78f15ae532b03515"
 issue = "chore:SS-ARCH-012"
 review_by = 2026-12-15
 responsibilities = [
@@ -495,22 +495,6 @@ responsibilities = [
   "host adapter discovery and signal dispatch",
 ]
 next_extraction = "Extract layout measurement and selector synchronization from navigation intents and selection policy."
-
-[[debts]]
-id = "SS-ARCH-038"
-owner = "output canvas presentation"
-paths = ["substitute/presentation/canvas/output/output_canvas_view.py"]
-fingerprint = "sha256:f054d242a372a10908278655d85513d93e7598976d83ea7191096795773b1ebc"
-issue = "chore:SS-ARCH-038"
-review_by = 2026-12-15
-responsibilities = [
-  "CuteCanvas workspace and document hosting",
-  "output navigation chrome and compare state",
-  "preview registry and lane presentation",
-  "transfer and external-editor integration",
-  "projection-session and interaction event routing",
-]
-next_extraction = "Extract preview-lane and transfer integration from the mounted CuteCanvas workspace view."
 
 [[debts]]
 id = "SS-ARCH-039"
@@ -1275,18 +1259,17 @@ next_extraction = "Extract closed-workflow persistence/resource cleanup and tab 
 id = "SS-ARCH-085"
 owner = "workspace canvas actions"
 paths = ["substitute/presentation/shell/workspace_canvas_actions.py"]
-fingerprint = "sha256:1f87e14f0f3f8c437da1060fdf12fe36ce97da7cdce697adb8609e0b77d9719e"
+fingerprint = "sha256:4e0877498c0e25a34b560e2b9a77faf498432689388a994cb36c406a87e2e7ee"
 issue = "chore:SS-ARCH-085"
 review_by = 2026-12-15
 responsibilities = [
   "output focus and navigation mutation",
-  "preview presentation and lifecycle",
   "external editor and asset reveal actions",
   "generated and loaded output ingestion",
   "output preparation and authorization",
   "canvas host visibility and error presentation",
 ]
-next_extraction = "Split preview lifecycle, external actions, and output ingestion from output-navigation commands."
+next_extraction = "Split external actions and output ingestion from output-navigation commands."
 
 [[debts]]
 id = "SS-ARCH-086"

--- a/ARCHITECTURE_WAIVERS.toml
+++ b/ARCHITECTURE_WAIVERS.toml
@@ -417,19 +417,6 @@ next_limit = 750
 debt = "SS-ARCH-037"
 
 [[waivers]]
-id = "SS-WAIVER-R038"
-owner = "output canvas presentation"
-rule = "STRUCT003"
-path = "substitute/presentation/canvas/output/output_canvas_view.py"
-kind = "remediation"
-justification = "The assessed file mixes CuteCanvas workspace and document hosting, output navigation chrome and compare state, preview registry and lane presentation, transfer and external-editor integration, projection-session and interaction event routing. Extract preview-lane and transfer integration from the mounted CuteCanvas workspace view."
-issue = "chore:SS-ARCH-038"
-review_by = 2026-12-15
-max_lines = 523
-next_limit = 500
-debt = "SS-ARCH-038"
-
-[[waivers]]
 id = "SS-WAIVER-R039"
 owner = "cube stack cart"
 rule = "STRUCT003"
@@ -1033,10 +1020,10 @@ owner = "workspace canvas actions"
 rule = "STRUCT003"
 path = "substitute/presentation/shell/workspace_canvas_actions.py"
 kind = "remediation"
-justification = "The assessed file mixes output focus and navigation mutation, preview presentation and lifecycle, external editor and asset reveal actions, generated and loaded output ingestion, output preparation and authorization, canvas host visibility and error presentation. Split preview lifecycle, external actions, and output ingestion from output-navigation commands."
+justification = "The assessed file mixes output focus and navigation mutation, external editor and asset reveal actions, generated and loaded output ingestion, output preparation and authorization, canvas host visibility and error presentation. Split external actions and output ingestion from output-navigation commands."
 issue = "chore:SS-ARCH-085"
 review_by = 2026-12-15
-max_lines = 916
+max_lines = 833
 next_limit = 732
 debt = "SS-ARCH-085"
 
@@ -1213,7 +1200,7 @@ kind = "structural"
 justification = "The module is a declarative lazy-export manifest for one package boundary: TYPE_CHECKING imports, __all__, and the lazy symbol map describe the same API surface. Its size follows the exported contract, and partitioning it would create multiple competing manifests for one namespace."
 issue = "chore:SS-WAIVER-S010"
 review_by = 2026-12-15
-max_lines = 668
+max_lines = 666
 
 [[waivers]]
 id = "SS-WAIVER-S011"
@@ -1232,10 +1219,10 @@ owner = "output preview registry"
 rule = "STRUCT003"
 path = "substitute/application/workflows/output_preview_registry.py"
 kind = "structural"
-justification = "OutputPreviewRegistry is one in-memory aggregate for preview-lane admission, identity, lookup, and retirement. Its value models and predicates encode the same lane invariants, and separating admission from storage would create two owners for registry consistency."
+justification = "OutputPreviewRegistry is one in-memory aggregate for preview-lane admission, identity, lookup, and retirement. Its acceptance predicates and mutations enforce the same lane-consistency invariant, and separating admission from storage would create two owners for registry consistency."
 issue = "chore:SS-WAIVER-S012"
 review_by = 2026-12-15
-max_lines = 544
+max_lines = 534
 
 [[waivers]]
 id = "SS-WAIVER-S013"
@@ -1807,7 +1794,7 @@ kind = "structural"
 justification = "GenerationFeedbackCoalescer is the single pending-state owner between high-frequency generation callbacks and UI rendering. Submission, authorization, keying, replacement, retirement, terminal ordering, and draining all enforce one coalesced batch contract."
 issue = "chore:SS-WAIVER-S066"
 review_by = 2026-12-15
-max_lines = 621
+max_lines = 618
 
 [[waivers]]
 id = "SS-WAIVER-S067"

--- a/ARCHITECTURE_WAIVERS.toml
+++ b/ARCHITECTURE_WAIVERS.toml
@@ -2078,10 +2078,10 @@ owner = "real-shell output canvas harness"
 rule = "STRUCT003"
 path = "tests/support/real_output_canvas/harness.py"
 kind = "structural"
-justification = "This module owns one user-level driver for the real-shell output canvas. Workflow and output seeding, preview and final delivery, route selection, rendered control interaction, workflow lifecycle, projection waiting, and snapshot capture are operations over the same mounted shell and active output session."
+justification = "This module owns one user-level driver for the real-shell output canvas. Harness-safe shell construction, workflow and output seeding, preview and final delivery, route selection, rendered control interaction, workflow lifecycle, projection waiting, and snapshot capture are operations over the same mounted shell and active output session."
 issue = "chore:SS-WAIVER-S120"
 review_by = 2026-12-15
-max_lines = 618
+max_lines = 631
 
 [[waivers]]
 id = "SS-WAIVER-S126"

--- a/TEST_WAIVERS.toml
+++ b/TEST_WAIVERS.toml
@@ -1257,3 +1257,16 @@ fingerprint = "sha256:9e6e1df86c427fee03c9d346fb2463dd1e9981436cff0aedb72e6d9682
 rationale = "This real-shell Output owner moves the production canvas between docked and top-level floating hosts to prove identical physical grid topology and active-composition ownership. A complete Windows ordinary run timed out after the move only after 1,203 prior tests in a reused xdist worker, while five concurrent fresh-process runs passed. Its shell, canvas, floating window, outputs, and filesystem are test-local with no shared file, port, environment, subprocess, or cross-process resource; fresh-process isolation is sufficient, and serialization would be inappropriate."
 issue = "chore:SS-TEST-WAIVER-C0275"
 review_by = 2026-12-15
+
+[[waivers]]
+id = "SS-TEST-WAIVER-C0276"
+owner = "Real-shell Output hierarchy navigation"
+kind = "classification"
+disposition = "process_isolated"
+rule = "ISOLATED001"
+candidates = ["ISOLATED001|tests/presentation/canvas/output/real_shell/test_hierarchy_navigation.py|isolated-module"]
+paths = ["tests/presentation/canvas/output/real_shell/test_hierarchy_navigation.py"]
+fingerprint = "sha256:9b3a4aebeeef64d54ee296c864536f3ca6c30479c53af6b2f8422c290205c3dd"
+rationale = "This native Qt module mounts the real shell, workflow workspace, output canvas, output projection, and hierarchy navigation surfaces. Its missing-batch source-switch contract aborted in CuteCanvas construction only after prior native Qt work in an ordinary xdist worker, while the complete six-test module passed in one fresh process and in twenty concurrent fresh-process launches across five four-worker rounds. It owns no shared file, port, environment, subprocess, or cross-process resource; process isolation is sufficient and global serialization would be inappropriate."
+issue = "chore:SS-TEST-WAIVER-C0276"
+review_by = 2026-12-15

--- a/substitute/application/generation/generation_models.py
+++ b/substitute/application/generation/generation_models.py
@@ -84,6 +84,7 @@ class GenerationRunStarted:
     output_session_id: str
     prompt_id: str
     client_id: str
+    preview_source_keys: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)

--- a/substitute/application/generation/generation_run_started_notifier.py
+++ b/substitute/application/generation/generation_run_started_notifier.py
@@ -1,0 +1,58 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Publish prompt-bound generation identity before visual events can arrive."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from substitute.application.generation.generation_models import GenerationRunStarted
+from substitute.application.ports.comfy_gateway import QueueVisualRunContext
+from substitute.domain.common import WorkflowId
+
+
+def notify_generation_run_started(
+    callback: Callable[[GenerationRunStarted], None] | None,
+    *,
+    workflow_id: WorkflowId,
+    generation_run_id: str,
+    output_session_id: str,
+    prompt_id: str,
+    client_id: str,
+    visual_context: QueueVisualRunContext,
+) -> None:
+    """Publish the run and its complete set of authorized preview placeholders."""
+
+    if callback is None:
+        return
+    callback(
+        GenerationRunStarted(
+            workflow_id=workflow_id,
+            generation_run_id=generation_run_id,
+            output_session_id=output_session_id,
+            prompt_id=prompt_id,
+            client_id=client_id,
+            preview_source_keys=frozenset(
+                source_key
+                for source in visual_context.sources.values()
+                if (source_key := source.get("sourceKey"))
+            ),
+        )
+    )
+
+
+__all__ = ["notify_generation_run_started"]

--- a/substitute/application/generation/generation_service.py
+++ b/substitute/application/generation/generation_service.py
@@ -70,9 +70,11 @@ from substitute.application.generation.asset_staging_service import (
 from substitute.application.generation.generation_models import (
     GenerationCallbacks,
     GenerationFailure,
-    GenerationRunStarted,
     GenerationStartResult,
     PreparedGenerationRequest,
+)
+from substitute.application.generation.generation_run_started_notifier import (
+    notify_generation_run_started,
 )
 from substitute.application.generation.preview_preference_service import (
     GenerationPreviewMethodResolver,
@@ -590,16 +592,15 @@ class GenerationService:
             on_timing=callbacks.on_timing,
             on_completed=on_listener_completed,
         )
-        if callbacks.on_run_started is not None:
-            callbacks.on_run_started(
-                GenerationRunStarted(
-                    workflow_id=request.workflow_id,
-                    generation_run_id=generation_run_id,
-                    output_session_id=request.scene_run_id or generation_run_id,
-                    prompt_id=prompt_id,
-                    client_id=run_client_id,
-                )
-            )
+        notify_generation_run_started(
+            callbacks.on_run_started,
+            workflow_id=request.workflow_id,
+            generation_run_id=generation_run_id,
+            output_session_id=request.scene_run_id or generation_run_id,
+            prompt_id=prompt_id,
+            client_id=run_client_id,
+            visual_context=visual_context,
+        )
         listener_result = self._comfy_gateway.start_listener(
             request=ListenerStartRequest(
                 prompt_id=prompt_id,
@@ -817,7 +818,6 @@ __all__ = [
     "GenerationCallbacks",
     "GenerationFailure",
     "GenerationRequest",
-    "GenerationRunStarted",
     "GenerationService",
     "GenerationStartResult",
     "PreparedGenerationRequest",

--- a/substitute/application/generation/visual_authorization.py
+++ b/substitute/application/generation/visual_authorization.py
@@ -43,6 +43,7 @@ class AcceptedVisualRun:
     generation_run_id: str
     prompt_id: str
     client_id: str
+    preview_source_keys: frozenset[str]
     state: VisualRunState = VisualRunState.RUNNING
 
 
@@ -66,6 +67,7 @@ class VisualAuthorizationService:
         generation_run_id: str,
         prompt_id: str,
         client_id: str,
+        preview_source_keys: frozenset[str] = frozenset(),
     ) -> None:
         """Accept one run and supersede older active runs for the workflow."""
 
@@ -81,6 +83,7 @@ class VisualAuthorizationService:
             generation_run_id=generation_run_id,
             prompt_id=prompt_id,
             client_id=client_id,
+            preview_source_keys=preview_source_keys,
             state=VisualRunState.RUNNING,
         )
         self._active_run_by_workflow[workflow_id] = generation_run_id
@@ -102,6 +105,7 @@ class VisualAuthorizationService:
             generation_run_id=run.generation_run_id,
             prompt_id=run.prompt_id,
             client_id=run.client_id,
+            preview_source_keys=run.preview_source_keys,
             state=VisualRunState.COMPLETED,
         )
 
@@ -129,6 +133,16 @@ class VisualAuthorizationService:
             run.state is VisualRunState.RUNNING
             and self._active_run_by_workflow.get(identity.workflow_id)
             == identity.generation_run_id
+        )
+
+    def authorize_preview_source(self, identity: GenerationVisualIdentity) -> bool:
+        """Allow an expected run source to create its first transient lane."""
+
+        run = self._matching_run(identity)
+        return (
+            run is not None
+            and self.authorize_preview(identity)
+            and identity.source_key in run.preview_source_keys
         )
 
     def authorize_final_output(self, identity: GenerationVisualIdentity) -> bool:
@@ -171,6 +185,7 @@ class VisualAuthorizationService:
             generation_run_id=run.generation_run_id,
             prompt_id=run.prompt_id,
             client_id=run.client_id,
+            preview_source_keys=run.preview_source_keys,
             state=state,
         )
         if self._active_run_by_workflow.get(workflow_id) == generation_run_id:

--- a/substitute/application/generation/visual_run_context_builder.py
+++ b/substitute/application/generation/visual_run_context_builder.py
@@ -29,6 +29,10 @@ from substitute.application.recipes.workflow_payload_nodes import (
     executable_prompt_nodes,
 )
 from substitute.domain.common import WorkflowId
+from substitute.domain.generation import (
+    output_source_key_for_cube,
+    output_source_key_for_node,
+)
 
 
 class VisualRunContextBuilder:
@@ -51,7 +55,7 @@ class VisualRunContextBuilder:
         """Return Backend routing metadata with explicit sources taking priority."""
 
         prompt_nodes = executable_prompt_nodes(workflow_payload)
-        node_to_output_source = _node_to_cube_output_source(prompt_nodes, workflow_id)
+        node_to_output_source = _node_to_cube_output_source(prompt_nodes)
         explicit_by_node = {
             source.node_id: {
                 "sourceKey": source.source_key,
@@ -68,7 +72,7 @@ class VisualRunContextBuilder:
             if source is None:
                 label = _source_label_for_prompt_node(node_id, node_data)
                 source = {
-                    "sourceKey": f"{workflow_id}:{node_id}",
+                    "sourceKey": output_source_key_for_node(node_id),
                     "sourceLabel": label,
                     "cubeAlias": label,
                 }
@@ -103,7 +107,6 @@ def _source_label_for_prompt_node(node_id: str, node_data: dict[str, object]) ->
 
 def _node_to_cube_output_source(
     prompt_nodes: Mapping[str, object],
-    workflow_id: WorkflowId,
 ) -> dict[str, dict[str, str]]:
     """Map upstream executable nodes to their unambiguous cube-output source."""
 
@@ -116,7 +119,10 @@ def _node_to_cube_output_source(
             continue
         label = _source_label_for_prompt_node(node_id, node_data)
         source = {
-            "sourceKey": f"{workflow_id}:{node_id}",
+            "sourceKey": output_source_key_for_cube(
+                cube_alias=label,
+                node_id=node_id,
+            ),
             "sourceLabel": label,
             "cubeAlias": label,
         }
@@ -151,7 +157,7 @@ def _upstream_node_ids(
         inputs = node_data.get("inputs")
         if not isinstance(inputs, Mapping):
             continue
-        for upstream_node_id in _linked_node_ids(inputs.values()):
+        for upstream_node_id in _linked_node_ids(tuple(inputs.values())):
             if upstream_node_id not in visited:
                 pending.append(upstream_node_id)
     return visited

--- a/substitute/application/workflows/__init__.py
+++ b/substitute/application/workflows/__init__.py
@@ -144,13 +144,15 @@ if TYPE_CHECKING:
         OutputCompareState,
     )
     from substitute.application.workflows.output_preview_registry import (
-        OutputPreviewAcceptance,
-        OutputPreviewCloseResult,
         OutputPreviewLane,
         OutputPreviewLaneKey,
         OutputPreviewLanePlacement,
         OutputPreviewRegistry,
         OutputPreviewRejectionReason,
+    )
+    from substitute.application.workflows.output_preview_results import (
+        OutputPreviewAcceptance,
+        OutputPreviewCloseResult,
     )
     from substitute.application.workflows.output_scene_run_service import (
         OutputSceneRunService,
@@ -392,12 +394,8 @@ _EXPORT_MODULES = {
     "OutputPreviewCloseIdentity": (
         "substitute.application.workflows.output_canvas_state_service"
     ),
-    "OutputPreviewAcceptance": (
-        "substitute.application.workflows.output_preview_registry"
-    ),
-    "OutputPreviewCloseResult": (
-        "substitute.application.workflows.output_preview_registry"
-    ),
+    "OutputPreviewAcceptance": "substitute.application.workflows.output_preview_results",
+    "OutputPreviewCloseResult": "substitute.application.workflows.output_preview_results",
     "OutputPreviewLane": "substitute.application.workflows.output_preview_registry",
     "OutputPreviewLaneKey": (
         "substitute.application.workflows.output_preview_registry"

--- a/substitute/application/workflows/output_canvas_projection.py
+++ b/substitute/application/workflows/output_canvas_projection.py
@@ -29,7 +29,10 @@ from sugarsubstitute_shared.localization import (
     render_source_application_text,
 )
 
-from substitute.domain.generation import OutputResultPosition
+from substitute.domain.generation import (
+    OutputResultPosition,
+    canonical_output_source_key,
+)
 from substitute.domain.workflow import (
     ImageMeta,
     OutputFocusMode,
@@ -333,7 +336,11 @@ def _source_key_for(image_id: UUID, image_meta: ImageMeta) -> str:
     """Return stable grouping identity for one output image."""
 
     if image_meta.source_key:
-        return image_meta.source_key
+        return canonical_output_source_key(
+            source_key=image_meta.source_key,
+            source_label=image_meta.source_label,
+            node_id=image_meta.node_id,
+        )
     if image_meta.cube_name:
         return image_meta.cube_name
     return str(image_id)

--- a/substitute/application/workflows/output_preview_projection.py
+++ b/substitute/application/workflows/output_preview_projection.py
@@ -1,0 +1,194 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Project live previews as transient Output source/set placeholders."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from substitute.application.workflows.output_canvas_projection import (
+    OutputCanvasImageItem,
+    OutputCanvasSceneGroup,
+    OutputCanvasSourceGroup,
+)
+from substitute.application.workflows.output_preview_registry import (
+    OutputPreviewLane,
+    OutputPreviewLanePlacement,
+)
+from substitute.domain.workflow import ImageMeta
+
+
+def overlay_preview_sources(
+    final_sources: Iterable[OutputCanvasSourceGroup],
+    preview_lanes: Iterable[OutputPreviewLane],
+    *,
+    scene_key: str | None,
+) -> tuple[OutputCanvasSourceGroup, ...]:
+    """Overlay set-one preview slots while preserving final source and set order."""
+
+    sources = list(final_sources)
+    source_indices = {source.source_key: index for index, source in enumerate(sources)}
+    for lane in _source_view_lanes(preview_lanes, scene_key=scene_key):
+        source_index = source_indices.get(lane.key.source_key)
+        preview_item = _preview_item(lane)
+        if source_index is None:
+            source_indices[lane.key.source_key] = len(sources)
+            sources.append(
+                OutputCanvasSourceGroup(
+                    source_key=lane.key.source_key,
+                    label=lane.source_label or lane.key.source_key,
+                    images_by_set={1: preview_item},
+                )
+            )
+            continue
+        current = sources[source_index]
+        images_by_set = dict(current.images_by_set)
+        images_by_set[1] = preview_item
+        sources[source_index] = OutputCanvasSourceGroup(
+            source_key=current.source_key,
+            label=current.label,
+            images_by_set=images_by_set,
+            label_is_default=current.label_is_default,
+        )
+    return tuple(sources)
+
+
+def overlay_preview_scenes(
+    final_scenes: Iterable[OutputCanvasSceneGroup],
+    preview_lanes: Iterable[OutputPreviewLane],
+) -> tuple[OutputCanvasSceneGroup, ...]:
+    """Overlay preview representatives and source placeholders into scene groups."""
+
+    lanes = tuple(preview_lanes)
+    scenes = list(final_scenes)
+    scene_indices = {scene.scene_key: index for index, scene in enumerate(scenes)}
+    scene_lanes: dict[str, list[OutputPreviewLane]] = {}
+    for lane in lanes:
+        if (
+            lane.key.placement is OutputPreviewLanePlacement.SCENE
+            and lane.key.scene_key is not None
+        ):
+            scene_lanes.setdefault(lane.key.scene_key, []).append(lane)
+    for scene_key, representatives in scene_lanes.items():
+        scene_index = scene_indices.get(scene_key)
+        final = scenes[scene_index] if scene_index is not None else None
+        representative = _representative_lane(final, representatives)
+        sources = overlay_preview_sources(
+            () if final is None else final.sources,
+            lanes,
+            scene_key=scene_key,
+        )
+        overlaid = OutputCanvasSceneGroup(
+            scene_run_id=(
+                representative.key.scene_run_id
+                or (final.scene_run_id if final is not None else "")
+            ),
+            scene_key=scene_key,
+            title=(
+                representative.scene_title
+                or (final.title if final is not None else scene_key)
+            ),
+            order=(
+                representative.scene_order
+                if representative.scene_order is not None
+                else (final.order if final is not None else len(scenes))
+            ),
+            sources=sources,
+            preview_image_id=representative.preview_id,
+            primary_image_id=final.primary_image_id if final is not None else None,
+            representative_source_key=representative.key.source_key,
+            representative_set_index=1,
+            status="running",
+            title_is_default=final.title_is_default if final is not None else False,
+        )
+        if scene_index is None:
+            scene_indices[scene_key] = len(scenes)
+            scenes.append(overlaid)
+        else:
+            scenes[scene_index] = overlaid
+    return tuple(sorted(scenes, key=lambda scene: scene.order))
+
+
+def _source_view_lanes(
+    preview_lanes: Iterable[OutputPreviewLane],
+    *,
+    scene_key: str | None,
+) -> tuple[OutputPreviewLane, ...]:
+    """Choose one source-view lane per source for the requested scene scope."""
+
+    selected: dict[str, OutputPreviewLane] = {}
+    for lane in preview_lanes:
+        if lane.key.scene_key != scene_key:
+            continue
+        current = selected.get(lane.key.source_key)
+        if current is None or (
+            current.key.placement is OutputPreviewLanePlacement.SCENE
+            and lane.key.placement is OutputPreviewLanePlacement.SOURCE
+        ):
+            selected[lane.key.source_key] = lane
+    return tuple(selected.values())
+
+
+def _preview_item(lane: OutputPreviewLane) -> OutputCanvasImageItem:
+    """Represent one live lane as the first batch slot of its eventual output."""
+
+    source_label = lane.source_label or lane.key.source_key
+    return OutputCanvasImageItem(
+        image_id=lane.preview_id,
+        image_meta=ImageMeta(
+            workflow_name=lane.key.workflow_id,
+            cube_name=source_label,
+            image_number=1,
+            suffix="",
+            path="",
+            source_key=lane.key.source_key,
+            source_label=source_label,
+            generation_run_id=lane.key.generation_run_id,
+            prompt_id=lane.key.prompt_id,
+            client_id=lane.client_id,
+            scene_run_id=lane.key.scene_run_id or "",
+            scene_key=lane.key.scene_key or "",
+            scene_title=lane.scene_title or "",
+            scene_order=lane.scene_order,
+            scene_count=lane.scene_count,
+            batch_index=0,
+        ),
+        set_index=1,
+    )
+
+
+def _representative_lane(
+    final_scene: OutputCanvasSceneGroup | None,
+    lanes: list[OutputPreviewLane],
+) -> OutputPreviewLane:
+    """Choose the furthest-progressed preview without regressing on late frames."""
+
+    source_order = (
+        {source.source_key: index for index, source in enumerate(final_scene.sources)}
+        if final_scene is not None
+        else {}
+    )
+    return max(
+        lanes,
+        key=lambda lane: source_order.get(
+            lane.key.source_key,
+            len(source_order) + lanes.index(lane),
+        ),
+    )
+
+
+__all__ = ["overlay_preview_scenes", "overlay_preview_sources"]

--- a/substitute/application/workflows/output_preview_registry.py
+++ b/substitute/application/workflows/output_preview_registry.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from uuid import UUID, uuid4
 
@@ -31,6 +31,10 @@ from substitute.application.workflows.output_canvas_projection import (
 from substitute.application.workflows.output_canvas_session import OutputCanvasSession
 from substitute.application.workflows.output_canvas_state_service import (
     OutputPreviewCloseIdentity,
+)
+from substitute.application.workflows.output_preview_results import (
+    OutputPreviewAcceptance,
+    OutputPreviewCloseResult,
 )
 from substitute.application.workflows.output_visual_events import (
     LivePreviewEvent,
@@ -140,45 +144,6 @@ class OutputPreviewLane:
     accepted_for_overview: bool = False
 
 
-@dataclass(frozen=True, slots=True)
-class OutputPreviewAcceptance:
-    """Return the result of accepting or rejecting one preview event."""
-
-    accepted: bool
-    lanes: tuple[OutputPreviewLane, ...] = ()
-    retired_preview_ids: tuple[UUID, ...] = ()
-    rejection_reason: OutputPreviewRejectionReason | None = None
-
-    @classmethod
-    def rejected(
-        cls,
-        reason: OutputPreviewRejectionReason,
-        *,
-        retired_preview_ids: tuple[UUID, ...] = (),
-    ) -> "OutputPreviewAcceptance":
-        """Return a rejected preview result."""
-
-        return cls(
-            accepted=False,
-            retired_preview_ids=retired_preview_ids,
-            rejection_reason=reason,
-        )
-
-
-@dataclass(frozen=True, slots=True)
-class OutputPreviewCloseResult:
-    """Describe preview lanes closed by a matching final output."""
-
-    closed_preview_ids: tuple[UUID, ...]
-    completed_keys: tuple[OutputPreviewLaneKey, ...]
-
-    @property
-    def closed(self) -> bool:
-        """Return whether any preview lane was closed."""
-
-        return bool(self.closed_preview_ids)
-
-
 @dataclass(slots=True)
 class OutputPreviewRegistry:
     """Track transient Output preview lanes independently from widgets."""
@@ -194,6 +159,8 @@ class OutputPreviewRegistry:
         session: OutputCanvasSession,
         active_workflow_id: str,
         authorize_preview: Callable[[GenerationVisualIdentity], bool] | None,
+        is_valid_source_placeholder: Callable[[GenerationVisualIdentity], bool]
+        | None = None,
         is_valid_scene_placeholder: Callable[
             [OutputSceneIdentity, GenerationVisualIdentity], bool
         ]
@@ -231,7 +198,10 @@ class OutputPreviewRegistry:
                 event,
                 OutputPreviewRejectionReason.UNAUTHORIZED_RUN,
             )
-        if not _source_is_allowed(identity.source_key, session):
+        if not _source_is_allowed(identity.source_key, session) and not (
+            callable(is_valid_source_placeholder)
+            and is_valid_source_placeholder(visual_identity)
+        ):
             return self._reject(
                 event,
                 OutputPreviewRejectionReason.SOURCE_OUTSIDE_SESSION,
@@ -257,10 +227,14 @@ class OutputPreviewRegistry:
                 OutputPreviewRejectionReason.COMPLETED_LANE,
                 retired_preview_ids=retired_ids,
             )
+        created_preview_ids = tuple(
+            lane.preview_id for lane in lanes if lane.key not in self._lanes
+        )
         accepted_lanes = tuple(self._store_lane(lane) for lane in lanes)
         return OutputPreviewAcceptance(
             accepted=True,
             lanes=accepted_lanes,
+            created_preview_ids=created_preview_ids,
             retired_preview_ids=retired_ids,
         )
 
@@ -309,6 +283,16 @@ class OutputPreviewRegistry:
             and lane.session_revision != session.revision
         )
         return self._remove_keys(keys)
+
+    def rebind_workflow_session(self, session: OutputCanvasSession) -> None:
+        """Carry active workflow lanes across navigation-only session revisions."""
+
+        for key, lane in tuple(self._lanes.items()):
+            if key.workflow_id != session.workflow_id.value:
+                continue
+            if lane.session_revision == session.revision:
+                continue
+            self._lanes[key] = replace(lane, session_revision=session.revision)
 
     def lanes_for_session(
         self,
@@ -642,8 +626,6 @@ def _is_null_image(image: object) -> bool:
 
 
 __all__ = [
-    "OutputPreviewAcceptance",
-    "OutputPreviewCloseResult",
     "OutputPreviewLane",
     "OutputPreviewLaneKey",
     "OutputPreviewLanePlacement",

--- a/substitute/application/workflows/output_preview_results.py
+++ b/substitute/application/workflows/output_preview_results.py
@@ -1,0 +1,73 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Describe preview-registry acceptance and final-lane closure outcomes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from substitute.application.workflows.output_preview_registry import (
+        OutputPreviewLane,
+        OutputPreviewLaneKey,
+        OutputPreviewRejectionReason,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class OutputPreviewAcceptance:
+    """Return the complete result of accepting or rejecting one preview event."""
+
+    accepted: bool
+    lanes: tuple[OutputPreviewLane, ...] = ()
+    created_preview_ids: tuple[UUID, ...] = ()
+    retired_preview_ids: tuple[UUID, ...] = ()
+    rejection_reason: OutputPreviewRejectionReason | None = None
+
+    @classmethod
+    def rejected(
+        cls,
+        reason: OutputPreviewRejectionReason,
+        *,
+        retired_preview_ids: tuple[UUID, ...] = (),
+    ) -> OutputPreviewAcceptance:
+        """Return a rejected preview result with any retired stale identities."""
+
+        return cls(
+            accepted=False,
+            retired_preview_ids=retired_preview_ids,
+            rejection_reason=reason,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OutputPreviewCloseResult:
+    """Describe preview lanes closed by a matching final output."""
+
+    closed_preview_ids: tuple[UUID, ...]
+    completed_keys: tuple[OutputPreviewLaneKey, ...]
+
+    @property
+    def closed(self) -> bool:
+        """Return whether any preview lane was closed."""
+
+        return bool(self.closed_preview_ids)
+
+
+__all__ = ["OutputPreviewAcceptance", "OutputPreviewCloseResult"]

--- a/substitute/domain/generation/__init__.py
+++ b/substitute/domain/generation/__init__.py
@@ -50,6 +50,11 @@ from substitute.domain.generation.output_organization import (
     OutputRunBucket,
 )
 from substitute.domain.generation.output_position import OutputResultPosition
+from substitute.domain.generation.output_source_key import (
+    canonical_output_source_key,
+    output_source_key_for_cube,
+    output_source_key_for_node,
+)
 from substitute.domain.generation.output_preferences import (
     default_output_preferences,
     effective_output_transfer_format,
@@ -102,6 +107,9 @@ __all__ = [
     "OutputPathToken",
     "OutputRunBucket",
     "OutputResultPosition",
+    "canonical_output_source_key",
+    "output_source_key_for_cube",
+    "output_source_key_for_node",
     "SUPPORTED_OUTPUT_PATH_TOKEN_NAMES",
     "SUPPORTED_OUTPUT_PATH_TOKENS",
     "SeedControlState",

--- a/substitute/domain/generation/output_source_key.py
+++ b/substitute/domain/generation/output_source_key.py
@@ -1,0 +1,66 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Define stable output-source identity across repeated workflow runs."""
+
+from __future__ import annotations
+
+
+def output_source_key_for_node(node_id: str) -> str:
+    """Return a workflow-local source key that survives generation reruns."""
+
+    normalized_node_id = node_id.strip()
+    if not normalized_node_id:
+        raise ValueError("Output source node id cannot be empty.")
+    return f"node:{normalized_node_id}"
+
+
+def output_source_key_for_cube(*, cube_alias: str, node_id: str) -> str:
+    """Return stable cube identity with node identity as an unlabeled fallback."""
+
+    normalized_alias = cube_alias.strip()
+    if normalized_alias:
+        return f"cube:{normalized_alias}"
+    return output_source_key_for_node(node_id)
+
+
+def canonical_output_source_key(
+    *,
+    source_key: str,
+    source_label: str,
+    node_id: str,
+) -> str:
+    """Migrate a legacy run-scoped node key without altering explicit keys."""
+
+    normalized_node_id = node_id.strip()
+    if not normalized_node_id:
+        return source_key
+    stable_key = output_source_key_for_cube(
+        cube_alias=source_label,
+        node_id=normalized_node_id,
+    )
+    if source_key.startswith("cube:") or source_key == stable_key:
+        return source_key
+    if source_key.endswith(f":{normalized_node_id}"):
+        return stable_key
+    return source_key or stable_key
+
+
+__all__ = [
+    "canonical_output_source_key",
+    "output_source_key_for_cube",
+    "output_source_key_for_node",
+]

--- a/substitute/infrastructure/comfy/output_source_identity_resolver.py
+++ b/substitute/infrastructure/comfy/output_source_identity_resolver.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, Mapping, cast
 
 from substitute.application.cubes import cube_alias_body
+from substitute.domain.generation import output_source_key_for_cube
 from substitute.shared.util.path_safety import safe_component
 
 
@@ -210,7 +211,6 @@ def resolve_output_source_identity_for_node(
         return OutputSourceResolution(
             source_identity=output_source_identity_for_node(
                 node_id,
-                workflow_id=workflow_id,
                 workflow_payload=workflow_payload,
             ),
             diagnostic=OutputSourceDiagnostic(
@@ -232,7 +232,6 @@ def resolve_output_source_identity_for_node(
         return OutputSourceResolution(
             source_identity=output_source_identity_for_node(
                 node_id,
-                workflow_id=workflow_id,
                 workflow_payload=workflow_payload,
             ),
             diagnostic=OutputSourceDiagnostic(
@@ -250,7 +249,6 @@ def resolve_output_source_identity_for_node(
     return OutputSourceResolution(
         source_identity=output_source_identity_for_node(
             cube_output_node_id,
-            workflow_id=workflow_id,
             workflow_payload=workflow_payload,
         )
     )
@@ -259,7 +257,6 @@ def resolve_output_source_identity_for_node(
 def output_source_identity_for_node(
     node_id: str,
     *,
-    workflow_id: str,
     workflow_payload: dict[str, object],
 ) -> OutputSourceIdentity:
     """Return canvas source identity for one executable output node."""
@@ -268,7 +265,10 @@ def output_source_identity_for_node(
     source_label = cube_alias or node_id
     return OutputSourceIdentity(
         node_id=node_id,
-        source_key=f"{workflow_id}:{node_id}",
+        source_key=output_source_key_for_cube(
+            cube_alias=cube_alias,
+            node_id=node_id,
+        ),
         source_label=source_label,
         cube_alias=cube_alias,
     )

--- a/substitute/presentation/canvas/output/output_canvas_view.py
+++ b/substitute/presentation/canvas/output/output_canvas_view.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from uuid import UUID, uuid4
 
 from PySide6.QtCore import QEvent, Qt, Signal
@@ -27,7 +27,6 @@ from PySide6.QtWidgets import QVBoxLayout, QWidget
 from cutecanvas import ExecutionRuntime, OutboundMimeProvider
 
 from substitute.application.workflows.canvas_route_projector_port import (
-    CanvasRouteIdentity,
     CanvasRouteSessionBoundaryPort,
     OutputRouteScope,
 )
@@ -51,9 +50,10 @@ from substitute.application.workflows.output_compare_resolution import (
     resolve_output_compare_selection,
 )
 from substitute.application.workflows.output_preview_registry import (
-    OutputPreviewAcceptance,
-    OutputPreviewLane,
     OutputPreviewRegistry,
+)
+from substitute.application.workflows.output_preview_results import (
+    OutputPreviewAcceptance,
 )
 from substitute.presentation.canvas.output.output_canvas_chrome import (
     install_output_navigation_chrome_theme_refresh,
@@ -84,6 +84,10 @@ from substitute.presentation.canvas.output.output_document_route_projector impor
 )
 from substitute.presentation.canvas.output.output_projection_content_synchronizer import (
     OutputProjectionContentSynchronizer,
+)
+from substitute.presentation.canvas.output.output_preview_navigation_presenter import (
+    OutputPreviewNavigationPresenter,
+    scene_overview_image_ids,
 )
 from substitute.presentation.canvas.output.output_canvas_zoom_indicators import (
     OutputCanvasZoomIndicators,
@@ -148,7 +152,6 @@ class OutputCanvas(QWidget):
         self._output_session: OutputCanvasSession | None = None
         self._output_projection: OutputCanvasProjection | None = None
         self._visible_compare_state = OutputCompareState()
-
         self.active_source_key: str | None = None
         self.active_scene_key: str | None = None
         self.active_scene_overview = False
@@ -223,13 +226,14 @@ class OutputCanvas(QWidget):
             ),
         )
         self._document_navigation = OutputDocumentNavigation(self)
+        self._preview_navigation = OutputPreviewNavigationPresenter(self)
         self._preview_presenter = OutputDocumentPreviewPresenter(
             preview_registry=lambda: self._preview_registry,
             document=self.document,
             output_session=lambda: self._output_session,
             refresh_preview_scope=self._bind_preview_scope,
-            present_source_preview=self._present_source_preview,
-            present_scene_previews=self._present_scene_previews,
+            present_source_preview=self._preview_navigation.present_source_preview,
+            present_scene_previews=self._preview_navigation.present_scene_previews,
         )
         install_output_navigation_chrome_theme_refresh(
             host=self,
@@ -379,6 +383,9 @@ class OutputCanvas(QWidget):
     def bind_projection_session(self, session: OutputCanvasSession) -> None:
         """Apply one authorized projection through the Output document workspace."""
 
+        previous_source_key = self.active_source_key
+        previous_set_index = self.active_set_index
+        self._preview_registry.rebind_workflow_session(session)
         self._output_session = session
         projection = session.projection
         self._output_projection = projection
@@ -387,6 +394,10 @@ class OutputCanvas(QWidget):
         self.active_scene_overview = projection.active_scene_overview
         self.active_source_key = projection.active_source_key
         self.active_set_index = projection.active_set_index
+        self._preview_navigation.restore_selection(
+            previous_source_key,
+            previous_set_index,
+        )
         if self.active_set_index > 0:
             self.last_real_set_index = self.active_set_index
         self.set_count = projection.set_count
@@ -442,20 +453,14 @@ class OutputCanvas(QWidget):
                 ):
                     return
         if projection.active_scene_overview:
-            session = self._output_session
-            preview_scenes = (
-                self._preview_registry.preview_scene_groups(session)
-                if session is not None
-                else {}
-            )
             self.document.present_grid(
-                _scene_overview_image_ids(
+                scene_overview_image_ids(
                     projection,
-                    preview_scenes=preview_scenes,
+                    preview_scenes=self._document_navigation.scene_groups(),
                 )
             )
             return
-        sources = _visible_sources(projection)
+        sources = tuple(self._document_navigation.visible_sources().values())
         if projection.active_set_index == 0:
             source = next(
                 (
@@ -468,6 +473,8 @@ class OutputCanvas(QWidget):
             if source is not None:
                 self.document.present_grid(_source_image_ids(source))
                 return
+        if self._preview_navigation.present_active_item(projection):
+            return
         if projection.active_uuid is not None:
             self._route_projector.apply_final_image_route(
                 output_route_identity_for_projection(projection),
@@ -498,51 +505,22 @@ class OutputCanvas(QWidget):
                 allowed_composition_ids=members.composition_ids,
             )
         )
-
-    def _present_source_preview(self, preview_id: UUID) -> None:
-        """Present one authorized source preview through the document route boundary."""
-
-        self._route_projector.apply_final_image_route(
-            CanvasRouteIdentity(
-                route_kind="output_image",
-                route_key=f"image:{preview_id}",
-                primary_image_id=preview_id,
-            ),
-            preview_id,
-        )
-
-    def _present_scene_previews(
-        self,
-        lanes: tuple[OutputPreviewLane, ...],
-    ) -> None:
-        """Present accepted scene-preview representatives when overview is active."""
-
-        session = self._output_session
-        if session is None:
-            return
-        preview_scenes = self._preview_registry.preview_scene_groups(session)
-        if not preview_scenes:
-            return
-        reported_scene_count = max(
-            (lane.scene_count or 0 for lane in lanes),
-            default=0,
-        )
-        self.scene_count = max(
-            self.scene_count,
-            reported_scene_count,
-            len(preview_scenes),
-        )
-        if self.scene_count > 1 and self.active_scene_key is None:
-            self.active_scene_key = next(iter(preview_scenes), None)
-            self.active_scene_overview = True
-        if not self.active_scene_overview:
-            return
-        image_ids = _scene_overview_image_ids(
-            self._output_projection,
-            preview_scenes=preview_scenes,
-        )
-        self.document.present_grid(image_ids)
         self._document_navigation.synchronize_projection()
+
+    def present_preview_selection(self, preview_id: UUID) -> None:
+        """Present one user-selected placeholder and preserve it across final refreshes."""
+
+        self._preview_navigation.present_selection(preview_id)
+
+    def present_preview_grid(self, image_ids: tuple[UUID, ...]) -> None:
+        """Present one user-selected grid containing a transient placeholder."""
+
+        self._preview_navigation.present_grid(image_ids)
+
+    def release_preview_navigation(self) -> None:
+        """Release transient focus before normal final-output navigation."""
+
+        self._preview_navigation.release()
 
     def _activate_workspace_target(self, composition_id: UUID) -> None:
         """Forward one document-grid activation to existing Output navigation signals."""
@@ -561,58 +539,10 @@ class OutputCanvas(QWidget):
             self._document_navigation.handle_workspace_presentation(presentation)
 
 
-def _visible_sources(
-    projection: OutputCanvasProjection,
-) -> tuple[OutputCanvasSourceGroup, ...]:
-    """Return source groups selected by the active scene context."""
-
-    if projection.scene_count <= 1 or projection.active_scene_key is None:
-        return projection.sources
-    scene = next(
-        (
-            scene
-            for scene in projection.scene_groups
-            if scene.scene_key == projection.active_scene_key
-        ),
-        None,
-    )
-    return projection.sources if scene is None else scene.sources
-
-
 def _source_image_ids(source: OutputCanvasSourceGroup) -> tuple[UUID, ...]:
     """Return ordered image identities for one source-grid presentation."""
 
     return tuple(item.image_id for _index, item in sorted(source.images_by_set.items()))
-
-
-def _scene_overview_image_ids(
-    projection: OutputCanvasProjection | None,
-    *,
-    preview_scenes: Mapping[str, object] | None = None,
-) -> tuple[UUID, ...]:
-    """Return ordered final or live-preview representatives for one scene overview."""
-
-    preview_by_key = preview_scenes or {}
-    image_ids: list[UUID] = []
-    final_scene_keys: set[str] = set()
-    if projection is not None:
-        for scene in projection.scene_groups:
-            final_scene_keys.add(scene.scene_key)
-            preview = preview_by_key.get(scene.scene_key)
-            preview_id = getattr(preview, "preview_image_id", None)
-            image_id = preview_id or scene.primary_image_id
-            if isinstance(image_id, UUID):
-                image_ids.append(image_id)
-    for scene_key, preview in sorted(
-        preview_by_key.items(),
-        key=lambda item: int(getattr(item[1], "order", 0)),
-    ):
-        if scene_key in final_scene_keys:
-            continue
-        preview_id = getattr(preview, "preview_image_id", None)
-        if isinstance(preview_id, UUID):
-            image_ids.append(preview_id)
-    return tuple(dict.fromkeys(image_ids))
 
 
 __all__ = ["OutputCanvas"]

--- a/substitute/presentation/canvas/output/output_canvas_view.pyi
+++ b/substitute/presentation/canvas/output/output_canvas_view.pyi
@@ -36,8 +36,10 @@ from substitute.application.workflows.output_canvas_projection import (
     OutputCanvasProjection,
 )
 from substitute.application.workflows.output_preview_registry import (
-    OutputPreviewAcceptance,
     OutputPreviewRegistry,
+)
+from substitute.application.workflows.output_preview_results import (
+    OutputPreviewAcceptance,
 )
 from substitute.application.workflows.output_canvas_state_service import (
     OutputPreviewCloseIdentity,
@@ -75,6 +77,10 @@ class OutputCanvas(QWidget):
     scene_count: int
     set_count: int
     _output_projection: OutputCanvasProjection | None
+    _output_session: OutputCanvasSession | None
+    _preview_registry: OutputPreviewRegistry
+    _preview_navigation: Any
+    _document_navigation: Any
     _set_picker: Any
     _scene_picker: Any
     _source_picker: Any
@@ -172,6 +178,15 @@ class OutputCanvas(QWidget):
         ...
     def clear_previews(self, source_key: str | None = None) -> None:
         """Retire transient previews for one source or all sources."""
+        ...
+    def present_preview_selection(self, preview_id: UUID) -> None:
+        """Present one user-selected transient placeholder."""
+        ...
+    def present_preview_grid(self, image_ids: tuple[UUID, ...]) -> None:
+        """Present one user-selected grid containing a transient placeholder."""
+        ...
+    def release_preview_navigation(self) -> None:
+        """Return navigation ownership to durable final outputs."""
         ...
     def set_canvas_detached(self, detached: bool) -> None:
         """Set manager-owned canvas attachment state."""

--- a/substitute/presentation/canvas/output/output_document_navigation.py
+++ b/substitute/presentation/canvas/output/output_document_navigation.py
@@ -28,10 +28,16 @@ from sugarsubstitute_shared.presentation.fluent_tooltips import (
 )
 
 from substitute.application.workflows.output_canvas_projection import (
+    OutputCanvasImageItem,
     OutputCanvasSceneGroup,
     OutputCanvasSourceGroup,
 )
 from substitute.application.workflows.output_compare_state import OutputCompareState
+from substitute.application.workflows.output_preview_projection import (
+    overlay_preview_scenes,
+    overlay_preview_sources,
+)
+from substitute.application.workflows.output_preview_registry import OutputPreviewLane
 from substitute.presentation.canvas.output.output_canvas_navigation_bar import (
     selector_width_for_widget_text,
 )
@@ -164,6 +170,16 @@ class OutputDocumentNavigation:
         sync_output_comparison_navigation_buttons(self.host)
         update_output_tabbar_container(self.host)
 
+    def visible_sources(self) -> dict[str, OutputCanvasSourceGroup]:
+        """Return final sources overlaid with current transient placeholders."""
+
+        return self._visible_sources()
+
+    def scene_groups(self) -> dict[str, OutputCanvasSceneGroup]:
+        """Return final scenes overlaid with current transient placeholders."""
+
+        return self._scene_groups()
+
     def handle_workspace_presentation(self, presentation: CanvasPresentation) -> None:
         """Persist user divider movement forwarded by the public workspace state."""
 
@@ -193,8 +209,8 @@ class OutputDocumentNavigation:
         if projection is None:
             return False
         if self.host.active_scene_overview:
-            for scene in projection.scene_groups:
-                if scene.primary_image_id == image_id:
+            for scene in self._scene_groups().values():
+                if image_id in {scene.preview_image_id, scene.primary_image_id}:
                     select_output_scene(
                         self.host,
                         scene.scene_key,
@@ -208,6 +224,9 @@ class OutputDocumentNavigation:
         for source in self._visible_sources().values():
             for item in source.images_by_set.values():
                 if item.image_id == image_id:
+                    if self._activate_preview_item(source.source_key, item):
+                        return True
+                    self.host.release_preview_navigation()
                     activate_output_item(
                         self.host,
                         source.source_key,
@@ -380,6 +399,16 @@ class OutputDocumentNavigation:
     def _select_set(self, set_index: int) -> None:
         """Apply one set picker choice through existing product navigation policy."""
 
+        source_key = self.host.active_source_key
+        source = self._visible_sources().get(source_key or "")
+        if source is not None:
+            item = source.images_by_set.get(set_index)
+            if item is not None and self._activate_preview_item(
+                source.source_key,
+                item,
+            ):
+                return
+        self.host.release_preview_navigation()
         select_output_set(
             self.host,
             set_index,
@@ -390,6 +419,15 @@ class OutputDocumentNavigation:
     def _select_source(self, source_key: str) -> None:
         """Apply one source tab or picker choice through product navigation policy."""
 
+        source = self._visible_sources().get(source_key)
+        item = (
+            None
+            if source is None
+            else source.images_by_set.get(self.host.active_set_index)
+        )
+        if item is not None and self._activate_preview_item(source_key, item):
+            return
+        self.host.release_preview_navigation()
         select_output_source(
             self.host,
             source_key,
@@ -397,15 +435,30 @@ class OutputDocumentNavigation:
             update_tabbar_container=lambda: update_output_tabbar_container(self.host),
         )
 
+    def _activate_preview_item(
+        self,
+        source_key: str,
+        item: OutputCanvasImageItem,
+    ) -> bool:
+        """Activate one preview placeholder without persisting a nonexistent final UUID."""
+
+        lane = self.host._preview_registry.lane_for_id(item.image_id)
+        if lane is None:
+            return False
+        activate_output_item(
+            self.host,
+            source_key,
+            item,
+            emit_selection=False,
+            update_tabbar_container=lambda: update_output_tabbar_container(self.host),
+        )
+        self.host.present_preview_selection(lane.preview_id)
+        return True
+
     def _select_scene(self, scene_key: str) -> None:
         """Apply one scene picker choice through product navigation policy."""
 
-        select_output_scene(
-            self.host,
-            scene_key,
-            scene_groups_by_key=self._scene_groups(),
-            update_tabbar_container=lambda: update_output_tabbar_container(self.host),
-        )
+        self.host._preview_navigation.select_scene(scene_key, self._scene_groups())
 
     def _visible_sources(self) -> dict[str, OutputCanvasSourceGroup]:
         """Return sources valid for the current scene-level navigation scope."""
@@ -413,8 +466,14 @@ class OutputDocumentNavigation:
         projection = self.host._output_projection
         if projection is None or self.host.active_scene_overview:
             return {}
-        if projection.scene_count <= 1:
-            return {source.source_key: source for source in projection.sources}
+        lanes = self._preview_lanes()
+        if self.host.scene_count <= 1:
+            sources = overlay_preview_sources(
+                projection.sources,
+                lanes,
+                scene_key=None,
+            )
+            return {source.source_key: source for source in sources}
         scene = self._scene_groups().get(self.host.active_scene_key or "")
         return (
             {}
@@ -426,21 +485,20 @@ class OutputDocumentNavigation:
         """Return current final scene groups keyed by their stable workflow identity."""
 
         projection = self.host._output_projection
-        groups = (
-            {}
-            if projection is None
-            else {scene.scene_key: scene for scene in projection.scene_groups}
+        scenes = overlay_preview_scenes(
+            () if projection is None else projection.scene_groups,
+            self._preview_lanes(),
         )
-        session = getattr(self.host, "_output_session", None)
-        registry = getattr(self.host, "_preview_registry", None)
-        preview_groups = (
-            registry.preview_scene_groups(session)
-            if session is not None and registry is not None
-            else {}
-        )
-        for scene_key, preview_group in preview_groups.items():
-            groups.setdefault(scene_key, preview_group)
-        return groups
+        return {scene.scene_key: scene for scene in scenes}
+
+    def _preview_lanes(self) -> tuple[OutputPreviewLane, ...]:
+        """Return preview lanes belonging to the bound Output session."""
+
+        session = self.host._output_session
+        registry = self.host._preview_registry
+        if session is None or registry is None:
+            return ()
+        return registry.lanes_for_session(session)
 
     def _scene_picker_width(self, items: tuple[CanvasNavPickerItem, ...]) -> int:
         """Return a scene menu width that fits its anchor and localized labels."""

--- a/substitute/presentation/canvas/output/output_document_preview_presenter.py
+++ b/substitute/presentation/canvas/output/output_document_preview_presenter.py
@@ -25,10 +25,12 @@ from uuid import UUID
 
 from substitute.application.workflows.output_canvas_session import OutputCanvasSession
 from substitute.application.workflows.output_preview_registry import (
-    OutputPreviewAcceptance,
     OutputPreviewLane,
     OutputPreviewLanePlacement,
     OutputPreviewRegistry,
+)
+from substitute.application.workflows.output_preview_results import (
+    OutputPreviewAcceptance,
 )
 
 
@@ -50,8 +52,8 @@ class OutputDocumentPreviewPresenter:
     document: OutputPreviewDocumentPort
     output_session: Callable[[], OutputCanvasSession | None]
     refresh_preview_scope: Callable[[], None]
-    present_source_preview: Callable[[UUID], None]
-    present_scene_previews: Callable[[tuple[OutputPreviewLane, ...]], None]
+    present_source_preview: Callable[[UUID, bool], None]
+    present_scene_previews: Callable[[tuple[OutputPreviewLane, ...]], bool]
 
     def apply_preview_acceptance(self, acceptance: OutputPreviewAcceptance) -> None:
         """Apply one session-authorized preview acceptance to Output document content."""
@@ -74,17 +76,19 @@ class OutputDocumentPreviewPresenter:
         for lane in lanes:
             self.document.admit_image(lane.preview_id, lane.image, title="Preview")
         self.refresh_preview_scope()
-        source_lane = _source_lane(lanes)
-        if source_lane is not None:
-            self.present_source_preview(source_lane.preview_id)
-            return
         scene_lanes = tuple(
             lane
             for lane in lanes
             if lane.key.placement is OutputPreviewLanePlacement.SCENE
         )
-        if scene_lanes:
-            self.present_scene_previews(scene_lanes)
+        if scene_lanes and self.present_scene_previews(scene_lanes):
+            return
+        source_lane = _source_lane(lanes)
+        if source_lane is not None:
+            self.present_source_preview(
+                source_lane.preview_id,
+                source_lane.preview_id in acceptance.created_preview_ids,
+            )
 
     def close_final_output_preview_lane(self, preview_ids: tuple[UUID, ...]) -> None:
         """Retire preview compositions superseded by one finalized output lane."""

--- a/substitute/presentation/canvas/output/output_preview_navigation_presenter.py
+++ b/substitute/presentation/canvas/output/output_preview_navigation_presenter.py
@@ -1,0 +1,364 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Present transient preview routes without changing durable Output navigation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol, cast
+from uuid import UUID
+
+from substitute.application.workflows.canvas_route_projector_port import (
+    CanvasRouteIdentity,
+)
+from substitute.application.workflows.output_canvas_projection import (
+    OutputCanvasProjection,
+    OutputCanvasSceneGroup,
+    OutputCanvasSourceGroup,
+)
+from substitute.application.workflows.output_canvas_session import (
+    OutputCanvasSession,
+    output_route_identity_for_projection,
+)
+from substitute.application.workflows.output_preview_registry import (
+    OutputPreviewLane,
+    OutputPreviewRegistry,
+)
+from substitute.application.workflows.output_scene_navigation_selection import (
+    OutputSceneNavigationSelection,
+)
+from substitute.presentation.canvas.output.output_canvas_navigation_chrome import (
+    update_output_tabbar_container,
+)
+from substitute.presentation.canvas.output.output_canvas_navigation_controller import (
+    activate_output_scene,
+    activate_output_scene_overview,
+)
+from substitute.presentation.canvas.output.output_canvas_navigation_policy import (
+    OutputCanvasNavigationPolicy,
+)
+from substitute.presentation.canvas.output.output_document_route_projector import (
+    OutputDocumentRouteProjector,
+)
+
+
+class _OutputPreviewDocumentPort(Protocol):
+    """Describe document presentation used by transient preview navigation."""
+
+    def present_grid(self, image_ids: tuple[UUID, ...]) -> bool:
+        """Present a grid of admitted images."""
+
+
+class _OutputPreviewDocumentNavigationPort(Protocol):
+    """Describe the preview-aware projection exposed by document navigation."""
+
+    def visible_sources(self) -> dict[str, OutputCanvasSourceGroup]:
+        """Return sources overlaid with transient preview placeholders."""
+
+    def scene_groups(self) -> dict[str, OutputCanvasSceneGroup]:
+        """Return scenes overlaid with transient preview placeholders."""
+
+    def synchronize_projection(self) -> None:
+        """Synchronize navigation chrome with current host state."""
+
+
+class _OutputPreviewSignalPort(Protocol):
+    """Describe a Qt-compatible navigation signal."""
+
+    def emit(self, *args: object) -> None:
+        """Publish one navigation event."""
+
+
+class _OutputPreviewNavigationHost(Protocol):
+    """Describe Output host state required by transient preview presentation."""
+
+    _preview_registry: OutputPreviewRegistry
+    _output_session: OutputCanvasSession | None
+    _output_projection: OutputCanvasProjection | None
+    _document_navigation: _OutputPreviewDocumentNavigationPort
+    document: _OutputPreviewDocumentPort
+    activeOutputSceneChanged: _OutputPreviewSignalPort
+    active_source_key: str | None
+    active_scene_key: str | None
+    active_scene_overview: bool
+    active_set_index: int
+    scene_count: int
+
+    @property
+    def route_projector(self) -> OutputDocumentRouteProjector:
+        """Return the authorized document route projector."""
+
+    def _bind_preview_scope(self) -> None:
+        """Refresh authorized document members after preview mutation."""
+
+
+class OutputPreviewNavigationPresenter:
+    """Own transient focus, preview routes, and preview-backed scene navigation."""
+
+    def __init__(self, host: object) -> None:
+        """Bind one Output host while keeping transient lock state private."""
+
+        self._host = cast(_OutputPreviewNavigationHost, host)
+        self._locked = False
+
+    def restore_selection(
+        self,
+        previous_source_key: str | None,
+        previous_set_index: int,
+    ) -> None:
+        """Preserve a user-selected placeholder across final projection refreshes."""
+
+        if not self._locked:
+            return
+        source = self._host._document_navigation.visible_sources().get(
+            previous_source_key or ""
+        )
+        if source is None or (
+            previous_set_index != 0 and previous_set_index not in source.images_by_set
+        ):
+            self._locked = False
+            return
+        self._host.active_source_key = previous_source_key
+        self._host.active_set_index = previous_set_index
+
+    def present_active_item(self, projection: OutputCanvasProjection) -> bool:
+        """Present the active final or preview item from the overlaid projection."""
+
+        sources = self._host._document_navigation.visible_sources()
+        source = sources.get(self._host.active_source_key or "")
+        item = (
+            None
+            if source is None
+            else source.images_by_set.get(self._host.active_set_index)
+        )
+        if item is None:
+            return False
+        route = (
+            _preview_route(item.image_id)
+            if self._host._preview_registry.lane_for_id(item.image_id) is not None
+            else output_route_identity_for_projection(projection)
+        )
+        self._host.route_projector.apply_final_image_route(route, item.image_id)
+        return True
+
+    def present_source_preview(self, preview_id: UUID, is_new: bool) -> None:
+        """Stream a placeholder without stealing deliberate earlier-source focus."""
+
+        lane = self._host._preview_registry.lane_for_id(preview_id)
+        if lane is None or self._host.active_scene_overview:
+            return
+        sources = self._host._document_navigation.visible_sources()
+        source_keys = tuple(sources)
+        if lane.key.source_key not in sources:
+            return
+        if self._host.active_source_key != lane.key.source_key:
+            source_index = source_keys.index(lane.key.source_key)
+            follows_current_tail = (
+                source_index == 0
+                and self._host.active_source_key is None
+                or source_index > 0
+                and self._host.active_source_key == source_keys[source_index - 1]
+            )
+            if (
+                not is_new
+                or not follows_current_tail
+                or self._host.active_set_index != 1
+            ):
+                return
+            self._host.active_source_key = lane.key.source_key
+            self._host._document_navigation.synchronize_projection()
+        self._host.route_projector.apply_final_image_route(
+            _preview_route(preview_id),
+            preview_id,
+        )
+
+    def present_selection(self, preview_id: UUID) -> None:
+        """Present a user-selected placeholder until durable navigation resumes."""
+
+        self._locked = True
+        self._host._bind_preview_scope()
+        self.present_source_preview(preview_id, False)
+
+    def present_grid(self, image_ids: tuple[UUID, ...]) -> None:
+        """Present a user-selected grid containing a transient placeholder."""
+
+        self._locked = True
+        self._host._bind_preview_scope()
+        self._host.document.present_grid(image_ids)
+
+    def release(self) -> None:
+        """Return navigation ownership to durable final outputs."""
+
+        self._locked = False
+
+    def present_scene_previews(
+        self,
+        lanes: tuple[OutputPreviewLane, ...],
+    ) -> bool:
+        """Present accepted scene representatives when scene overview is active."""
+
+        if self._host._output_session is None:
+            return False
+        preview_scenes = self._host._document_navigation.scene_groups()
+        if not preview_scenes:
+            return False
+        reported_scene_count = max(
+            (lane.scene_count or 0 for lane in lanes),
+            default=0,
+        )
+        self._host.scene_count = max(
+            self._host.scene_count,
+            reported_scene_count,
+            len(preview_scenes),
+        )
+        if self._host.scene_count > 1 and self._host.active_scene_key is None:
+            self._host.active_scene_key = next(iter(preview_scenes), None)
+            self._host.active_scene_overview = True
+        if not self._host.active_scene_overview:
+            return False
+        self._host.document.present_grid(
+            scene_overview_image_ids(
+                self._host._output_projection,
+                preview_scenes=preview_scenes,
+            )
+        )
+        self._host._document_navigation.synchronize_projection()
+        return True
+
+    def select_scene(
+        self,
+        scene_key: str,
+        scene_groups: Mapping[str, OutputCanvasSceneGroup],
+    ) -> None:
+        """Apply scene navigation while keeping placeholder routes transient."""
+
+        action = OutputCanvasNavigationPolicy.scene_selection_action(scene_key)
+
+        def update_chrome() -> None:
+            """Refresh Output navigation chrome after one scene transition."""
+
+            update_output_tabbar_container(self._host)
+
+        if action.kind == "activate_scene_overview":
+            if activate_output_scene_overview(
+                self._host,
+                update_tabbar_container=update_chrome,
+            ):
+                self._host.activeOutputSceneChanged.emit(
+                    OutputSceneNavigationSelection(
+                        scene_key=None,
+                        overview=True,
+                        source_key=None,
+                        set_index=1,
+                        image_id=None,
+                    )
+                )
+            return
+        selection = activate_output_scene(
+            self._host,
+            action.scene_key,
+            scene_groups_by_key=scene_groups,
+            update_tabbar_container=update_chrome,
+        )
+        if selection is None or self._present_scene_selection(selection, scene_groups):
+            return
+        self._host.activeOutputSceneChanged.emit(selection)
+
+    def _present_scene_selection(
+        self,
+        selection: OutputSceneNavigationSelection,
+        scene_groups: Mapping[str, OutputCanvasSceneGroup],
+    ) -> bool:
+        """Present a preview-backed concrete scene selection when one exists."""
+
+        preview_id = selection.image_id
+        if (
+            preview_id is not None
+            and self._host._preview_registry.lane_for_id(preview_id) is not None
+        ):
+            self.present_selection(preview_id)
+            return True
+        if selection.set_index != 0 or selection.source_key is None:
+            return False
+        scene = scene_groups.get(selection.scene_key or "")
+        source = next(
+            (
+                candidate
+                for candidate in (() if scene is None else scene.sources)
+                if candidate.source_key == selection.source_key
+            ),
+            None,
+        )
+        image_ids = (
+            ()
+            if source is None
+            else tuple(
+                item.image_id
+                for _set_index, item in sorted(source.images_by_set.items())
+            )
+        )
+        if not any(
+            self._host._preview_registry.lane_for_id(image_id) is not None
+            for image_id in image_ids
+        ):
+            return False
+        self.present_grid(image_ids)
+        return True
+
+
+def scene_overview_image_ids(
+    projection: OutputCanvasProjection | None,
+    *,
+    preview_scenes: Mapping[str, object] | None = None,
+) -> tuple[UUID, ...]:
+    """Return ordered final or live-preview representatives for scene overview."""
+
+    preview_by_key = preview_scenes or {}
+    image_ids: list[UUID] = []
+    final_scene_keys: set[str] = set()
+    if projection is not None:
+        for scene in projection.scene_groups:
+            final_scene_keys.add(scene.scene_key)
+            preview_id = getattr(
+                preview_by_key.get(scene.scene_key), "preview_image_id", None
+            )
+            image_id = preview_id or scene.primary_image_id
+            if isinstance(image_id, UUID):
+                image_ids.append(image_id)
+    for scene_key, preview in sorted(
+        preview_by_key.items(),
+        key=lambda item: int(getattr(item[1], "order", 0)),
+    ):
+        if scene_key in final_scene_keys:
+            continue
+        preview_id = getattr(preview, "preview_image_id", None)
+        if isinstance(preview_id, UUID):
+            image_ids.append(preview_id)
+    return tuple(dict.fromkeys(image_ids))
+
+
+def _preview_route(preview_id: UUID) -> CanvasRouteIdentity:
+    """Build the transient document route for one preview placeholder."""
+
+    return CanvasRouteIdentity(
+        route_kind="output_image",
+        route_key=f"image:{preview_id}",
+        primary_image_id=preview_id,
+    )
+
+
+__all__ = ["OutputPreviewNavigationPresenter", "scene_overview_image_ids"]

--- a/substitute/presentation/shell/generation_feedback_coalescer.py
+++ b/substitute/presentation/shell/generation_feedback_coalescer.py
@@ -44,6 +44,9 @@ from substitute.application.workflows.output_visual_events import (
     LiveFinalOutputEvent,
     LivePreviewEvent,
 )
+from substitute.presentation.shell.generation_visual_run_registration import (
+    register_generation_visual_run,
+)
 from substitute.shared.logging.logger import get_logger, log_debug
 
 _LOGGER = get_logger("presentation.shell.generation_feedback_coalescer")
@@ -206,13 +209,7 @@ class GenerationFeedbackCoalescer:
             prompt_id=event.prompt_id,
             client_id=event.client_id,
         )
-        if self._visual_authorization is not None:
-            self._visual_authorization.register_run(
-                workflow_id=event.workflow_id,
-                generation_run_id=event.generation_run_id,
-                prompt_id=event.prompt_id,
-                client_id=event.client_id,
-            )
+        register_generation_visual_run(self._visual_authorization, event)
         log_debug(
             _LOGGER,
             "Generation feedback run registered",

--- a/substitute/presentation/shell/generation_visual_run_registration.py
+++ b/substitute/presentation/shell/generation_visual_run_registration.py
@@ -1,0 +1,44 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Register generation-run visual authorization from shell feedback events."""
+
+from __future__ import annotations
+
+from substitute.application.generation import (
+    GenerationRunStarted,
+    VisualAuthorizationService,
+)
+
+
+def register_generation_visual_run(
+    authorization: VisualAuthorizationService | None,
+    event: GenerationRunStarted,
+) -> None:
+    """Register every identity and placeholder source authorized for one run."""
+
+    if authorization is None:
+        return
+    authorization.register_run(
+        workflow_id=event.workflow_id,
+        generation_run_id=event.generation_run_id,
+        prompt_id=event.prompt_id,
+        client_id=event.client_id,
+        preview_source_keys=event.preview_source_keys,
+    )
+
+
+__all__ = ["register_generation_visual_run"]

--- a/substitute/presentation/shell/workspace_canvas_actions.py
+++ b/substitute/presentation/shell/workspace_canvas_actions.py
@@ -37,13 +37,11 @@ from substitute.application.errors import (
 from substitute.application.ports.file_manager_gateway import FileRevealResult
 from substitute.application.ports import GenerationVisualIdentity, OutputImageUpdate
 from substitute.application.workflows.output_preview_registry import (
-    OutputPreviewAcceptance,
     OutputPreviewRegistry,
     OutputPreviewRejectionReason,
 )
-from substitute.application.workflows.output_visual_events import (
-    LivePreviewEvent,
-    OutputSceneIdentity,
+from substitute.application.workflows.output_preview_results import (
+    OutputPreviewAcceptance,
 )
 from substitute.application.workflows.output_canvas_state_service import (
     OutputImageRegistrationResult,
@@ -54,7 +52,6 @@ from substitute.application.workflows.output_canvas_focus_service import (
     OutputFocusMutationResult,
     OutputFocusSnapshot,
 )
-from substitute.application.workflows.output_canvas_session import OutputCanvasSession
 from substitute.application.workflows.output_scene_navigation_selection import (
     OutputSceneNavigationSelection,
 )
@@ -67,6 +64,9 @@ from substitute.presentation.shell.output_image_commit_pipeline import (
 )
 from substitute.presentation.shell.generation_feedback_presenter import (
     generation_feedback_presenter_for,
+)
+from substitute.presentation.shell.workspace_preview_actions import (
+    WorkspacePreviewActions,
 )
 from substitute.presentation.shell.workflow_surface_invalidation import (
     CANVAS_AND_GENERATION_SURFACES,
@@ -440,6 +440,10 @@ class WorkspaceCanvasActions:
         self._view = view
         self._error_presenter = error_presenter
         self._asset_reveal_service = asset_reveal_service
+        self._preview_actions = WorkspacePreviewActions(
+            view,
+            self._log_missing_output_canvas,
+        )
 
     def on_active_output_changed(self, uuid_str: str) -> None:
         """Persist the currently selected output image id into workflow state."""
@@ -532,83 +536,12 @@ class WorkspaceCanvasActions:
     ) -> None:
         """Display preview image only after strict identity and session checks."""
 
-        if not isinstance(preview, LivePreviewEvent):
-            return
-        view = self._view
-        workflow_id = preview.identity.workflow_id
-        output_canvas = view.canvas_host.canvas_for("Output")
-        if output_canvas is None:
-            self._log_missing_output_canvas(workflow_id)
-            return
-        session = self._output_session_for_preview(output_canvas, workflow_id)
-        if session is None:
-            return
-        authorization = getattr(view, "visual_authorization_service", None)
-        authorize_preview = getattr(authorization, "authorize_preview", None)
-        if not callable(authorize_preview):
-            return
-        acceptance = view.output_preview_registry.accept_preview(
-            preview,
-            session=session,
-            active_workflow_id=view.workflow_session_service.active_workflow_id,
-            authorize_preview=authorize_preview,
-            is_valid_scene_placeholder=self._valid_scene_preview_placeholder,
-        )
-        if not acceptance.accepted and not acceptance.retired_preview_ids:
-            return
-        apply_preview = getattr(output_canvas, "apply_preview_acceptance", None)
-        if callable(apply_preview):
-            apply_preview(acceptance)
-            return
-        self._log_missing_output_canvas(workflow_id)
-
-    def _output_session_for_preview(
-        self,
-        output_canvas: object,
-        workflow_id: str,
-    ) -> OutputCanvasSession | None:
-        """Return or bind the active visible Output session for a preview."""
-
-        view = self._view
-        session_service = getattr(view, "workflow_session_service", None)
-        active_workflow_id = str(
-            getattr(session_service, "active_workflow_id", "") or ""
-        )
-        if workflow_id != active_workflow_id:
-            return None
-        session = getattr(output_canvas, "_output_session", None)
-        if (
-            isinstance(session, OutputCanvasSession)
-            and session.workflow_id.value == workflow_id
-        ):
-            return session
-        canvas_host = getattr(view, "canvas_host", None)
-        is_canvas_visible = getattr(canvas_host, "is_canvas_visible", None)
-        if callable(is_canvas_visible) and not bool(is_canvas_visible("Output")):
-            return None
-        workflows = getattr(session_service, "workflows", None)
-        if not isinstance(workflows, Mapping):
-            return None
-        coordinator = getattr(view, "output_canvas_projection_coordinator", None)
-        project_workflow = getattr(coordinator, "project_workflow", None)
-        if not callable(project_workflow):
-            return None
-        project_workflow(workflows, workflow_id)
-        session = getattr(output_canvas, "_output_session", None)
-        return session if isinstance(session, OutputCanvasSession) else None
+        self._preview_actions.display_preview_image(preview)
 
     def clear_output_previews(self, workflow_id: str) -> None:
         """Clear transient output previews for the active workflow only."""
 
-        view = self._view
-        if workflow_id != view.workflow_session_service.active_workflow_id:
-            return
-        output_canvas = view.canvas_host.canvas_for("Output")
-        clear_previews = getattr(output_canvas, "clear_previews", None)
-        if callable(clear_previews):
-            clear_previews()
-        else:
-            self._log_missing_output_canvas(workflow_id)
+        self._preview_actions.clear_output_previews(workflow_id)
 
     def open_image_in_external_editor(
         self,
@@ -815,26 +748,6 @@ class WorkspaceCanvasActions:
         generation_feedback_presenter_for(self._view).log_missing_output_canvas(
             workflow_id
         )
-
-    def _valid_scene_preview_placeholder(
-        self,
-        scene: OutputSceneIdentity,
-        identity: GenerationVisualIdentity,
-    ) -> bool:
-        """Return whether a scene preview is known to the active scene run."""
-
-        scene_run_service = getattr(self._view, "output_scene_run_service", None)
-        run_for_id = getattr(scene_run_service, "run_for_id", None)
-        if not callable(run_for_id):
-            return False
-        run = run_for_id(scene.run_id)
-        if run is None or getattr(run, "workflow_id", None) != identity.workflow_id:
-            return False
-        scene_entry = getattr(run, "scene_for_key", lambda _scene_key: None)(scene.key)
-        if scene_entry is None:
-            return False
-        status = getattr(scene_entry, "status", "")
-        return status in {"pending", "dispatching", "comfy_pending", "running"}
 
     def _schedule_registered_output_projection(
         self,

--- a/substitute/presentation/shell/workspace_preview_actions.py
+++ b/substitute/presentation/shell/workspace_preview_actions.py
@@ -1,0 +1,159 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Authorize and project live Output preview placeholders for the workspace."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from substitute.application.ports import GenerationVisualIdentity
+from substitute.application.workflows.output_canvas_session import OutputCanvasSession
+from substitute.application.workflows.output_visual_events import (
+    LivePreviewEvent,
+    OutputSceneIdentity,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspacePreviewActions:
+    """Own live preview authorization, session binding, and canvas admission."""
+
+    view: object
+    log_missing_output_canvas: Callable[[str], None]
+
+    def display_preview_image(self, preview: object) -> None:
+        """Display a preview only after strict run, source, and session checks."""
+
+        if not isinstance(preview, LivePreviewEvent):
+            return
+        workflow_id = preview.identity.workflow_id
+        output_canvas = self._output_canvas()
+        if output_canvas is None:
+            self.log_missing_output_canvas(workflow_id)
+            return
+        session = self._output_session(output_canvas, workflow_id)
+        if session is None:
+            return
+        authorization = getattr(self.view, "visual_authorization_service", None)
+        authorize_preview = getattr(authorization, "authorize_preview", None)
+        authorize_source = getattr(authorization, "authorize_preview_source", None)
+        registry = getattr(self.view, "output_preview_registry", None)
+        accept_preview = getattr(registry, "accept_preview", None)
+        session_service = getattr(self.view, "workflow_session_service", None)
+        if not callable(authorize_preview) or not callable(accept_preview):
+            return
+        acceptance = accept_preview(
+            preview,
+            session=session,
+            active_workflow_id=str(
+                getattr(session_service, "active_workflow_id", "") or ""
+            ),
+            authorize_preview=authorize_preview,
+            is_valid_source_placeholder=authorize_source,
+            is_valid_scene_placeholder=self._valid_scene_placeholder,
+        )
+        if not acceptance.accepted and not acceptance.retired_preview_ids:
+            return
+        apply_preview = getattr(output_canvas, "apply_preview_acceptance", None)
+        if callable(apply_preview):
+            apply_preview(acceptance)
+            return
+        self.log_missing_output_canvas(workflow_id)
+
+    def clear_output_previews(self, workflow_id: str) -> None:
+        """Clear transient previews only for the active workflow."""
+
+        session_service = getattr(self.view, "workflow_session_service", None)
+        active_workflow_id = str(
+            getattr(session_service, "active_workflow_id", "") or ""
+        )
+        if workflow_id != active_workflow_id:
+            return
+        clear_previews = getattr(self._output_canvas(), "clear_previews", None)
+        if callable(clear_previews):
+            clear_previews()
+            return
+        self.log_missing_output_canvas(workflow_id)
+
+    def _output_canvas(self) -> object | None:
+        """Return the configured Output canvas when its host exposes one."""
+
+        canvas_host = getattr(self.view, "canvas_host", None)
+        canvas_for = getattr(canvas_host, "canvas_for", None)
+        return canvas_for("Output") if callable(canvas_for) else None
+
+    def _output_session(
+        self,
+        output_canvas: object,
+        workflow_id: str,
+    ) -> OutputCanvasSession | None:
+        """Return or bind the active visible Output session for a preview."""
+
+        session_service = getattr(self.view, "workflow_session_service", None)
+        active_workflow_id = str(
+            getattr(session_service, "active_workflow_id", "") or ""
+        )
+        if workflow_id != active_workflow_id:
+            return None
+        session = getattr(output_canvas, "_output_session", None)
+        if (
+            isinstance(session, OutputCanvasSession)
+            and session.workflow_id.value == workflow_id
+        ):
+            return session
+        canvas_host = getattr(self.view, "canvas_host", None)
+        is_canvas_visible = getattr(canvas_host, "is_canvas_visible", None)
+        if callable(is_canvas_visible) and not bool(is_canvas_visible("Output")):
+            return None
+        workflows = getattr(session_service, "workflows", None)
+        if not isinstance(workflows, Mapping):
+            return None
+        coordinator = getattr(self.view, "output_canvas_projection_coordinator", None)
+        project_workflow = getattr(coordinator, "project_workflow", None)
+        if not callable(project_workflow):
+            return None
+        project_workflow(workflows, workflow_id)
+        session = getattr(output_canvas, "_output_session", None)
+        return session if isinstance(session, OutputCanvasSession) else None
+
+    def _valid_scene_placeholder(
+        self,
+        scene: OutputSceneIdentity,
+        identity: GenerationVisualIdentity,
+    ) -> bool:
+        """Return whether a scene placeholder belongs to the active scene run."""
+
+        scene_run_service = getattr(self.view, "output_scene_run_service", None)
+        run_for_id = getattr(scene_run_service, "run_for_id", None)
+        if not callable(run_for_id):
+            return False
+        run = run_for_id(scene.run_id)
+        if run is None or getattr(run, "workflow_id", None) != identity.workflow_id:
+            return False
+        scene_entry = getattr(run, "scene_for_key", lambda _scene_key: None)(scene.key)
+        if scene_entry is None:
+            return False
+        return getattr(scene_entry, "status", "") in {
+            "pending",
+            "dispatching",
+            "comfy_pending",
+            "running",
+        }
+
+
+__all__ = ["WorkspacePreviewActions"]

--- a/tests/application/generation/generation_service/test_asset_staging.py
+++ b/tests/application/generation/generation_service/test_asset_staging.py
@@ -104,7 +104,7 @@ def test_run_single_generation_queues_staged_payload_when_staging_is_configured(
     assert preview_method == "latent2rgb"
     assert sugar_script == 'use "cube" as A'
     assert visual_context is not None
-    assert visual_context.sources["1"]["sourceKey"] == "wf-1:1"
+    assert visual_context.sources["1"]["sourceKey"] == "node:1"
 
 
 def test_run_single_generation_queues_selected_image_not_cube_default() -> None:

--- a/tests/application/generation/generation_service/test_execution_dispatch.py
+++ b/tests/application/generation/generation_service/test_execution_dispatch.py
@@ -103,7 +103,7 @@ def test_run_single_generation_happy_path_queues_and_starts_listener() -> None:
     assert visual_context is not None
     assert visual_context.workflow_id == "wf-1"
     assert visual_context.client_id == run_client_id
-    assert visual_context.sources["N1"]["sourceKey"] == "wf-1:N1"
+    assert visual_context.sources["N1"]["sourceKey"] == "node:N1"
     assert len(fake_gateway.listener_requests) == 1
     listener_request = fake_gateway.listener_requests[0]
     assert listener_request.workflow_id == "wf-1"
@@ -119,6 +119,9 @@ def test_run_single_generation_happy_path_queues_and_starts_listener() -> None:
     assert getattr(recorder.run_started[0], "prompt_id") == "pid-1"
     assert getattr(recorder.run_started[0], "output_session_id") == (
         listener_request.generation_run_id
+    )
+    assert getattr(recorder.run_started[0], "preview_source_keys") == frozenset(
+        {"node:N1"}
     )
     assert workflow_export_service.calls[0]["output_dir"] == (
         Path.cwd() / "user" / "projects"

--- a/tests/application/generation/test_visual_run_context_builder.py
+++ b/tests/application/generation/test_visual_run_context_builder.py
@@ -1,0 +1,76 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify generation visual routing uses durable cube source identities."""
+
+from __future__ import annotations
+
+from substitute.application.generation.visual_run_context_builder import (
+    VisualRunContextBuilder,
+)
+from substitute.domain.common import WorkflowId
+
+
+def test_cube_visual_source_key_survives_compiled_node_id_changes() -> None:
+    """Use the cube alias for preview and final routing across recompilations."""
+
+    builder = VisualRunContextBuilder()
+    first = builder.build(
+        workflow_payload=_cube_payload(sampler_id="11", output_id="12"),
+        workflow_id=WorkflowId("workflow-old"),
+        generation_run_id="run-old",
+        client_id="client-old",
+        scene_run_id=None,
+        scene_key=None,
+        scene_title=None,
+        scene_order=None,
+        scene_count=None,
+    )
+    second = builder.build(
+        workflow_payload=_cube_payload(sampler_id="31", output_id="32"),
+        workflow_id=WorkflowId("workflow-new"),
+        generation_run_id="run-new",
+        client_id="client-new",
+        scene_run_id=None,
+        scene_key=None,
+        scene_title=None,
+        scene_order=None,
+        scene_count=None,
+    )
+
+    assert {source["sourceKey"] for source in first.sources.values()} == {
+        "cube:Text to Image"
+    }
+    assert {source["sourceKey"] for source in second.sources.values()} == {
+        "cube:Text to Image"
+    }
+
+
+def _cube_payload(*, sampler_id: str, output_id: str) -> dict[str, object]:
+    """Return one compiled cube whose executable ids may change per run."""
+
+    return {
+        sampler_id: {
+            "class_type": "KSampler",
+            "inputs": {},
+            "_meta": {"title": "Text to Image.KSampler"},
+        },
+        output_id: {
+            "class_type": "SugarCubes.CubeOutput",
+            "inputs": {"images": [sampler_id, 0]},
+            "_meta": {"title": "Text to Image.Output"},
+        },
+    }

--- a/tests/application/workflows/output_canvas_projection/test_source_grouping.py
+++ b/tests/application/workflows/output_canvas_projection/test_source_grouping.py
@@ -156,6 +156,90 @@ def test_projection_keeps_duplicate_labels_separate_by_source_key() -> None:
     assert [source.label for source in projection.sources] == ["Output", "Output"]
 
 
+def test_projection_merges_run_scoped_keys_for_the_same_output_node() -> None:
+    """Restored finals and a new run must not duplicate the four cube tabs."""
+
+    workflow = WorkflowState()
+    ids = [uuid4() for _ in range(6)]
+    workflow.output_image_uuids = ids
+    metadata = {
+        ids[0]: build_meta(
+            "Text to Image",
+            source_key="workflow-old:8",
+            node_id="8",
+            list_index=0,
+        ),
+        ids[1]: build_meta(
+            "Diffusion Upscale",
+            source_key="workflow-old:17",
+            node_id="17",
+            list_index=0,
+        ),
+        ids[2]: build_meta(
+            "Text to Image",
+            source_key="workflow-new:108",
+            node_id="108",
+            list_index=0,
+        ),
+        ids[3]: build_meta(
+            "Diffusion Upscale",
+            source_key="workflow-new:117",
+            node_id="117",
+            list_index=0,
+        ),
+        ids[4]: build_meta(
+            "Automask Detailer",
+            source_key="workflow-new:29",
+            node_id="29",
+            list_index=0,
+        ),
+        ids[5]: build_meta(
+            "Automask Detailer 2",
+            source_key="workflow-new:36",
+            node_id="36",
+            list_index=0,
+        ),
+    }
+
+    projection = build_output_canvas_projection(workflow, metadata)
+
+    assert [source.source_key for source in projection.sources] == [
+        "cube:Text to Image",
+        "cube:Diffusion Upscale",
+        "cube:Automask Detailer",
+        "cube:Automask Detailer 2",
+    ]
+    assert [source.label for source in projection.sources] == [
+        "Text to Image",
+        "Diffusion Upscale",
+        "Automask Detailer",
+        "Automask Detailer 2",
+    ]
+
+
+def test_projection_preserves_explicit_source_keys_unrelated_to_node_identity() -> None:
+    """Authored source keys must remain distinct when node metadata is incidental."""
+
+    workflow = WorkflowState()
+    first_id = uuid4()
+    second_id = uuid4()
+    workflow.output_image_uuids = [first_id, second_id]
+
+    projection = build_output_canvas_projection(
+        workflow,
+        {
+            first_id: build_meta(
+                "Output", source_key="alpha", node_id="7", list_index=0
+            ),
+            second_id: build_meta(
+                "Output", source_key="beta", node_id="7", list_index=0
+            ),
+        },
+    )
+
+    assert [source.source_key for source in projection.sources] == ["alpha", "beta"]
+
+
 def test_projection_allows_ragged_source_groups() -> None:
     """Sources with fewer set images should remain selectable."""
 

--- a/tests/application/workflows/output_preview_lifecycle/test_projection_overlay.py
+++ b/tests/application/workflows/output_preview_lifecycle/test_projection_overlay.py
@@ -1,0 +1,186 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Characterize transient preview placeholders in Output navigation projections."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from substitute.application.workflows.output_canvas_projection import (
+    OutputCanvasImageItem,
+    OutputCanvasSourceGroup,
+)
+from substitute.application.workflows.output_preview_projection import (
+    overlay_preview_sources,
+)
+from substitute.application.workflows.output_preview_registry import (
+    OutputPreviewLane,
+    OutputPreviewLaneKey,
+    OutputPreviewLanePlacement,
+)
+from substitute.domain.workflow import CanvasSessionRevision, ImageMeta
+
+
+def test_preview_only_cube_creates_source_tab_placeholder() -> None:
+    """Append a preview-only cube after existing finalized cube sources."""
+
+    text_id = uuid4()
+    preview_id = uuid4()
+    sources = overlay_preview_sources(
+        (_source("text", "Text to Image", {1: text_id}),),
+        (_preview("upscale", "Diffusion Upscale", preview_id),),
+        scene_key=None,
+    )
+
+    assert tuple(source.source_key for source in sources) == ("text", "upscale")
+    assert sources[1].label == "Diffusion Upscale"
+    assert sources[1].images_by_set[1].image_id == preview_id
+
+
+def test_preview_replaces_only_first_batch_slot_and_keeps_other_finals() -> None:
+    """Overlay the live frame on set one while retaining later finalized sets."""
+
+    final_ids = {1: uuid4(), 2: uuid4(), 3: uuid4()}
+    preview_id = uuid4()
+    sources = overlay_preview_sources(
+        (_source("detail", "Detailer", final_ids),),
+        (_preview("detail", "Detailer", preview_id),),
+        scene_key=None,
+    )
+
+    images = sources[0].images_by_set
+    assert images[1].image_id == preview_id
+    assert images[2].image_id == final_ids[2]
+    assert images[3].image_id == final_ids[3]
+
+
+def test_scene_preview_placeholder_is_scoped_to_its_scene() -> None:
+    """Keep independent scene previews from crossing source projections."""
+
+    first_preview_id = uuid4()
+    second_preview_id = uuid4()
+    lanes = (
+        _preview("upscale", "Upscale", first_preview_id, scene_key="first"),
+        _preview("upscale", "Upscale", second_preview_id, scene_key="second"),
+    )
+
+    first_sources = overlay_preview_sources((), lanes, scene_key="first")
+    second_sources = overlay_preview_sources((), lanes, scene_key="second")
+
+    assert first_sources[0].images_by_set[1].image_id == first_preview_id
+    assert second_sources[0].images_by_set[1].image_id == second_preview_id
+
+
+def test_source_lane_takes_precedence_over_duplicate_scene_lane() -> None:
+    """Use the source-view identity when one frame owns both preview placements."""
+
+    scene_preview_id = uuid4()
+    source_preview_id = uuid4()
+    lanes = (
+        _preview(
+            "detail",
+            "Detailer",
+            scene_preview_id,
+            scene_key="portrait",
+            placement=OutputPreviewLanePlacement.SCENE,
+        ),
+        _preview(
+            "detail",
+            "Detailer",
+            source_preview_id,
+            scene_key="portrait",
+            placement=OutputPreviewLanePlacement.SOURCE,
+        ),
+    )
+
+    sources = overlay_preview_sources((), lanes, scene_key="portrait")
+
+    assert sources[0].images_by_set[1].image_id == source_preview_id
+
+
+def _source(
+    source_key: str,
+    label: str,
+    image_ids: dict[int, UUID],
+) -> OutputCanvasSourceGroup:
+    """Build one finalized source group."""
+
+    return OutputCanvasSourceGroup(
+        source_key,
+        label,
+        {
+            set_index: OutputCanvasImageItem(
+                image_id=image_id,
+                image_meta=_meta(source_key, label, set_index),
+                set_index=set_index,
+            )
+            for set_index, image_id in image_ids.items()
+        },
+    )
+
+
+def _preview(
+    source_key: str,
+    label: str,
+    preview_id: UUID,
+    *,
+    scene_key: str | None = None,
+    placement: OutputPreviewLanePlacement = OutputPreviewLanePlacement.SOURCE,
+) -> OutputPreviewLane:
+    """Build one accepted transient lane."""
+
+    key = (
+        OutputPreviewLaneKey.scene(
+            workflow_id="workflow",
+            generation_run_id="run",
+            prompt_id="prompt",
+            source_key=source_key,
+            scene_run_id="scene-run",
+            scene_key=scene_key or "scene",
+        )
+        if placement is OutputPreviewLanePlacement.SCENE
+        else OutputPreviewLaneKey.source(
+            workflow_id="workflow",
+            generation_run_id="run",
+            prompt_id="prompt",
+            source_key=source_key,
+            scene_run_id="scene-run" if scene_key else None,
+            scene_key=scene_key,
+        )
+    )
+    return OutputPreviewLane(
+        key=key,
+        preview_id=preview_id,
+        image=object(),
+        source_label=label,
+        client_id="client",
+        session_revision=CanvasSessionRevision(1),
+    )
+
+
+def _meta(source_key: str, label: str, set_index: int) -> ImageMeta:
+    """Build minimal final metadata for an Output source slot."""
+
+    return ImageMeta(
+        workflow_name="workflow",
+        cube_name=label,
+        image_number=set_index,
+        suffix="",
+        path="",
+        source_key=source_key,
+        source_label=label,
+    )

--- a/tests/application/workflows/output_preview_lifecycle/test_registry_acceptance.py
+++ b/tests/application/workflows/output_preview_lifecycle/test_registry_acceptance.py
@@ -168,6 +168,60 @@ def test_registry_rejects_stale_prompt_or_client_identity() -> None:
     assert registry.images_by_id() == {}
 
 
+def test_registry_accepts_expected_source_before_first_final_output() -> None:
+    """An active run may preview an expected source before session projection exists."""
+
+    registry = OutputPreviewRegistry(_uuid_factory=uuid_sequence())
+    session = build_registry_session(source_keys=())
+    authorization = VisualAuthorizationService()
+    authorization.register_run(
+        workflow_id="wf",
+        generation_run_id="run",
+        prompt_id="prompt",
+        client_id="client",
+        preview_source_keys=frozenset({"wf:save"}),
+    )
+
+    result = registry.accept_preview(
+        build_preview_event(source_key="wf:save"),
+        session=session,
+        active_workflow_id="wf",
+        authorize_preview=authorization.authorize_preview,
+        is_valid_source_placeholder=authorization.authorize_preview_source,
+    )
+
+    assert result.accepted is True
+    assert result.lanes[0].key.source_key == "wf:save"
+
+
+def test_registry_rejects_unexpected_source_before_first_final_output() -> None:
+    """A backend source absent from run metadata must not create a preview lane."""
+
+    registry = OutputPreviewRegistry()
+    session = build_registry_session(source_keys=())
+    authorization = VisualAuthorizationService()
+    authorization.register_run(
+        workflow_id="wf",
+        generation_run_id="run",
+        prompt_id="prompt",
+        client_id="client",
+        preview_source_keys=frozenset({"wf:save"}),
+    )
+
+    result = registry.accept_preview(
+        build_preview_event(source_key="wf:other"),
+        session=session,
+        active_workflow_id="wf",
+        authorize_preview=authorization.authorize_preview,
+        is_valid_source_placeholder=authorization.authorize_preview_source,
+    )
+
+    assert (
+        result.rejection_reason is OutputPreviewRejectionReason.SOURCE_OUTSIDE_SESSION
+    )
+    assert registry.images_by_id() == {}
+
+
 def test_registry_retires_old_session_previews_without_accepting_route_mutation() -> (
     None
 ):

--- a/tests/ci_test_policy.py
+++ b/tests/ci_test_policy.py
@@ -270,6 +270,7 @@ ISOLATED_TEST_MODULES = frozenset(
         "tests/presentation/workflows/cube_stack/test_scroll_and_indicator.py",
         # These real-shell Output contracts can abort after prior native Qt work
         # in one xdist process, while concurrent fresh processes are stable.
+        "tests/presentation/canvas/output/real_shell/test_hierarchy_navigation.py",
         "tests/presentation/canvas/output/real_shell/test_hierarchy_persistence.py",
         "tests/presentation/canvas/output/real_shell/test_workflow_lifecycle.py",
         # This floating Output rehosting contract can stop receiving layout

--- a/tests/infrastructure/comfy/listener/run_contract/test_execution_timing.py
+++ b/tests/infrastructure/comfy/listener/run_contract/test_execution_timing.py
@@ -106,7 +106,7 @@ def test_run_emits_prompt_and_cube_timing_before_completion(
     assert [
         (item.cube_alias, item.source_key, item.duration_ms)
         for item in timing[0].cube_timings
-    ] == [("CubeA", "wf-1:3", 2500.0)]
+    ] == [("CubeA", "cube:CubeA", 2500.0)]
 
 
 def test_run_excludes_cached_nodes_from_cube_timing(

--- a/tests/infrastructure/comfy/listener/test_output_pipeline.py
+++ b/tests/infrastructure/comfy/listener/test_output_pipeline.py
@@ -108,7 +108,7 @@ def test_listener_output_pipeline_builds_source_resolver_for_cube_outputs() -> N
 
     assert pipeline.cube_output_node_ids == {"2"}
     assert source_identity.node_id == "2"
-    assert source_identity.source_key == "wf-1:2"
+    assert source_identity.source_key == "cube:CubeA"
     assert source_identity.cube_alias == "CubeA"
 
 

--- a/tests/infrastructure/comfy/listener/test_output_source_resolver.py
+++ b/tests/infrastructure/comfy/listener/test_output_source_resolver.py
@@ -102,7 +102,7 @@ def test_ambiguous_output_source_mapping_warns_once() -> None:
     second = resolver.resolve("0")
 
     assert first == second
-    assert first.source_key == "workflow-1:0"
+    assert first.source_key == "cube:Cube"
     assert [diagnostic.level for diagnostic in diagnostics] == ["warning", "debug"]
     assert all(
         diagnostic.message

--- a/tests/infrastructure/comfy/listener/test_runtime_composition.py
+++ b/tests/infrastructure/comfy/listener/test_runtime_composition.py
@@ -133,7 +133,7 @@ def test_listener_runtime_composition_builds_default_connection_context() -> Non
     assert runtime.progress_context.client_id == "client-1"
     assert runtime.cube_output_node_ids == {"2"}
     assert source_identity.node_id == "2"
-    assert source_identity.source_key == "wf-1:2"
+    assert source_identity.source_key == "cube:CubeA"
     assert source_identity.cube_alias == "CubeA"
 
 

--- a/tests/infrastructure/comfy/output_images/test_source_identity.py
+++ b/tests/infrastructure/comfy/output_images/test_source_identity.py
@@ -159,7 +159,7 @@ def test_resolve_output_source_identity_reports_ambiguous_mapping_once() -> None
         ambiguous_warning_keys=warning_keys,
     )
 
-    assert first.source_identity.source_key == "wf-1:shared"
+    assert first.source_identity.source_key == "cube:Shared"
     assert first.source_identity.source_label == "Shared"
     assert first.diagnostic is not None
     assert first.diagnostic.level == "warning"
@@ -183,7 +183,7 @@ def test_resolve_output_source_identity_reports_missing_mapping() -> None:
         ambiguous_warning_keys=set(),
     )
 
-    assert result.source_identity.source_key == "wf-1:lonely"
+    assert result.source_identity.source_key == "cube:Lonely"
     assert result.source_identity.source_label == "Lonely"
     assert result.diagnostic is not None
     assert result.diagnostic.level == "warning"
@@ -210,7 +210,6 @@ def test_output_cube_numbers_match_alias_body_and_node_id() -> None:
     numbers = output_cube_numbers_by_alias(workflow_payload)
     identity = output_source_identity_for_node(
         "output-1",
-        workflow_id="wf-1",
         workflow_payload=workflow_payload,
     )
 

--- a/tests/presentation/canvas/output/document/support.py
+++ b/tests/presentation/canvas/output/document/support.py
@@ -147,6 +147,18 @@ def _projection(
     )
 
 
+def _empty_projection() -> OutputCanvasProjection:
+    """Build an Output projection before the run has produced a final image."""
+
+    return OutputCanvasProjection(
+        sources=(),
+        active_source_key=None,
+        active_set_index=1,
+        active_uuid=None,
+        set_count=0,
+    )
+
+
 def _linked_projection(
     first_id: UUID,
     second_id: UUID,
@@ -236,8 +248,17 @@ def _source_preview_lane(
     )
 
 
-def _live_preview_event(image: QImage) -> LivePreviewEvent:
-    """Build one strict source preview emitted by the Comfy feedback path."""
+def _live_preview_event(
+    image: QImage,
+    *,
+    source_key: str = "source",
+    scene_run_id: str | None = None,
+    scene_key: str | None = None,
+    scene_title: str | None = None,
+    scene_order: int | None = None,
+    scene_count: int | None = None,
+) -> LivePreviewEvent:
+    """Build one strict preview emitted by the Comfy feedback path."""
 
     event = LivePreviewEvent.from_update(
         PreviewImageUpdate(
@@ -247,8 +268,13 @@ def _live_preview_event(image: QImage) -> LivePreviewEvent:
             prompt_id="prompt",
             client_id="client",
             node_id="preview-node",
-            source_key="source",
+            source_key=source_key,
             source_label="Source",
+            scene_run_id=scene_run_id,
+            scene_key=scene_key,
+            scene_title=scene_title,
+            scene_order=scene_order,
+            scene_count=scene_count,
         )
     )
     assert event is not None

--- a/tests/presentation/canvas/output/document/test_document_state.py
+++ b/tests/presentation/canvas/output/document/test_document_state.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from uuid import uuid4
+from uuid import UUID, uuid4
 from PySide6.QtGui import (
     QColor,
 )
@@ -29,8 +29,10 @@ from substitute.application.workflows.output_detail_inspection import (
     OutputDetailInspectionGroup,
 )
 from substitute.application.workflows.output_preview_registry import (
-    OutputPreviewAcceptance,
     OutputPreviewRegistry,
+)
+from substitute.application.workflows.output_preview_results import (
+    OutputPreviewAcceptance,
 )
 from substitute.presentation.canvas.output.output_canvas_view import OutputCanvas
 from substitute.presentation.canvas.output.output_document import OutputCanvasDocument
@@ -41,6 +43,7 @@ from .rendering_support import _wait_for_rendered_color
 from .support import (
     _image,
     _app,
+    _empty_projection,
     _projection,
     _session,
     _source_preview_lane,
@@ -294,6 +297,200 @@ def test_comfy_preview_event_reaches_the_visible_output_document(
         replacement_target = canvas.workspace.canvasFor(replacement_target_id)
         assert replacement_target is not None
         assert _wait_for_rendered_color(app, replacement_target, QColor("blue"))
+    finally:
+        canvas.close()
+        destroy_qt_object(canvas)
+
+
+def test_first_run_batch_preview_frames_replace_same_visible_lane(
+    execution_runtime: ExecutionRuntime,
+) -> None:
+    """Display and replace preview frames before the first final output exists."""
+
+    app = _app()
+    boundary = create_canvas_session_boundary()
+    registry = OutputPreviewRegistry()
+    canvas = OutputCanvas(
+        execution_runtime=execution_runtime,
+        preview_registry=registry,
+        route_session_boundary=boundary,
+    )
+    try:
+        canvas.resize(640, 480)
+        canvas.show()
+        session = _session(boundary, _empty_projection())
+        canvas.bind_projection_session(session)
+
+        first = registry.accept_preview(
+            _live_preview_event(_image("green")),
+            session=session,
+            active_workflow_id="workflow",
+            authorize_preview=lambda _identity: True,
+            is_valid_source_placeholder=lambda _identity: True,
+        )
+        assert first.accepted
+        canvas.apply_preview_acceptance(first)
+        preview_id = first.lanes[0].preview_id
+        assert tuple(canvas.tabbar.items) == ("source",)
+        assert canvas.active_source_key == "source"
+        target_id = canvas.document.composition_id_for(preview_id)
+        assert target_id is not None
+        target = canvas.workspace.canvasFor(target_id)
+        assert target is not None
+        assert _wait_for_rendered_color(app, target, QColor("green"))
+
+        replacement = registry.accept_preview(
+            _live_preview_event(_image("blue")),
+            session=session,
+            active_workflow_id="workflow",
+            authorize_preview=lambda _identity: True,
+            is_valid_source_placeholder=lambda _identity: True,
+        )
+        assert replacement.accepted
+        assert replacement.lanes[0].preview_id == preview_id
+        canvas.apply_preview_acceptance(replacement)
+        replacement_target_id = canvas.document.composition_id_for(preview_id)
+        assert replacement_target_id is not None
+        replacement_target = canvas.workspace.canvasFor(replacement_target_id)
+        assert replacement_target is not None
+        assert _wait_for_rendered_color(app, replacement_target, QColor("blue"))
+    finally:
+        canvas.close()
+        destroy_qt_object(canvas)
+
+
+def test_streaming_preview_tab_does_not_steal_focus_after_source_navigation(
+    execution_runtime: ExecutionRuntime,
+) -> None:
+    """Keep later frames behind their placeholder tab after manual navigation."""
+
+    app = _app()
+    final_id = uuid4()
+    boundary = create_canvas_session_boundary()
+    registry = OutputPreviewRegistry()
+    canvas = OutputCanvas(
+        execution_runtime=execution_runtime,
+        preview_registry=registry,
+        route_session_boundary=boundary,
+    )
+    try:
+        canvas.resize(640, 480)
+        canvas.show()
+        assert canvas.document.admit_image(final_id, _image("red"))
+        session = _session(boundary, _projection(final_id, uuid4()))
+        canvas.bind_projection_session(session)
+
+        first = registry.accept_preview(
+            _live_preview_event(_image("green"), source_key="upscale"),
+            session=session,
+            active_workflow_id="workflow",
+            authorize_preview=lambda _identity: True,
+            is_valid_source_placeholder=lambda _identity: True,
+        )
+        assert first.accepted
+        canvas.apply_preview_acceptance(first)
+        preview_id = first.lanes[0].preview_id
+        assert tuple(canvas.tabbar.items) == ("source", "upscale")
+        assert canvas.active_source_key == "upscale"
+
+        selected_finals: list[str] = []
+        canvas.activeOutputChanged.connect(selected_finals.append)
+        canvas.tabbar.setCurrentItem("source")
+        app.processEvents()
+        assert canvas.active_source_key == "source"
+        assert selected_finals == [str(final_id)]
+
+        replacement = registry.accept_preview(
+            _live_preview_event(_image("blue"), source_key="upscale"),
+            session=session,
+            active_workflow_id="workflow",
+            authorize_preview=lambda _identity: True,
+            is_valid_source_placeholder=lambda _identity: True,
+        )
+        assert replacement.accepted
+        assert replacement.created_preview_ids == ()
+        canvas.apply_preview_acceptance(replacement)
+        assert canvas.active_source_key == "source"
+        assert selected_finals == [str(final_id)]
+
+        canvas.tabbar.setCurrentItem("upscale")
+        app.processEvents()
+        assert canvas.active_source_key == "upscale"
+        preview_composition = canvas.document.composition_id_for(preview_id)
+        assert preview_composition is not None
+        assert canvas.workspace.session.presentation.target_ids == (
+            preview_composition,
+        )
+    finally:
+        canvas.close()
+        destroy_qt_object(canvas)
+
+
+def test_scene_previews_form_live_overview_before_any_final_output(
+    execution_runtime: ExecutionRuntime,
+) -> None:
+    """Keep running scene previews isolated and visible in a live overview grid."""
+
+    _app()
+    boundary = create_canvas_session_boundary()
+    registry = OutputPreviewRegistry()
+    canvas = OutputCanvas(
+        execution_runtime=execution_runtime,
+        preview_registry=registry,
+        route_session_boundary=boundary,
+    )
+    try:
+        canvas.resize(640, 480)
+        canvas.show()
+        session = _session(boundary, _empty_projection())
+        canvas.bind_projection_session(session)
+
+        preview_ids: list[UUID] = []
+        for order, (scene_key, color) in enumerate(
+            (("scene-a", "green"), ("scene-b", "blue"))
+        ):
+            acceptance = registry.accept_preview(
+                _live_preview_event(
+                    _image(color),
+                    scene_run_id="scene-run",
+                    scene_key=scene_key,
+                    scene_title=scene_key,
+                    scene_order=order,
+                    scene_count=2,
+                ),
+                session=session,
+                active_workflow_id="workflow",
+                authorize_preview=lambda _identity: True,
+                is_valid_source_placeholder=lambda _identity: True,
+                is_valid_scene_placeholder=lambda _scene, _identity: True,
+            )
+            assert acceptance.accepted
+            preview_ids.extend(
+                lane.preview_id
+                for lane in acceptance.lanes
+                if lane.key.placement.value == "scene"
+            )
+            canvas.apply_preview_acceptance(acceptance)
+
+        assert canvas.active_scene_overview is True
+        assert canvas.scene_count == 2
+        target_ids = canvas.workspace.session.presentation.target_ids
+        assert {
+            canvas.document.composition_id_for(preview_id) for preview_id in preview_ids
+        } <= set(target_ids)
+
+        canvas._document_navigation._select_scene("scene-a")
+        assert canvas.active_scene_overview is False
+        assert canvas.active_scene_key == "scene-a"
+        assert tuple(canvas.tabbar.items) == ("source",)
+        source_preview_id = next(
+            lane.preview_id
+            for lane in registry.lanes_for_session(session)
+            if lane.key.placement.value == "source" and lane.key.scene_key == "scene-a"
+        )
+        source_composition = canvas.document.composition_id_for(source_preview_id)
+        assert source_composition is not None
+        assert canvas.workspace.session.presentation.target_ids == (source_composition,)
     finally:
         canvas.close()
         destroy_qt_object(canvas)

--- a/tests/presentation/canvas/output/document/test_preview_tab_lifecycle.py
+++ b/tests/presentation/canvas/output/document/test_preview_tab_lifecycle.py
@@ -1,0 +1,226 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify real Output source tabs across preview and final lifecycle changes."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from substitute.application.workflows.canvas_route_projector_port import (
+    create_canvas_session_boundary,
+)
+from substitute.application.workflows.output_canvas_projection import (
+    OutputCanvasImageItem,
+    OutputCanvasProjection,
+    OutputCanvasSourceGroup,
+    build_output_canvas_projection,
+)
+from substitute.application.workflows.output_preview_registry import (
+    OutputPreviewRegistry,
+)
+from substitute.application.workflows.output_canvas_state_service import (
+    OutputPreviewCloseIdentity,
+)
+from substitute.domain.workflow import ImageMeta, WorkflowState
+from substitute.presentation.canvas.output.output_canvas_view import OutputCanvas
+from cutecanvas import ExecutionRuntime
+from tests.application.workflows.output_canvas_projection.support import build_meta
+from tests.support.qt.lifecycle import destroy_qt_object
+
+from .support import _app, _image, _live_preview_event, _session
+
+
+def test_real_source_tabs_merge_restored_and_current_run_cube_outputs(
+    execution_runtime: ExecutionRuntime,
+) -> None:
+    """Render four cube tabs from the six finals in the reported duplicate strip."""
+
+    _app()
+    workflow = WorkflowState()
+    image_ids = tuple(uuid4() for _index in range(6))
+    workflow.output_image_uuids = list(image_ids)
+    metadata = _duplicate_strip_metadata(image_ids)
+    projection = build_output_canvas_projection(workflow, metadata)
+    boundary = create_canvas_session_boundary()
+    canvas = OutputCanvas(
+        execution_runtime=execution_runtime,
+        preview_registry=OutputPreviewRegistry(),
+        route_session_boundary=boundary,
+    )
+    try:
+        for image_id in image_ids:
+            assert canvas.document.admit_image(image_id, _image("red"))
+        canvas.bind_projection_session(_session(boundary, projection))
+
+        assert tuple(canvas.tabbar.items) == (
+            "cube:Text to Image",
+            "cube:Diffusion Upscale",
+            "cube:Automask Detailer",
+            "cube:Automask Detailer 2",
+        )
+        assert tuple(item.text() for item in canvas.tabbar.items.values()) == (
+            "Text to Image",
+            "Diffusion Upscale",
+            "Automask Detailer",
+            "Automask Detailer 2",
+        )
+    finally:
+        canvas.close()
+        destroy_qt_object(canvas)
+
+
+def test_matching_final_replaces_preview_without_adding_a_second_tab(
+    execution_runtime: ExecutionRuntime,
+) -> None:
+    """Retire a source placeholder when its matching set-one final arrives."""
+
+    _app()
+    boundary = create_canvas_session_boundary()
+    registry = OutputPreviewRegistry()
+    canvas = OutputCanvas(
+        execution_runtime=execution_runtime,
+        preview_registry=registry,
+        route_session_boundary=boundary,
+    )
+    source_key = "cube:Diffusion Upscale"
+    try:
+        empty_session = _session(
+            boundary,
+            OutputCanvasProjection(
+                sources=(),
+                active_source_key=None,
+                active_set_index=1,
+                active_uuid=None,
+                set_count=0,
+            ),
+        )
+        canvas.bind_projection_session(empty_session)
+        acceptance = registry.accept_preview(
+            _live_preview_event(_image("green"), source_key=source_key),
+            session=empty_session,
+            active_workflow_id="workflow",
+            authorize_preview=lambda _identity: True,
+            is_valid_source_placeholder=lambda _identity: True,
+        )
+        assert acceptance.accepted
+        canvas.apply_preview_acceptance(acceptance)
+        preview_id = acceptance.lanes[0].preview_id
+        assert tuple(canvas.tabbar.items) == (source_key,)
+
+        final_id = uuid4()
+        final_meta = ImageMeta(
+            workflow_name="workflow",
+            cube_name="Diffusion Upscale",
+            image_number=1,
+            suffix="",
+            path="E:/outputs/final.png",
+            source_key=source_key,
+            source_label="Diffusion Upscale",
+            generation_run_id="run",
+            prompt_id="prompt",
+            client_id="client",
+            node_id="preview-node",
+            list_index=0,
+        )
+        assert canvas.document.admit_image(final_id, _image("blue"))
+        canvas.close_final_output_preview_lane(
+            OutputPreviewCloseIdentity(
+                workflow_id="workflow",
+                image_id=final_id,
+                source_key=source_key,
+                source_label="Diffusion Upscale",
+                generation_run_id="run",
+                prompt_id="prompt",
+                client_id="client",
+                node_id="preview-node",
+                list_index=0,
+                scene_run_id=None,
+                scene_key=None,
+                scene_title=None,
+                scene_order=None,
+                scene_count=None,
+            )
+        )
+        final_projection = OutputCanvasProjection(
+            sources=(
+                OutputCanvasSourceGroup(
+                    source_key=source_key,
+                    label="Diffusion Upscale",
+                    images_by_set={
+                        1: OutputCanvasImageItem(
+                            image_id=final_id,
+                            image_meta=final_meta,
+                            set_index=1,
+                        )
+                    },
+                ),
+            ),
+            active_source_key=source_key,
+            active_set_index=1,
+            active_uuid=final_id,
+            set_count=1,
+        )
+        canvas.bind_projection_session(_session(boundary, final_projection))
+
+        assert registry.lane_for_id(preview_id) is None
+        assert canvas.document.composition_id_for(preview_id) is None
+        assert tuple(canvas.tabbar.items) == (source_key,)
+        final_composition = canvas.document.composition_id_for(final_id)
+        assert final_composition is not None
+        assert canvas.workspace.session.presentation.target_ids == (final_composition,)
+    finally:
+        canvas.close()
+        destroy_qt_object(canvas)
+
+
+def _duplicate_strip_metadata(
+    image_ids: tuple[UUID, ...],
+) -> dict[UUID, ImageMeta]:
+    """Build the old/new final identities that produced six visible source tabs."""
+
+    labels = (
+        "Text to Image",
+        "Diffusion Upscale",
+        "Text to Image",
+        "Diffusion Upscale",
+        "Automask Detailer",
+        "Automask Detailer 2",
+    )
+    node_ids = ("8", "17", "28", "31", "34", "36")
+    run_names = (
+        "workflow-old",
+        "workflow-old",
+        "workflow-new",
+        "workflow-new",
+        "workflow-new",
+        "workflow-new",
+    )
+    return {
+        image_id: build_meta(
+            label,
+            source_key=f"{run_name}:{node_id}",
+            node_id=node_id,
+            list_index=0,
+        )
+        for image_id, label, node_id, run_name in zip(
+            image_ids,
+            labels,
+            node_ids,
+            run_names,
+            strict=True,
+        )
+    }

--- a/tests/presentation/shell/canvas_actions/test_preview_lifecycle.py
+++ b/tests/presentation/shell/canvas_actions/test_preview_lifecycle.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 
-from substitute.application.workflows.output_preview_registry import (
+from substitute.application.workflows.output_preview_results import (
     OutputPreviewAcceptance,
 )
 from substitute.domain.workflow import (

--- a/tests/presentation/shell/canvas_actions/test_registration.py
+++ b/tests/presentation/shell/canvas_actions/test_registration.py
@@ -22,7 +22,7 @@ import uuid
 from types import SimpleNamespace
 
 
-from substitute.application.workflows.output_preview_registry import (
+from substitute.application.workflows.output_preview_results import (
     OutputPreviewAcceptance,
 )
 from substitute.application.workflows.output_canvas_state_service import (

--- a/tests/support/real_output_canvas/harness.py
+++ b/tests/support/real_output_canvas/harness.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from pathlib import Path
+from unittest.mock import patch
 from uuid import UUID
 
 from PySide6.QtWidgets import QWidget
@@ -67,7 +68,19 @@ class RealShellOutputCanvasHarness:
         self.app = _ensure_qapp()
         self.output_root = output_root
         self.canvas_io_service = _CanvasIoService()
-        self.shell = _HarnessShell(self.canvas_io_service)
+        with patch.dict(
+            "os.environ",
+            {
+                "SUGAR_SUBSTITUTE_STARTUP_HARNESS": "1",
+                "SUGAR_SUBSTITUTE_STARTUP_HARNESS_DEFER_INPUT_SAM": "1",
+            },
+        ):
+            self.shell = _HarnessShell(self.canvas_io_service)
+        input_canvas = self.shell.canvas_host.canvas_for("Input").canvas
+        if input_canvas.installedFeatures != ("mask",):
+            raise AssertionError(
+                "Output canvas harness must not install network-backed Input features"
+            )
         self._input = MountedWidgetInput(self.app)
         self.workflows: dict[str, WorkflowHandle] = {}
         available = self.app.primaryScreen().availableGeometry()


### PR DESCRIPTION
## Summary
- restore streaming Comfy/SugarCubes previews as navigable output placeholders
- keep preview identity aligned with final cube outputs across cube, scene, and batch projections
- replace preview placeholders with final outputs without changing established canvas tab behavior
- isolate one native real-shell Output module after a demonstrated reused-worker Qt crash; assertions remain unchanged

## Verification
- `python -m ruff format .`
- `python -m ruff check .`
- `python -m mypy --strict substitute tests`
- `python -m tools.check_architecture`
- `python -m tools.check_test_governance`
- `python -m pytest -n auto -q -m "not serial and not isolated"`
- `python -m tools.ci.run_isolated_test_modules --junit-dir=build/test-results/local-isolated` (87 modules)
- `python -m tools.ci.run_serial_test_modules --junit-dir=build/test-results/local-serial`

## Scope
This PR contains no managed Comfy DynamicVRAM launch flag and does not claim to fix the separate automask-detailer OOM hard crash.