### PR TITLE
fix(ui): prevent tooltips from persisting after hover ends

### DIFF
--- a/sugarsubstitute_shared/presentation/_fluent_tooltip_geometry.py
+++ b/sugarsubstitute_shared/presentation/_fluent_tooltip_geometry.py
@@ -1,0 +1,139 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Calculate bounded QFluent tooltip geometry for the presentation owner."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from PySide6.QtCore import QEvent, QObject, QPoint, QRect, QSize
+from PySide6.QtGui import QCursor, QGuiApplication
+
+DEFAULT_CURSOR_OFFSET = QPoint(14, 18)
+_SCREEN_MARGIN = 4
+_MAXIMUM_WIDTH = 420
+_MINIMUM_CONTENT_WIDTH = 120
+
+
+def cursor_tooltip_position(
+    *,
+    cursor_global_pos: QPoint,
+    tooltip_size: QSize,
+    offset: QPoint | None = None,
+    screen_geometry: QRect | None = None,
+) -> QPoint:
+    """Return a cursor-relative tooltip position clamped to the active screen."""
+
+    geometry = screen_geometry or _screen_geometry(cursor_global_pos)
+    desired = cursor_global_pos + (offset or DEFAULT_CURSOR_OFFSET)
+    maximum_x = max(
+        geometry.left(),
+        geometry.right() - tooltip_size.width() - _SCREEN_MARGIN,
+    )
+    maximum_y = max(
+        geometry.top(),
+        geometry.bottom() - tooltip_size.height() - _SCREEN_MARGIN,
+    )
+    return QPoint(
+        min(max(desired.x(), geometry.left()), maximum_x),
+        min(max(desired.y(), geometry.top()), maximum_y),
+    )
+
+
+def configure_tooltip_bounds(tooltip: object) -> None:
+    """Apply bounded wrapping to one QFluent tooltip widget."""
+
+    _set_maximum_width(tooltip, _MAXIMUM_WIDTH)
+    container = getattr(tooltip, "container", None)
+    container_width = _inner_width(
+        _MAXIMUM_WIDTH,
+        _horizontal_margins(_layout(tooltip)),
+    )
+    if container is not None:
+        _set_maximum_width(container, container_width)
+    label = getattr(tooltip, "label", None)
+    if label is None:
+        return
+    label.setWordWrap(True)
+    _set_maximum_width(
+        label,
+        _inner_width(
+            container_width,
+            _horizontal_margins(getattr(tooltip, "containerLayout", None)),
+        ),
+    )
+
+
+def event_global_position(watched: QObject, event: QEvent) -> QPoint:
+    """Resolve the latest global cursor position from Qt event APIs."""
+
+    global_position = getattr(event, "globalPosition", None)
+    if callable(global_position):
+        return cast(QPoint, global_position().toPoint())
+    global_pos = getattr(event, "globalPos", None)
+    if callable(global_pos):
+        return cast(QPoint, global_pos())
+    local_position = getattr(event, "position", None)
+    map_to_global = getattr(watched, "mapToGlobal", None)
+    if callable(local_position) and callable(map_to_global):
+        return cast(QPoint, map_to_global(local_position().toPoint()))
+    return QCursor.pos()
+
+
+def _screen_geometry(cursor_position: QPoint) -> QRect:
+    """Return available geometry for the screen containing the cursor."""
+
+    screen = (
+        QGuiApplication.screenAt(cursor_position) or QGuiApplication.primaryScreen()
+    )
+    return screen.availableGeometry() if screen is not None else QRect(0, 0, 1920, 1080)
+
+
+def _layout(widget: object) -> object | None:
+    """Return a widget layout when exposed."""
+
+    getter = getattr(widget, "layout", None)
+    return getter() if callable(getter) else None
+
+
+def _horizontal_margins(layout: object | None) -> int:
+    """Return left and right layout margins."""
+
+    if layout is None:
+        return 0
+    getter = getattr(layout, "contentsMargins", None)
+    if not callable(getter):
+        return 0
+    margins = getter()
+    return int(margins.left()) + int(margins.right())
+
+
+def _inner_width(width: int, margins: int) -> int:
+    """Return bounded content width after layout margins."""
+
+    return max(_MINIMUM_CONTENT_WIDTH, width - margins)
+
+
+def _set_maximum_width(widget: object, width: int) -> None:
+    """Set a maximum width on a QFluent tooltip component."""
+
+    setter = getattr(widget, "setMaximumWidth", None)
+    if callable(setter):
+        setter(width)
+
+
+__all__ = ["cursor_tooltip_position"]

--- a/sugarsubstitute_shared/presentation/fluent_tooltips.py
+++ b/sugarsubstitute_shared/presentation/fluent_tooltips.py
@@ -26,6 +26,7 @@ from PySide6.QtCore import QEvent, QObject, QPoint, QSize, Qt, QTimer
 from PySide6.QtGui import QCursor
 from PySide6.QtWidgets import QApplication, QWidget
 from qfluentwidgets import ToolTipFilter, ToolTipPosition  # type: ignore[import-untyped]
+from shiboken6 import isValid
 
 from sugarsubstitute_shared.presentation._fluent_tooltip_geometry import (
     DEFAULT_CURSOR_OFFSET,
@@ -149,7 +150,7 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
         if not self.isEnter or not self._canShowToolTip():
             return
         focused_widget = QApplication.focusWidget()
-        if self._tooltip is None and self._canShowToolTip():
+        if self._live_tooltip() is None and self._canShowToolTip():
             self._tooltip = self._createToolTip()
         super().showToolTip()
         if focused_widget is not None:
@@ -160,7 +161,7 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
                     _restore_focus_after_tooltip_show(focused_ref)
                 ),
             )
-        tooltip = self._tooltip
+        tooltip = self._live_tooltip()
         if tooltip is None:
             return
         self._hover_guard_timer.start()
@@ -236,11 +237,14 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
 
         if not self._canShowToolTip():
             return
-        if self._tooltip is None:
+        if self._live_tooltip() is None:
             self._tooltip = self._createToolTip()
         owner = cast(QWidget, self.parent())
+        tooltip = self._live_tooltip()
+        if tooltip is None:
+            return
         configured_duration = owner.toolTipDuration()
-        self._tooltip.setDuration(
+        tooltip.setDuration(
             configured_duration
             if configured_duration > 0
             else _DEFAULT_VISIBLE_DURATION_MS
@@ -259,13 +263,23 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
         """Stop every presentation timer and hide the shared tooltip window."""
 
         self._hover_guard_timer.stop()
+        self._live_tooltip()
         super().hideToolTip()
         self.isEnter = bool(self._hovered_widget_ids)
+
+    def _live_tooltip(self) -> _FluentToolTip | None:
+        """Return the tooltip only while its platform-owned Qt object survives."""
+
+        tooltip = self._tooltip
+        if tooltip is None or isValid(tooltip):
+            return tooltip
+        self._tooltip = None
+        return None
 
     def _tooltip_text_changed(self, text: str, *, changed: bool) -> None:
         """Synchronize visible and pending presentation with owner text changes."""
 
-        tooltip = self._tooltip
+        tooltip = self._live_tooltip()
         if not text:
             self._dismiss_tooltip()
             return

--- a/sugarsubstitute_shared/presentation/fluent_tooltips.py
+++ b/sugarsubstitute_shared/presentation/fluent_tooltips.py
@@ -19,19 +19,24 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Protocol, cast
+from typing import Protocol, TypeGuard, cast
 from weakref import ReferenceType, ref
 
-from PySide6.QtCore import QEvent, QObject, QPoint, QRect, QSize, Qt, QTimer
-from PySide6.QtGui import QCursor, QGuiApplication
+from PySide6.QtCore import QEvent, QObject, QPoint, QSize, Qt, QTimer
+from PySide6.QtGui import QCursor
 from PySide6.QtWidgets import QApplication, QWidget
 from qfluentwidgets import ToolTipFilter, ToolTipPosition  # type: ignore[import-untyped]
 
+from sugarsubstitute_shared.presentation._fluent_tooltip_geometry import (
+    DEFAULT_CURSOR_OFFSET,
+    configure_tooltip_bounds,
+    cursor_tooltip_position,
+    event_global_position,
+)
+
 _FILTER_ATTRIBUTE = "_sugarsubstitute_fluent_tooltip_filter"
-_DEFAULT_CURSOR_OFFSET = QPoint(14, 18)
-_SCREEN_MARGIN = 4
-_MAXIMUM_WIDTH = 420
-_MINIMUM_CONTENT_WIDTH = 120
+_DEFAULT_VISIBLE_DURATION_MS = 10_000
+_HOVER_GUARD_INTERVAL_MS = 100
 
 
 class ToolTipTarget(Protocol):
@@ -56,6 +61,12 @@ class _FluentToolTip(Protocol):
     def move(self, position: QPoint) -> None:
         """Move the tooltip to a global position."""
 
+    def setDuration(self, duration: int) -> None:  # noqa: N802
+        """Set the maximum visible lifetime in milliseconds."""
+
+    def setText(self, text: str) -> None:  # noqa: N802
+        """Replace the displayed tooltip content."""
+
 
 class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
     """Extend QFluent's filter with app-required cursor and dynamic behavior."""
@@ -76,12 +87,19 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
         super().__init__(owner, show_delay_ms, position)
         self._show_delay_ms = show_delay_ms
         self._cursor_anchor = cursor_anchor
-        self._cursor_offset = cursor_offset or _DEFAULT_CURSOR_OFFSET
+        self._cursor_offset = cursor_offset or DEFAULT_CURSOR_OFFSET
         self._show_when_disabled = show_when_disabled
         self._tooltip_provider = tooltip_provider
         self._cursor_global_position = QCursor.pos()
         self._tooltip: _FluentToolTip | None = None
         self._watched_widget_ids: set[int] = set()
+        self._watched_widget_refs: dict[int, ReferenceType[QWidget]] = {
+            id(owner): ref(owner)
+        }
+        self._hovered_widget_ids: set[int] = set()
+        self._hover_guard_timer = QTimer(self)
+        self._hover_guard_timer.setInterval(_HOVER_GUARD_INTERVAL_MS)
+        self._hover_guard_timer.timeout.connect(self._dismiss_if_pointer_outside)
 
     @property
     def show_delay_ms(self) -> int:
@@ -96,7 +114,7 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
         super().setToolTipDelay(delay)
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:  # noqa: N802
-        """Update dynamic content and delegate display ownership to QFluent."""
+        """Own hover state without relying on QFluent's shared boolean flag."""
 
         event_type = event.type()
         if event_type in {
@@ -104,16 +122,31 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
             QEvent.Type.MouseMove,
             QEvent.Type.ToolTip,
         }:
-            self._cursor_global_position = _event_global_position(watched, event)
+            self._cursor_global_position = event_global_position(watched, event)
             self._refresh_dynamic_tooltip(watched, event)
-        if event_type == QEvent.Type.Wheel:
+        if event_type == QEvent.Type.ToolTip:
+            return True
+        if event_type == QEvent.Type.Enter:
+            self._enter_watched_widget(watched)
+        elif event_type in {
+            QEvent.Type.Close,
+            QEvent.Type.Destroy,
+            QEvent.Type.Hide,
+            QEvent.Type.Leave,
+        }:
+            self._leave_watched_widget(watched)
+        elif event_type in {
+            QEvent.Type.MouseButtonPress,
+            QEvent.Type.Wheel,
+            QEvent.Type.WindowDeactivate,
+        }:
             self.hideToolTip()
-        return bool(super().eventFilter(watched, event))
+        return bool(QObject.eventFilter(self, watched, event))
 
     def showToolTip(self) -> None:  # noqa: N802
         """Show QFluent's tooltip and optionally move it beside the cursor."""
 
-        if not self._canShowToolTip():
+        if not self.isEnter or not self._canShowToolTip():
             return
         focused_widget = QApplication.focusWidget()
         if self._tooltip is None and self._canShowToolTip():
@@ -130,7 +163,8 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
         tooltip = self._tooltip
         if tooltip is None:
             return
-        _configure_tooltip_bounds(tooltip)
+        self._hover_guard_timer.start()
+        configure_tooltip_bounds(tooltip)
         tooltip.adjustSize()
         if self._cursor_anchor:
             tooltip.move(
@@ -140,6 +174,12 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
                     offset=self._cursor_offset,
                 )
             )
+
+    def hideToolTip(self) -> None:  # noqa: N802
+        """Dismiss visible and pending presentation and reset hover ownership."""
+
+        self._hovered_widget_ids.clear()
+        self._dismiss_tooltip()
 
     def hide_tooltip(self) -> None:
         """Expose the app's snake-case lifecycle API over QFluent."""
@@ -162,7 +202,7 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
             Qt.WindowType.WindowDoesNotAcceptFocus,
             True,
         )
-        _configure_tooltip_bounds(tooltip)
+        configure_tooltip_bounds(tooltip)
         return tooltip
 
     def _canShowToolTip(self) -> bool:  # noqa: N802
@@ -183,23 +223,128 @@ class FluentToolTipFilter(ToolTipFilter):  # type: ignore[misc]
         owner = cast(QWidget, self.parent())
         set_fluent_tooltip_text(owner, self._tooltip_provider(watched, event) or "")
 
+    def _enter_watched_widget(self, watched: QObject) -> None:
+        """Start or retain presentation when one installed target is entered."""
+
+        watched_id = id(watched)
+        self._hovered_widget_ids.add(watched_id)
+        self.isEnter = True
+        self._schedule_tooltip_show()
+
+    def _schedule_tooltip_show(self) -> None:
+        """Create and schedule tooltip presentation for the current content."""
+
+        if not self._canShowToolTip():
+            return
+        if self._tooltip is None:
+            self._tooltip = self._createToolTip()
+        owner = cast(QWidget, self.parent())
+        configured_duration = owner.toolTipDuration()
+        self._tooltip.setDuration(
+            configured_duration
+            if configured_duration > 0
+            else _DEFAULT_VISIBLE_DURATION_MS
+        )
+        self.timer.start(self._show_delay_ms)
+
+    def _leave_watched_widget(self, watched: QObject) -> None:
+        """Dismiss only after the pointer has left every installed target."""
+
+        self._hovered_widget_ids.discard(id(watched))
+        self.isEnter = bool(self._hovered_widget_ids)
+        if not self.isEnter:
+            self._dismiss_tooltip()
+
+    def _dismiss_tooltip(self) -> None:
+        """Stop every presentation timer and hide the shared tooltip window."""
+
+        self._hover_guard_timer.stop()
+        super().hideToolTip()
+        self.isEnter = bool(self._hovered_widget_ids)
+
+    def _tooltip_text_changed(self, text: str, *, changed: bool) -> None:
+        """Synchronize visible and pending presentation with owner text changes."""
+
+        tooltip = self._tooltip
+        if not text:
+            self._dismiss_tooltip()
+            return
+        if tooltip is not None:
+            tooltip.setText(text)
+            configure_tooltip_bounds(tooltip)
+            tooltip.adjustSize()
+        if changed and self._hovered_widget_ids:
+            self._schedule_tooltip_show()
+
+    def _dismiss_if_pointer_outside(self) -> None:
+        """Recover when a platform transition omits the expected leave event."""
+
+        cursor_position = QCursor.pos()
+        if any(
+            self._widget_contains_global_position(watched_id, cursor_position)
+            for watched_id in tuple(self._hovered_widget_ids)
+        ):
+            return
+        self.hideToolTip()
+
+    def _widget_contains_global_position(
+        self,
+        watched_id: int,
+        global_position: QPoint,
+    ) -> bool:
+        """Return whether one live, visible target contains a global position."""
+
+        watched_ref = self._watched_widget_refs.get(watched_id)
+        watched = watched_ref() if watched_ref is not None else None
+        if watched is None:
+            return False
+        try:
+            return watched.isVisible() and watched.rect().contains(
+                watched.mapFromGlobal(global_position)
+            )
+        except RuntimeError:
+            self._forget_watched_widget(watched_id)
+            return False
+
+    def _remember_watched_widget(self, watched: QWidget) -> None:
+        """Retain a weak target reference for hover validity checks."""
+
+        self._watched_widget_refs[id(watched)] = ref(watched)
+
     def _forget_watched_widget(self, watched_id: int) -> None:
         """Release one destroyed widget identity from idempotent installation state."""
 
         self._watched_widget_ids.discard(watched_id)
+        self._watched_widget_refs.pop(watched_id, None)
+        self._hovered_widget_ids.discard(watched_id)
+        self.isEnter = bool(self._hovered_widget_ids)
+        if not self.isEnter:
+            self._dismiss_tooltip()
 
 
 def set_fluent_tooltip_text(target: ToolTipTarget, text: str) -> None:
     """Set tooltip text and ensure QWidget targets use QFluent presentation."""
 
     if isinstance(target, QWidget):
-        QWidget.setToolTip(target, str(text))
-        if not isinstance(
-            getattr(target, _FILTER_ATTRIBUTE, None), FluentToolTipFilter
-        ):
+        rendered_text = str(text)
+        text_changed = target.toolTip() != rendered_text
+        QWidget.setToolTip(target, rendered_text)
+        existing_filter = getattr(target, _FILTER_ATTRIBUTE, None)
+        if isinstance(existing_filter, FluentToolTipFilter):
+            existing_filter._tooltip_text_changed(
+                rendered_text,
+                changed=text_changed,
+            )
+        elif rendered_text:
             ensure_fluent_tooltip_filter(target)
         return
     target.setToolTip(str(text))
+
+
+def supports_fluent_tooltip(target: object) -> TypeGuard[ToolTipTarget]:
+    """Return whether an object can receive text through the tooltip owner."""
+
+    return callable(getattr(target, "setToolTip", None))
 
 
 def ensure_fluent_tooltip_filter(
@@ -220,7 +365,7 @@ def ensure_fluent_tooltip_filter(
         tooltip_filter.setToolTipDelay(show_delay_ms)
         tooltip_filter.position = position
         tooltip_filter._cursor_anchor = cursor_anchor
-        tooltip_filter._cursor_offset = cursor_offset or _DEFAULT_CURSOR_OFFSET
+        tooltip_filter._cursor_offset = cursor_offset or DEFAULT_CURSOR_OFFSET
         tooltip_filter._show_when_disabled = show_when_disabled
         tooltip_filter._tooltip_provider = tooltip_provider
     else:
@@ -237,6 +382,7 @@ def ensure_fluent_tooltip_filter(
     for watched in watched_widgets or (owner,):
         watched.setMouseTracking(cursor_anchor or tooltip_provider is not None)
         watched_id = id(watched)
+        tooltip_filter._remember_watched_widget(watched)
         if watched_id not in tooltip_filter._watched_widget_ids:
             watched.installEventFilter(tooltip_filter)
             tooltip_filter._watched_widget_ids.add(watched_id)
@@ -263,80 +409,6 @@ def release_fluent_tooltips(root: QWidget) -> None:
         tooltip_filter._tooltip = None
 
 
-def cursor_tooltip_position(
-    *,
-    cursor_global_pos: QPoint,
-    tooltip_size: QSize,
-    offset: QPoint | None = None,
-    screen_geometry: QRect | None = None,
-) -> QPoint:
-    """Return a cursor-relative tooltip position clamped to the active screen."""
-
-    geometry = screen_geometry or _screen_geometry(cursor_global_pos)
-    desired = cursor_global_pos + (offset or _DEFAULT_CURSOR_OFFSET)
-    maximum_x = max(
-        geometry.left(),
-        geometry.right() - tooltip_size.width() - _SCREEN_MARGIN,
-    )
-    maximum_y = max(
-        geometry.top(),
-        geometry.bottom() - tooltip_size.height() - _SCREEN_MARGIN,
-    )
-    return QPoint(
-        min(max(desired.x(), geometry.left()), maximum_x),
-        min(max(desired.y(), geometry.top()), maximum_y),
-    )
-
-
-def _event_global_position(watched: QObject, event: QEvent) -> QPoint:
-    """Resolve the latest global cursor position from Qt event APIs."""
-
-    global_position = getattr(event, "globalPosition", None)
-    if callable(global_position):
-        return cast(QPoint, global_position().toPoint())
-    global_pos = getattr(event, "globalPos", None)
-    if callable(global_pos):
-        return cast(QPoint, global_pos())
-    local_position = getattr(event, "position", None)
-    map_to_global = getattr(watched, "mapToGlobal", None)
-    if callable(local_position) and callable(map_to_global):
-        return cast(QPoint, map_to_global(local_position().toPoint()))
-    return QCursor.pos()
-
-
-def _screen_geometry(cursor_position: QPoint) -> QRect:
-    """Return available geometry for the screen containing the cursor."""
-
-    screen = (
-        QGuiApplication.screenAt(cursor_position) or QGuiApplication.primaryScreen()
-    )
-    return screen.availableGeometry() if screen is not None else QRect(0, 0, 1920, 1080)
-
-
-def _configure_tooltip_bounds(tooltip: object) -> None:
-    """Apply bounded wrapping to one QFluent tooltip widget."""
-
-    _set_maximum_width(tooltip, _MAXIMUM_WIDTH)
-    container = getattr(tooltip, "container", None)
-    container_width = _inner_width(
-        _MAXIMUM_WIDTH,
-        _horizontal_margins(_layout(tooltip)),
-    )
-    if container is not None:
-        _set_maximum_width(container, container_width)
-    label = getattr(tooltip, "label", None)
-    if label is None:
-        return
-    label.setWordWrap(True)
-    _set_maximum_width(
-        label,
-        _inner_width(
-            container_width,
-            _horizontal_margins(getattr(tooltip, "containerLayout", None)),
-        ),
-    )
-
-
 def _restore_focus_after_tooltip_show(
     focused_ref: ReferenceType[QWidget],
 ) -> None:
@@ -353,39 +425,6 @@ def _restore_focus_after_tooltip_show(
         return
 
 
-def _layout(widget: object) -> object | None:
-    """Return a widget layout when exposed."""
-
-    getter = getattr(widget, "layout", None)
-    return getter() if callable(getter) else None
-
-
-def _horizontal_margins(layout: object | None) -> int:
-    """Return left and right layout margins."""
-
-    if layout is None:
-        return 0
-    getter = getattr(layout, "contentsMargins", None)
-    if not callable(getter):
-        return 0
-    margins = getter()
-    return int(margins.left()) + int(margins.right())
-
-
-def _inner_width(width: int, margins: int) -> int:
-    """Return bounded content width after layout margins."""
-
-    return max(_MINIMUM_CONTENT_WIDTH, width - margins)
-
-
-def _set_maximum_width(widget: object, width: int) -> None:
-    """Set a maximum width on a QFluent tooltip component."""
-
-    setter = getattr(widget, "setMaximumWidth", None)
-    if callable(setter):
-        setter(width)
-
-
 __all__ = [
     "FluentToolTipFilter",
     "ToolTipPosition",
@@ -394,4 +433,5 @@ __all__ = [
     "cursor_tooltip_position",
     "ensure_fluent_tooltip_filter",
     "set_fluent_tooltip_text",
+    "supports_fluent_tooltip",
 ]

--- a/sugarsubstitute_shared/presentation/localization/application_text.py
+++ b/sugarsubstitute_shared/presentation/localization/application_text.py
@@ -141,9 +141,10 @@ def set_localized_tooltip(
 
     from sugarsubstitute_shared.presentation.fluent_tooltips import (
         set_fluent_tooltip_text,
+        supports_fluent_tooltip,
     )
 
-    if not callable(getattr(target, "setToolTip", None)):
+    if not supports_fluent_tooltip(target):
         raise TypeError("Localized tooltip targets must expose setToolTip().")
     if not isinstance(target, QObject):
         set_fluent_tooltip_text(

--- a/tests/presentation/generation/queue/test_row.py
+++ b/tests/presentation/generation/queue/test_row.py
@@ -19,8 +19,10 @@
 from __future__ import annotations
 
 import pytest
-from PySide6.QtCore import QObject, QPoint, Qt
+from PySide6.QtCore import QPoint, Qt
 from PySide6.QtTest import QSignalSpy, QTest
+
+from sugarsubstitute_shared.presentation.fluent_tooltips import FluentToolTipFilter
 
 from substitute.presentation.generation.queue_item_row import (
     GenerationQueueItemRow,
@@ -134,9 +136,11 @@ def test_queue_row_routes_body_and_action_tooltips(
         assert row._title_label.toolTip() == ""
         assert row._subtitle_label.toolTip() == ""
         assert row._action_button.toolTip() == action_tooltip
-        assert row._tooltip_filter is not None
-        assert isinstance(row._tooltip_filter, QObject)
+        assert isinstance(row._tooltip_filter, FluentToolTipFilter)
         assert row._tooltip_filter.parent() is row
+        assert row._text_column.findChild(FluentToolTipFilter) is None
+        assert row._title_label.findChild(FluentToolTipFilter) is None
+        assert row._subtitle_label.findChild(FluentToolTipFilter) is None
     finally:
         destroy_qt_object(row)
 

--- a/tests/qualification/prompt_editor/real_shell/observability/test_owner_state.py
+++ b/tests/qualification/prompt_editor/real_shell/observability/test_owner_state.py
@@ -19,9 +19,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-import warnings
 
-from PySide6.QtCore import QCoreApplication, QEvent
+from PySide6.QtCore import QCoreApplication, QEvent, Qt
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication, QWidget
 from qfluentwidgets import ToolTipFilter  # type: ignore[import-untyped]
@@ -77,14 +76,10 @@ def test_real_shell_moves_ambient_hover_to_neutral_target(
     tooltip_filter.showToolTip()
     tooltip = getattr(tooltip_filter, "_tooltip", None)
     assert isinstance(tooltip, QWidget)
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r"Function: 'QApplication\.setActiveWindow.*",
-            category=DeprecationWarning,
-        )
-        QApplication.setActiveWindow(tooltip)
-    assert QApplication.activeWindow() is tooltip
+    assert tooltip.focusPolicy() == Qt.FocusPolicy.NoFocus
+    assert tooltip.testAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+    assert tooltip.windowFlags() & Qt.WindowType.WindowDoesNotAcceptFocus
+    assert QApplication.activeWindow() is not tooltip
 
     all_tooltip_filters = real_shell_scenario.shell.findChildren(ToolTipFilter)
     for pending_filter in all_tooltip_filters:

--- a/tests/shared/fluent_tooltips/test_lifecycle.py
+++ b/tests/shared/fluent_tooltips/test_lifecycle.py
@@ -19,9 +19,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import cast
 
 import pytest
+from PySide6.QtCore import QEvent
 from PySide6.QtWidgets import QApplication, QWidget
+from shiboken6 import delete, isValid
 
 from sugarsubstitute_shared.presentation.fluent_tooltips import (
     FluentToolTipFilter,
@@ -71,3 +74,26 @@ def test_release_fluent_tooltips_invalidates_surviving_filter_window(
 
     assert tooltip.hidden
     assert getattr(tooltip_filter, "_tooltip", None) is None
+
+
+def test_final_owner_event_tolerates_platform_deleted_tooltip(
+    tooltip_control: QWidget,
+) -> None:
+    """Owner teardown must remain safe when Qt deletes its tooltip window first."""
+
+    set_fluent_tooltip_text(tooltip_control, "Tooltip")
+    tooltip_filter = tooltip_control.findChild(FluentToolTipFilter)
+    assert tooltip_filter is not None
+    tooltip_filter.isEnter = True
+    tooltip_filter.show_tooltip()
+    tooltip = cast(QWidget, tooltip_filter._tooltip)
+    delete(tooltip)
+    assert not isValid(tooltip)
+
+    tooltip_filter.eventFilter(
+        tooltip_control,
+        QEvent(QEvent.Type.Hide),
+    )
+
+    assert tooltip_filter._tooltip is None
+    assert tooltip_filter.isEnter is False

--- a/tests/shared/fluent_tooltips/test_persistence.py
+++ b/tests/shared/fluent_tooltips/test_persistence.py
@@ -1,0 +1,306 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Prove QFluent tooltips cannot persist after their hover relationship ends."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from PySide6.QtCore import QEvent, QPoint, QSize
+from PySide6.QtGui import QCursor
+from PySide6.QtWidgets import QApplication, QWidget
+
+from sugarsubstitute_shared.presentation.fluent_tooltips import (
+    FluentToolTipFilter,
+    ensure_fluent_tooltip_filter,
+    set_fluent_tooltip_text,
+)
+from tests.support.qt.lifecycle import destroy_qt_object
+from tests.support.qt.semantic_wait import wait_for_qt_condition
+
+
+class _TooltipProbe:
+    """Record presentation state without relying on a native tooltip window."""
+
+    def __init__(self) -> None:
+        """Initialize hidden content with Qt's automatic duration sentinel."""
+
+        self.duration = -1
+        self.hidden = False
+        self.shown = False
+        self.text = ""
+
+    def setDuration(self, duration: int) -> None:  # noqa: N802
+        """Record the configured maximum visible lifetime."""
+
+        self.duration = duration
+
+    def setText(self, text: str) -> None:  # noqa: N802
+        """Record the current tooltip content."""
+
+        self.text = text
+
+    def adjustPos(self, _owner: QWidget, _position: object) -> None:  # noqa: N802
+        """Accept QFluent's owner-relative positioning pass."""
+
+    def adjustSize(self) -> None:  # noqa: N802
+        """Accept the shared bounded-size pass."""
+
+    def size(self) -> QSize:
+        """Return deterministic geometry for cursor positioning."""
+
+        return QSize(120, 40)
+
+    def move(self, _position: QPoint) -> None:
+        """Accept cursor-relative positioning."""
+
+    def show(self) -> None:
+        """Record visible presentation."""
+
+        self.shown = True
+        self.hidden = False
+
+    def hide(self) -> None:
+        """Record dismissed presentation."""
+
+        self.hidden = True
+        self.shown = False
+
+
+class _GlobalPositionEvent(QEvent):
+    """Expose a deterministic Qt 6 global pointer position."""
+
+    def __init__(self, event_type: QEvent.Type, global_position: QPoint) -> None:
+        """Store the requested type and global position."""
+
+        super().__init__(event_type)
+        self._global_position = global_position
+
+    def globalPosition(self) -> object:  # noqa: N802
+        """Return a QPointF-like object accepted by the tooltip owner."""
+
+        return type(
+            "_PointF",
+            (),
+            {"toPoint": lambda _self: self._global_position},
+        )()
+
+
+def _enter(position: QPoint) -> _GlobalPositionEvent:
+    """Create one deterministic enter event."""
+
+    return _GlobalPositionEvent(QEvent.Type.Enter, position)
+
+
+def _leave(position: QPoint) -> _GlobalPositionEvent:
+    """Create one deterministic leave event."""
+
+    return _GlobalPositionEvent(QEvent.Type.Leave, position)
+
+
+def test_nested_target_transition_keeps_tooltip_until_all_targets_are_left(
+    qt_application_owner: QApplication,
+) -> None:
+    """Parent leave ordering must not dismiss or strand a child hover."""
+
+    _ = qt_application_owner
+    owner = QWidget()
+    watched = QWidget(owner)
+    owner.setToolTip("details")
+    tooltip = _TooltipProbe()
+    tooltip_filter = ensure_fluent_tooltip_filter(
+        owner, owner, watched, show_delay_ms=0
+    )
+    tooltip_filter._tooltip = tooltip
+    try:
+        tooltip_filter.eventFilter(owner, _enter(QPoint(50, 60)))
+        tooltip_filter.show_tooltip()
+        tooltip_filter.eventFilter(watched, _enter(QPoint(51, 61)))
+        tooltip_filter.eventFilter(owner, _leave(QPoint(51, 61)))
+
+        assert tooltip.shown is True
+        assert tooltip_filter.isEnter is True
+
+        tooltip_filter.eventFilter(watched, _leave(QPoint(52, 62)))
+
+        assert tooltip.hidden is True
+        assert tooltip_filter.isEnter is False
+    finally:
+        destroy_qt_object(owner)
+
+
+def test_default_qt_duration_becomes_a_finite_tooltip_lifetime(
+    qt_application_owner: QApplication,
+) -> None:
+    """Qt's automatic duration sentinel must not create an immortal tooltip."""
+
+    _ = qt_application_owner
+    owner = QWidget()
+    owner.setToolTip("details")
+    tooltip = _TooltipProbe()
+    tooltip_filter = ensure_fluent_tooltip_filter(owner, show_delay_ms=0)
+    tooltip_filter._tooltip = tooltip
+    try:
+        tooltip_filter.eventFilter(owner, _enter(QPoint(50, 60)))
+
+        assert owner.toolTipDuration() == -1
+        assert tooltip.duration > 0
+    finally:
+        destroy_qt_object(owner)
+
+
+def test_clearing_tooltip_text_immediately_dismisses_visible_content(
+    qt_application_owner: QApplication,
+) -> None:
+    """Recycled controls must not retain tooltip content from prior state."""
+
+    _ = qt_application_owner
+    owner = QWidget()
+    set_fluent_tooltip_text(owner, "details")
+    tooltip_filter = owner.findChild(FluentToolTipFilter)
+    assert tooltip_filter is not None
+    tooltip = _TooltipProbe()
+    tooltip.shown = True
+    tooltip_filter._tooltip = tooltip
+    try:
+        set_fluent_tooltip_text(owner, "")
+
+        assert owner.toolTip() == ""
+        assert tooltip.hidden is True
+    finally:
+        destroy_qt_object(owner)
+
+
+def test_empty_tooltip_text_does_not_install_inert_presentation(
+    qt_application_owner: QApplication,
+) -> None:
+    """Clearing child content must not create competing tooltip filters."""
+
+    _ = qt_application_owner
+    owner = QWidget()
+    try:
+        set_fluent_tooltip_text(owner, "")
+
+        assert owner.findChild(FluentToolTipFilter) is None
+    finally:
+        destroy_qt_object(owner)
+
+
+def test_dynamic_content_can_resume_during_one_viewport_hover(
+    qt_application_owner: QApplication,
+) -> None:
+    """An empty dynamic region must not discard the surrounding hover session."""
+
+    _ = qt_application_owner
+    owner = QWidget()
+    set_fluent_tooltip_text(owner, "first item")
+    tooltip_filter = owner.findChild(FluentToolTipFilter)
+    assert tooltip_filter is not None
+    tooltip = _TooltipProbe()
+    tooltip_filter._tooltip = tooltip
+    try:
+        tooltip_filter.eventFilter(owner, _enter(QPoint(50, 60)))
+        tooltip_filter.show_tooltip()
+        assert tooltip.shown is True
+
+        set_fluent_tooltip_text(owner, "")
+
+        assert tooltip.hidden is True
+        assert tooltip_filter.isEnter is True
+
+        set_fluent_tooltip_text(owner, "second item")
+        tooltip_filter.show_tooltip()
+
+        assert tooltip.shown is True
+        assert tooltip.text == "second item"
+    finally:
+        destroy_qt_object(owner)
+
+
+def test_visible_tooltip_self_dismisses_when_leave_delivery_is_lost(
+    qt_application_owner: QApplication,
+) -> None:
+    """A visible tooltip must recover when the platform omits a leave event."""
+
+    _ = qt_application_owner
+    original_cursor_position = QCursor.pos()
+    owner = QWidget()
+    owner.setGeometry(100, 100, 120, 60)
+    owner.show()
+    owner.setToolTip("details")
+    tooltip = _TooltipProbe()
+    tooltip_filter = ensure_fluent_tooltip_filter(
+        owner,
+        show_delay_ms=0,
+        cursor_anchor=True,
+    )
+    tooltip_filter._tooltip = tooltip
+    try:
+        inside = owner.mapToGlobal(owner.rect().center())
+        QCursor.setPos(inside)
+        tooltip_filter.eventFilter(owner, _enter(inside))
+        tooltip_filter.show_tooltip()
+        assert tooltip.shown is True
+
+        QCursor.setPos(owner.mapToGlobal(QPoint(owner.width() + 40, 0)))
+
+        wait_for_qt_condition(
+            lambda: tooltip.hidden,
+            timeout_ms=500,
+            description="tooltip self-dismissal after a lost leave event",
+            state=lambda: {
+                "cursor": QCursor.pos(),
+                "owner_rect": owner.rect(),
+                "tooltip_shown": tooltip.shown,
+            },
+        )
+    finally:
+        QCursor.setPos(original_cursor_position)
+        destroy_qt_object(owner)
+
+
+def test_real_tooltip_window_recovers_from_lost_leave_delivery_headlessly(
+    qt_application_owner: QApplication,
+) -> None:
+    """The mounted QFluent window must disappear without a delivered leave event."""
+
+    _ = qt_application_owner
+    original_cursor_position = QCursor.pos()
+    owner = QWidget()
+    owner.setGeometry(100, 100, 120, 60)
+    owner.show()
+    set_fluent_tooltip_text(owner, "real tooltip")
+    tooltip_filter = owner.findChild(FluentToolTipFilter)
+    assert tooltip_filter is not None
+    try:
+        inside = owner.mapToGlobal(owner.rect().center())
+        QCursor.setPos(inside)
+        tooltip_filter.eventFilter(owner, _enter(inside))
+        tooltip_filter.show_tooltip()
+        tooltip = cast(QWidget, tooltip_filter._tooltip)
+        assert tooltip.isVisible()
+
+        QCursor.setPos(owner.mapToGlobal(QPoint(owner.width() + 40, 0)))
+
+        wait_for_qt_condition(
+            lambda: not tooltip.isVisible(),
+            timeout_ms=500,
+            description="real QFluent tooltip self-dismissal",
+        )
+    finally:
+        QCursor.setPos(original_cursor_position)
+        destroy_qt_object(owner)

--- a/tests/tools/check_localization/test_source_policy.py
+++ b/tests/tools/check_localization/test_source_policy.py
@@ -80,6 +80,50 @@ def test_tooltip_policy_rejects_indirect_native_property_writes(
     )
 
 
+def test_tooltip_policy_exempts_only_the_authoritative_owner(tmp_path: Path) -> None:
+    """Localization adapters must delegate instead of becoming a second owner."""
+
+    owner_root = tmp_path / "sugarsubstitute_shared" / "presentation"
+    localization_root = owner_root / "localization"
+    localization_root.mkdir(parents=True)
+    (owner_root / "fluent_tooltips.py").write_text(
+        "target.setToolTip('owner-managed')\n",
+        encoding="utf-8",
+    )
+    (localization_root / "application_text.py").write_text(
+        "target.setToolTip('bypass')\n",
+        encoding="utf-8",
+    )
+
+    violations = find_non_fluent_tooltip_usage(tmp_path)
+
+    assert tuple((item.filename, item.reason) for item in violations) == (
+        (
+            "sugarsubstitute_shared/presentation/localization/application_text.py",
+            "setToolTip() must be routed through set_fluent_tooltip_text()",
+        ),
+    )
+
+
+def test_tooltip_policy_requires_the_authoritative_filter_installer(
+    tmp_path: Path,
+) -> None:
+    """Production code must not construct even the shared filter directly."""
+
+    source_root = tmp_path / "substitute" / "presentation"
+    source_root.mkdir(parents=True)
+    (source_root / "direct_filter.py").write_text(
+        "FluentToolTipFilter(widget)\n",
+        encoding="utf-8",
+    )
+
+    violations = find_non_fluent_tooltip_usage(tmp_path)
+
+    assert tuple(item.reason for item in violations) == (
+        "tooltip widgets and filters may only be created by the shared owner",
+    )
+
+
 def test_visible_application_copy_has_an_explicit_locale_owner() -> None:
     """Static app copy must be marked instead of inferred from widget state."""
 

--- a/tools/check_localization.py
+++ b/tools/check_localization.py
@@ -40,12 +40,7 @@ class SourcePolicyViolation:
     reason: str
 
 
-_TOOLTIP_ADAPTERS = frozenset(
-    {
-        Path("sugarsubstitute_shared/presentation/fluent_tooltips.py"),
-        Path("sugarsubstitute_shared/presentation/localization/application_text.py"),
-    }
-)
+_TOOLTIP_OWNER = Path("sugarsubstitute_shared/presentation/fluent_tooltips.py")
 
 
 def find_ascii_input_restrictions(
@@ -88,7 +83,7 @@ def find_non_fluent_tooltip_usage(
     for root in roots:
         for path in sorted(root.rglob("*.py")):
             relative_path = path.relative_to(project_root)
-            if relative_path in _TOOLTIP_ADAPTERS:
+            if relative_path == _TOOLTIP_OWNER:
                 continue
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             for node in ast.walk(tree):
@@ -230,7 +225,12 @@ def _tooltip_policy_reason(node: ast.AST) -> str | None:
         return "tooltip property writes must use the shared QFluent owner"
     if callable_name == "setToolTip":
         return "setToolTip() must be routed through set_fluent_tooltip_text()"
-    if callable_name in {"QToolTip", "ToolTip", "ToolTipFilter"}:
+    if callable_name in {
+        "FluentToolTipFilter",
+        "QToolTip",
+        "ToolTip",
+        "ToolTipFilter",
+    }:
         return "tooltip widgets and filters may only be created by the shared owner"
     if callable_name in {"CursorToolTipFilter", "install_cursor_tooltip_filter"}:
         return "the retired cursor tooltip path must not be used"


### PR DESCRIPTION
## Summary
- centralize tooltip lifecycle recovery in the shared Fluent owner
- recover from nested-target event ordering and lost Leave delivery with finite lifetime and cursor guard
- enforce the single tooltip path and cover generation queue plus real offscreen tooltip windows

## Verification
- `python -m ruff format .`
- `python -m ruff check .`
- `python -m mypy --strict substitute tests`
- `python -m pytest -n auto -q -m "not serial and not isolated"`
- `python -m tools.ci.run_isolated_test_modules --junit-dir=build/test-results/local-isolated`
- `python -m tools.ci.run_serial_test_modules --junit-dir=build/test-results/local-serial`
- `python -m tools.check_architecture`
- `python -m tools.check_test_governance`
- `python -m tools.check_localization`

Closes #104