### PR TITLE
fix(updates): ship the startup UI with Windows launcher updates

### DIFF
--- a/sugarsubstitute_shared/launcher_update/targets.py
+++ b/sugarsubstitute_shared/launcher_update/targets.py
@@ -43,6 +43,7 @@ WINDOWS_X64_BUNDLE = LauncherBundleTarget(
     support_relative_path=Path("launcher-bin"),
     replacement_roots=(
         Path("SugarSubstitute.exe"),
+        Path("LauncherUi.exe"),
         Path("Repair.exe"),
         Path("launcher-bin"),
     ),

--- a/tests/launcher/installation_workflow/first_run/support.py
+++ b/tests/launcher/installation_workflow/first_run/support.py
@@ -100,6 +100,7 @@ def write_valid_launcher_bundle_zip(path: Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(path, "w") as archive:
         archive.writestr("SugarSubstitute.exe", b"launcher")
+        archive.writestr("LauncherUi.exe", b"launcher UI")
         archive.writestr("Repair.exe", b"repair launcher")
         archive.writestr("launcher-bin/python312.dll", b"dll")
     return path

--- a/tests/launcher/repair/test_execution_service.py
+++ b/tests/launcher/repair/test_execution_service.py
@@ -154,6 +154,7 @@ def _write_launcher(path: Path) -> None:
 
     path.mkdir(parents=True)
     (path / "SugarSubstitute.exe").write_bytes(b"new-launcher")
+    (path / "LauncherUi.exe").write_bytes(b"new-launcher-ui")
     (path / "Repair.exe").write_bytes(b"new-repair")
     (path / "launcher-bin").mkdir()
     (path / "launcher-bin" / "runtime.dll").write_bytes(b"new-support")
@@ -193,6 +194,7 @@ def _write_old_install(layout: InstallLayout) -> None:
     layout.runtime_python.write_bytes(b"old-python")
     layout.executable_path.parent.mkdir(parents=True, exist_ok=True)
     layout.executable_path.write_bytes(b"old-launcher")
+    (layout.root / "LauncherUi.exe").write_bytes(b"old-launcher-ui")
     (layout.root / "Repair.exe").write_bytes(b"old-repair")
     layout.launcher_support_path.mkdir()
     (layout.launcher_support_path / "runtime.dll").write_bytes(b"old-support")
@@ -234,6 +236,7 @@ def test_execution_commits_exact_version_and_preserves_all_user_comfy_data(
     ) == '__version__ = "1.2.3"\n'
     assert layout.runtime_python.read_bytes() == b"candidate-python"
     assert layout.executable_path.read_bytes() == b"new-launcher"
+    assert (layout.root / "LauncherUi.exe").read_bytes() == b"new-launcher-ui"
     assert (layout.root / "Repair.exe").read_bytes() == b"new-repair"
     assert {path: path.read_bytes() for path in protected_paths} == before
 
@@ -279,6 +282,7 @@ def test_execution_rolls_back_every_component_after_final_validation_failure(
     ) == '__version__ = "0.9.0"\n'
     assert layout.runtime_python.read_bytes() == b"old-python"
     assert layout.executable_path.read_bytes() == b"old-launcher"
+    assert (layout.root / "LauncherUi.exe").read_bytes() == b"old-launcher-ui"
     assert (layout.root / "Repair.exe").read_bytes() == b"old-repair"
     assert (layout.launcher_support_path / "runtime.dll").read_bytes() == b"old-support"
 

--- a/tests/launcher/update_activation/transaction/support.py
+++ b/tests/launcher/update_activation/transaction/support.py
@@ -34,6 +34,7 @@ def _write_installed_layout(root: Path) -> Path:
 
     root.mkdir(parents=True)
     (root / "SugarSubstitute.exe").write_text("old launcher", encoding="utf-8")
+    (root / "LauncherUi.exe").write_text("old launcher UI", encoding="utf-8")
     (root / "Repair.exe").write_text("old repair", encoding="utf-8")
     (root / "launcher-bin").mkdir()
     (root / "launcher-bin" / "runtime.txt").write_text("old", encoding="utf-8")
@@ -77,6 +78,7 @@ def _write_bundle(path: Path, *, marker: str) -> Path:
 
     with zipfile.ZipFile(path, "w") as bundle:
         bundle.writestr("SugarSubstitute.exe", marker)
+        bundle.writestr("LauncherUi.exe", f"{marker} UI")
         bundle.writestr("Repair.exe", f"{marker} repair")
         bundle.writestr("launcher-bin/runtime.txt", "new")
     return path
@@ -87,6 +89,7 @@ def _write_bundle_tree(path: Path, *, marker: str) -> None:
 
     path.mkdir(parents=True)
     (path / "SugarSubstitute.exe").write_text(marker, encoding="utf-8")
+    (path / "LauncherUi.exe").write_text(f"{marker} UI", encoding="utf-8")
     (path / "Repair.exe").write_text(f"{marker} repair", encoding="utf-8")
     (path / "launcher-bin").mkdir()
     (path / "launcher-bin" / "runtime.txt").write_text("new", encoding="utf-8")

--- a/tests/launcher/update_activation/transaction/test_promotion_rollback.py
+++ b/tests/launcher/update_activation/transaction/test_promotion_rollback.py
@@ -51,6 +51,7 @@ def test_transaction_replaces_only_launcher_and_preserves_install_data(
     LauncherUpdateTransaction(wait_timeout_seconds=0).apply(request_path=request_path)
 
     assert (install_root / "SugarSubstitute.exe").read_text() == "new launcher"
+    assert (install_root / "LauncherUi.exe").read_text() == "new launcher UI"
     assert (install_root / "launcher-bin" / "runtime.txt").read_text() == "new"
     for relative_path in (
         "app/preserve.txt",
@@ -70,7 +71,7 @@ def test_transaction_rolls_back_both_bundle_roots_on_copy_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A partial two-root Windows promotion must restore the old bundle."""
+    """A partial Windows promotion must restore the old bundle."""
 
     install_root = _write_installed_layout(tmp_path / "SugarSubstitute")
     request_path = LauncherBundleStager().stage(
@@ -99,6 +100,7 @@ def test_transaction_rolls_back_both_bundle_roots_on_copy_failure(
         )
 
     assert (install_root / "SugarSubstitute.exe").read_text() == "old launcher"
+    assert (install_root / "LauncherUi.exe").read_text() == "old launcher UI"
     assert (install_root / "launcher-bin" / "runtime.txt").read_text() == "old"
 
 
@@ -119,9 +121,13 @@ def test_transaction_recovers_interrupted_backup_before_retry(
     backup_root = update_root / "backup"
     backup_root.mkdir(parents=True)
     (install_root / "SugarSubstitute.exe").replace(backup_root / "SugarSubstitute.exe")
+    (install_root / "LauncherUi.exe").replace(backup_root / "LauncherUi.exe")
     (install_root / "launcher-bin").replace(backup_root / "launcher-bin")
     (install_root / "SugarSubstitute.exe").write_text(
         "interrupted partial", encoding="utf-8"
+    )
+    (install_root / "LauncherUi.exe").write_text(
+        "interrupted partial UI", encoding="utf-8"
     )
     (install_root / "launcher-bin").mkdir()
     (install_root / "launcher-bin" / "runtime.txt").write_text(
@@ -147,6 +153,7 @@ def test_transaction_recovers_interrupted_backup_before_retry(
         )
 
     assert (install_root / "SugarSubstitute.exe").read_text() == "old launcher"
+    assert (install_root / "LauncherUi.exe").read_text() == "old launcher UI"
     assert (install_root / "launcher-bin" / "runtime.txt").read_text() == "old"
 
 

--- a/tests/launcher/update_activation/transaction/test_staging_validation.py
+++ b/tests/launcher/update_activation/transaction/test_staging_validation.py
@@ -61,6 +61,7 @@ def test_stager_verifies_and_persists_complete_bundle(tmp_path: Path) -> None:
     assert request.install_root == install_root.resolve()
     assert request.version == "0.11.0"
     assert (request.staged_bundle_dir / "SugarSubstitute.exe").read_text() == "new"
+    assert (request.staged_bundle_dir / "LauncherUi.exe").read_text() == "new UI"
     assert (request.staged_bundle_dir / "launcher-bin" / "runtime.txt").is_file()
 
 

--- a/tests/qualification/release/payload/test_builder.py
+++ b/tests/qualification/release/payload/test_builder.py
@@ -239,6 +239,7 @@ def test_local_release_channel_writes_optional_launcher_bundle_asset(
     )
     with zipfile.ZipFile(launcher_zip) as archive:
         assert "SugarSubstitute.exe" in archive.namelist()
+        assert "LauncherUi.exe" in archive.namelist()
         assert "launcher-bin/python312.dll" in archive.namelist()
     assert result.installer_assets["windows_x64_exe"].filename == installer_exe.name
     assert installer_exe.read_text(encoding="utf-8") == "setup"
@@ -496,6 +497,7 @@ def _write_fixture_launcher_bundle(root: Path) -> Path:
     """Write a minimal PyInstaller onedir launcher bundle fixture."""
 
     _write_file(root / "SugarSubstitute.exe", "launcher")
+    _write_file(root / "LauncherUi.exe", "launcher UI")
     _write_file(root / "Repair.exe", "repair launcher")
     _write_file(root / "launcher-bin" / "python312.dll", "dll")
     return root

--- a/tests/qualification/windows/launcher/test_update_transaction_long_paths.py
+++ b/tests/qualification/windows/launcher/test_update_transaction_long_paths.py
@@ -51,6 +51,10 @@ def test_transaction_promotes_launcher_inside_long_install_root(
             "old launcher",
             encoding="utf-8",
         )
+        (install_root / "LauncherUi.exe").write_text(
+            "old launcher UI",
+            encoding="utf-8",
+        )
         (install_root / "Repair.exe").write_text("old repair", encoding="utf-8")
         (install_root / "launcher-bin").mkdir()
         (install_root / "launcher-bin" / "runtime.txt").write_text(
@@ -60,6 +64,10 @@ def test_transaction_promotes_launcher_inside_long_install_root(
         staged_root.mkdir(parents=True)
         (staged_root / "SugarSubstitute.exe").write_text(
             "new launcher",
+            encoding="utf-8",
+        )
+        (staged_root / "LauncherUi.exe").write_text(
+            "new launcher UI",
             encoding="utf-8",
         )
         (staged_root / "Repair.exe").write_text("new repair", encoding="utf-8")
@@ -83,6 +91,9 @@ def test_transaction_promotes_launcher_inside_long_install_root(
         assert (install_root / "SugarSubstitute.exe").read_text(
             encoding="utf-8"
         ) == "new launcher"
+        assert (install_root / "LauncherUi.exe").read_text(
+            encoding="utf-8"
+        ) == "new launcher UI"
         assert (install_root / "launcher-bin" / "runtime.txt").read_text(
             encoding="utf-8"
         ) == "new runtime"


### PR DESCRIPTION
## Summary

- register LauncherUi.exe as part of the authoritative Windows launcher replacement contract
- include it in release payload, staged-update, promotion, rollback, repair, and long-path coverage
- unblock the canary Windows artifact build that rejected the new executable as an unexpected root

## Verification

- full Windows ordinary test suite
- all 88 isolated test modules
- serial test module
- Ruff format and lint
- strict mypy
- architecture and test governance