### PR TITLE
fix(canvas): keep sequential Cube previews aligned with final tabs

### DIFF
--- a/ARCHITECTURE_WAIVERS.toml
+++ b/ARCHITECTURE_WAIVERS.toml
@@ -1219,10 +1219,10 @@ owner = "output preview registry"
 rule = "STRUCT003"
 path = "substitute/application/workflows/output_preview_registry.py"
 kind = "structural"
-justification = "OutputPreviewRegistry is one in-memory aggregate for preview-lane admission, identity, lookup, and retirement. Its acceptance predicates and mutations enforce the same lane-consistency invariant, and separating admission from storage would create two owners for registry consistency."
+justification = "OutputPreviewRegistry is one in-memory aggregate for preview-lane admission, identity, lookup, generation-session rebinding, and retirement. Its acceptance predicates and mutations enforce the same lane-consistency invariant: a lane belongs to one workflow run and one current canvas-session revision. Separating session transition from lane storage would create two owners for registry consistency."
 issue = "chore:SS-WAIVER-S012"
 review_by = 2026-12-15
-max_lines = 534
+max_lines = 553
 
 [[waivers]]
 id = "SS-WAIVER-S013"

--- a/substitute/application/generation/visual_run_context_builder.py
+++ b/substitute/application/generation/visual_run_context_builder.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Mapping
 
 from substitute.application.cubes import cube_alias_body
@@ -108,10 +109,10 @@ def _source_label_for_prompt_node(node_id: str, node_data: dict[str, object]) ->
 def _node_to_cube_output_source(
     prompt_nodes: Mapping[str, object],
 ) -> dict[str, dict[str, str]]:
-    """Map upstream executable nodes to their unambiguous cube-output source."""
+    """Map executable nodes to their nearest unambiguous cube-output source."""
 
     output_sources: dict[str, dict[str, str]] = {}
-    candidate_sources_by_node: dict[str, list[dict[str, str]]] = {}
+    candidates_by_node: dict[str, list[tuple[int, dict[str, str]]]] = {}
     for node_id, node_data in prompt_nodes.items():
         if not isinstance(node_data, dict):
             continue
@@ -127,30 +128,40 @@ def _node_to_cube_output_source(
             "cubeAlias": label,
         }
         output_sources[node_id] = source
-        for upstream_node_id in _upstream_node_ids(prompt_nodes, node_id):
-            candidate_sources_by_node.setdefault(upstream_node_id, []).append(source)
+        for upstream_node_id, distance in _upstream_node_distances(
+            prompt_nodes,
+            node_id,
+        ).items():
+            candidates_by_node.setdefault(upstream_node_id, []).append(
+                (distance, source)
+            )
     for node_id, source in output_sources.items():
-        candidate_sources_by_node[node_id] = [source]
-    return {
-        node_id: sources[0]
-        for node_id, sources in candidate_sources_by_node.items()
-        if len({source["sourceKey"] for source in sources}) == 1
-    }
+        candidates_by_node[node_id] = [(0, source)]
+    resolved_sources: dict[str, dict[str, str]] = {}
+    for node_id, candidates in candidates_by_node.items():
+        nearest_distance = min(distance for distance, _source in candidates)
+        nearest_sources = [
+            source for distance, source in candidates if distance == nearest_distance
+        ]
+        if len({source["sourceKey"] for source in nearest_sources}) == 1:
+            resolved_sources[node_id] = nearest_sources[0]
+    return resolved_sources
 
 
-def _upstream_node_ids(
+def _upstream_node_distances(
     prompt_nodes: Mapping[str, object],
     start_node_id: str,
-) -> set[str]:
-    """Return executable node ids that feed one output node."""
+) -> dict[str, int]:
+    """Return the shortest upstream distance from one output to each feeder."""
 
-    visited: set[str] = set()
-    pending = [start_node_id]
+    distances: dict[str, int] = {}
+    pending = deque(((start_node_id, 0),))
     while pending:
-        node_id = pending.pop()
-        if node_id in visited:
+        node_id, distance = pending.popleft()
+        previous_distance = distances.get(node_id)
+        if previous_distance is not None and previous_distance <= distance:
             continue
-        visited.add(node_id)
+        distances[node_id] = distance
         node_data = prompt_nodes.get(node_id)
         if not isinstance(node_data, dict):
             continue
@@ -158,9 +169,8 @@ def _upstream_node_ids(
         if not isinstance(inputs, Mapping):
             continue
         for upstream_node_id in _linked_node_ids(tuple(inputs.values())):
-            if upstream_node_id not in visited:
-                pending.append(upstream_node_id)
-    return visited
+            pending.append((upstream_node_id, distance + 1))
+    return distances
 
 
 def _linked_node_ids(values: object) -> tuple[str, ...]:

--- a/substitute/application/workflows/output_preview_registry.py
+++ b/substitute/application/workflows/output_preview_registry.py
@@ -284,15 +284,20 @@ class OutputPreviewRegistry:
         )
         return self._remove_keys(keys)
 
-    def rebind_workflow_session(self, session: OutputCanvasSession) -> None:
-        """Carry active workflow lanes across navigation-only session revisions."""
+    def rebind_workflow_session(self, session: OutputCanvasSession) -> tuple[UUID, ...]:
+        """Carry current-run lanes and retire lanes superseded by another run."""
 
+        retired_keys: list[OutputPreviewLaneKey] = []
         for key, lane in tuple(self._lanes.items()):
             if key.workflow_id != session.workflow_id.value:
+                continue
+            if not _lane_can_follow_session(lane, session):
+                retired_keys.append(key)
                 continue
             if lane.session_revision == session.revision:
                 continue
             self._lanes[key] = replace(lane, session_revision=session.revision)
+        return self._remove_keys(tuple(retired_keys))
 
     def lanes_for_session(
         self,
@@ -616,6 +621,23 @@ def _final_matches_lane(
     if key.scene_key != (identity.scene_key or None):
         return False
     return key.source_key == identity.source_key
+
+
+def _lane_can_follow_session(
+    lane: OutputPreviewLane,
+    session: OutputCanvasSession,
+) -> bool:
+    """Return whether a preview belongs to the run represented by a new session."""
+
+    generation = session.generation_identity
+    if generation is None:
+        return True
+    key = lane.key
+    return (
+        key.generation_run_id == generation.generation_run_id
+        and key.prompt_id == generation.prompt_id
+        and lane.client_id == generation.client_id
+    )
 
 
 def _is_null_image(image: object) -> bool:

--- a/substitute/presentation/canvas/output/output_canvas_view.py
+++ b/substitute/presentation/canvas/output/output_canvas_view.py
@@ -385,7 +385,8 @@ class OutputCanvas(QWidget):
 
         previous_source_key = self.active_source_key
         previous_set_index = self.active_set_index
-        self._preview_registry.rebind_workflow_session(session)
+        retired_preview_ids = self._preview_registry.rebind_workflow_session(session)
+        self._preview_presenter.close_final_output_preview_lane(retired_preview_ids)
         self._output_session = session
         projection = session.projection
         self._output_projection = projection

--- a/tests/application/generation/test_visual_run_context_builder.py
+++ b/tests/application/generation/test_visual_run_context_builder.py
@@ -59,6 +59,32 @@ def test_cube_visual_source_key_survives_compiled_node_id_changes() -> None:
     }
 
 
+def test_chained_cube_nodes_use_their_nearest_output_source() -> None:
+    """Route each stage preview to its nearest downstream CubeOutput tab."""
+
+    context = VisualRunContextBuilder().build(
+        workflow_payload=_chained_cube_payload(),
+        workflow_id=WorkflowId("workflow"),
+        generation_run_id="run",
+        client_id="client",
+        scene_run_id=None,
+        scene_key=None,
+        scene_title=None,
+        scene_order=None,
+        scene_count=None,
+    )
+
+    assert {
+        node_id: context.sources[node_id]["sourceKey"]
+        for node_id in ("9", "11", "25", "32")
+    } == {
+        "9": "cube:Text to Image",
+        "11": "cube:Diffusion Upscale",
+        "25": "cube:Automask Detailer",
+        "32": "cube:Automask Detailer 2",
+    }
+
+
 def _cube_payload(*, sampler_id: str, output_id: str) -> dict[str, object]:
     """Return one compiled cube whose executable ids may change per run."""
 
@@ -74,3 +100,31 @@ def _cube_payload(*, sampler_id: str, output_id: str) -> dict[str, object]:
             "_meta": {"title": "Text to Image.Output"},
         },
     }
+
+
+def _chained_cube_payload() -> dict[str, object]:
+    """Return four sequential cubes whose early nodes reach every later output."""
+
+    payload: dict[str, object] = {}
+    previous_output_id: str | None = None
+    for sampler_id, output_id, label in (
+        ("9", "8", "Text to Image"),
+        ("11", "17", "Diffusion Upscale"),
+        ("25", "29", "Automask Detailer"),
+        ("32", "36", "Automask Detailer 2"),
+    ):
+        sampler_inputs = (
+            {} if previous_output_id is None else {"image": [previous_output_id, 0]}
+        )
+        payload[sampler_id] = {
+            "class_type": "KSampler",
+            "inputs": sampler_inputs,
+            "_meta": {"title": f"{label}.KSampler"},
+        }
+        payload[output_id] = {
+            "class_type": "SugarCubes.CubeOutput",
+            "inputs": {"images": [sampler_id, 0]},
+            "_meta": {"title": f"{label}.Output"},
+        }
+        previous_output_id = output_id
+    return payload

--- a/tests/application/workflows/output_preview_lifecycle/test_registry_acceptance.py
+++ b/tests/application/workflows/output_preview_lifecycle/test_registry_acceptance.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from uuid import UUID
 
 from substitute.application.ports import PreviewImageUpdate
@@ -28,6 +29,7 @@ from substitute.application.workflows import (
     OutputPreviewRejectionReason,
 )
 from substitute.domain.workflow import (
+    CanvasGenerationIdentity,
     CanvasSessionBoundary,
 )
 
@@ -251,6 +253,42 @@ def test_registry_retires_old_session_previews_without_accepting_route_mutation(
     assert second.retired_preview_ids == (UUID(int=1),)
     assert second.lanes[0].preview_id == UUID(int=2)
     assert tuple(registry.images_by_id()) == (UUID(int=2),)
+
+
+def test_registry_rebind_retires_preview_from_superseded_generation() -> None:
+    """Do not carry a previous run's preview into a newer final-output session."""
+
+    registry = OutputPreviewRegistry(_uuid_factory=uuid_sequence())
+    boundary = CanvasSessionBoundary()
+    first_session = build_registry_session(source_keys=(), boundary=boundary)
+    acceptance = registry.accept_preview(
+        build_preview_event(source_key="cube:Text to Image"),
+        session=first_session,
+        active_workflow_id="wf",
+        authorize_preview=lambda _identity: True,
+        is_valid_source_placeholder=lambda _identity: True,
+    )
+    next_session = build_registry_session(
+        source_keys=("cube:Text to Image",),
+        boundary=boundary,
+    )
+    next_session = replace(
+        next_session,
+        session=replace(
+            next_session.session,
+            generation_identity=CanvasGenerationIdentity(
+                generation_run_id="new-run",
+                prompt_id="new-prompt",
+                client_id="new-client",
+            ),
+        ),
+    )
+
+    retired_ids = registry.rebind_workflow_session(next_session)
+
+    assert acceptance.accepted
+    assert retired_ids == (UUID(int=1),)
+    assert registry.images_by_id() == {}
 
 
 def test_registry_accepts_in_progress_scene_placeholder_for_same_workflow_run() -> None:

--- a/tests/presentation/canvas/output/real_shell/test_four_cube_preview_lifecycle.py
+++ b/tests/presentation/canvas/output/real_shell/test_four_cube_preview_lifecycle.py
@@ -1,0 +1,182 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify sequential four-cube previews settle into exactly four Output tabs."""
+
+from __future__ import annotations
+
+from substitute.application.generation import GenerationRunStarted
+from substitute.application.generation.visual_run_context_builder import (
+    VisualRunContextBuilder,
+)
+from substitute.application.ports import QueueVisualRunContext
+from substitute.domain.common import WorkflowId
+from tests.support.real_output_canvas.harness import RealShellOutputCanvasHarness
+from tests.support.real_output_canvas.models import GenerationRunHandle, OutputSpec
+
+
+def test_four_cube_previews_settle_into_four_matching_final_tabs(
+    harness: RealShellOutputCanvasHarness,
+) -> None:
+    """Replace every stage preview in place while preserving earlier final tabs."""
+
+    context = _build_visual_context()
+    harness.add_workflow("brown-haired", activate=True)
+    run = harness.start_run("brown-haired")
+    _register_preview_sources(harness, run, context)
+    stages = (
+        ("9", "8", (95, 55, 40), (125, 75, 55)),
+        ("11", "17", (70, 105, 155), (85, 125, 180)),
+        ("25", "29", (125, 85, 145), (150, 105, 170)),
+        ("32", "36", (155, 100, 90), (180, 125, 110)),
+    )
+    expected_source_keys: list[str] = []
+
+    for output_count, (
+        preview_node,
+        output_node,
+        preview_color,
+        final_color,
+    ) in enumerate(stages, start=1):
+        preview_spec = _output_spec(context, preview_node, preview_color)
+        expected_source_keys.append(preview_spec.source_key)
+        harness.emit_preview(run, preview_spec)
+        harness.wait_for_preview_count(1)
+        harness.wait_until(
+            lambda: (
+                tuple(harness.shell.output_canvas.tabbar.items)
+                == tuple(expected_source_keys)
+            )
+        )
+        harness.assert_preview_displayed(color=preview_color)
+
+        harness.emit_output(
+            run,
+            _output_spec(context, output_node, final_color),
+        )
+        harness.wait_for_output_count("brown-haired", output_count)
+        harness.wait_for_preview_count(0)
+        harness.wait_until(
+            lambda: (
+                "workflow-brown-haired"
+                not in harness.fingerprint().pending_projection_workflows
+            )
+        )
+        harness.wait_until(
+            lambda: (
+                tuple(harness.shell.output_canvas.tabbar.items)
+                == tuple(expected_source_keys)
+            )
+        )
+        try:
+            harness.assert_showing_workflow("brown-haired", color=final_color)
+        except AssertionError as error:
+            raise AssertionError(
+                f"four-cube stage {output_count} did not settle: {harness.fingerprint()}"
+            ) from error
+
+    harness.assert_no_previews()
+    assert tuple(
+        item.text() for item in harness.shell.output_canvas.tabbar.items.values()
+    ) == (
+        "Text to Image",
+        "Diffusion Upscale",
+        "Automask Detailer",
+        "Automask Detailer 2",
+    )
+
+
+def _build_visual_context() -> QueueVisualRunContext:
+    """Build routing context for the reported four-stage compiled graph shape."""
+
+    return VisualRunContextBuilder().build(
+        workflow_payload=_chained_cube_payload(),
+        workflow_id=WorkflowId("workflow-brown-haired"),
+        generation_run_id="workflow-brown-haired-run-1",
+        client_id="workflow-brown-haired-client-1",
+        scene_run_id=None,
+        scene_key=None,
+        scene_title=None,
+        scene_order=None,
+        scene_count=None,
+    )
+
+
+def _register_preview_sources(
+    harness: RealShellOutputCanvasHarness,
+    run: GenerationRunHandle,
+    context: QueueVisualRunContext,
+) -> None:
+    """Publish the builder-derived preview placeholders through real ingress."""
+
+    harness.shell.generation_feedback_dispatcher.on_run_started(
+        GenerationRunStarted(
+            workflow_id=run.workflow.workflow_id,
+            generation_run_id=run.generation_run_id,
+            output_session_id=run.output_session_id,
+            prompt_id=run.prompt_id,
+            client_id=run.client_id,
+            preview_source_keys=frozenset(
+                source["sourceKey"] for source in context.sources.values()
+            ),
+        )
+    )
+    harness.process_events()
+    harness.shell.generation_feedback_dispatcher.flush_now()
+    harness.process_events()
+
+
+def _output_spec(
+    context: QueueVisualRunContext,
+    node_id: str,
+    color: tuple[int, int, int],
+) -> OutputSpec:
+    """Build one callback specification from production-derived source metadata."""
+
+    source = context.sources[node_id]
+    return OutputSpec(
+        source_key=source["sourceKey"],
+        source_label=source["sourceLabel"],
+        color=color,
+        node_id=node_id,
+    )
+
+
+def _chained_cube_payload() -> dict[str, object]:
+    """Return the four chained output stages from the brown-haired workflow."""
+
+    payload: dict[str, object] = {}
+    previous_output_id: str | None = None
+    for sampler_id, output_id, label in (
+        ("9", "8", "Text to Image"),
+        ("11", "17", "Diffusion Upscale"),
+        ("25", "29", "Automask Detailer"),
+        ("32", "36", "Automask Detailer 2"),
+    ):
+        payload[sampler_id] = {
+            "class_type": "KSampler",
+            "inputs": (
+                {} if previous_output_id is None else {"image": [previous_output_id, 0]}
+            ),
+            "_meta": {"title": f"{label}.KSampler"},
+        }
+        payload[output_id] = {
+            "class_type": "SugarCubes.CubeOutput",
+            "inputs": {"images": [sampler_id, 0]},
+            "_meta": {"title": f"{label}.Output"},
+        }
+        previous_output_id = output_id
+    return payload


### PR DESCRIPTION
## Summary
- route each live preview to the nearest downstream Cube output instead of dropping preview identity when chained Cubes share upstream nodes
- retire preview lanes from superseded generation sessions before projecting their final results
- cover the four-stage brown-haired workflow lifecycle through the real headless Output canvas shell

## Result
The expected sequence now settles into exactly four matching tabs:

1. Text to Image
2. Diffusion Upscale
3. Automask Detailer
4. Automask Detailer 2

Each preview creates or updates its matching tab, and each final replaces that preview without duplicating or mismatching the tab.

## Verification
- `python -m ruff format .`
- `python -m ruff check .`
- `python -m mypy --strict substitute tests`
- `python -m tools.check_architecture`
- `python -m tools.check_test_governance`
- `python -m pytest -n auto -q -m "not serial and not isolated"`
- `python -m tools.ci.run_isolated_test_modules --junit-dir=build/test-results/local-isolated`
- `python -m tools.ci.run_serial_test_modules --junit-dir=build/test-results/local-serial`
- real cached brown-haired workflow replayed with `QT_QPA_PLATFORM=offscreen`