### PR TITLE
fix(installer): make canary setup complete installation reliably

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
       qualification_candidate_run_id: ${{ inputs.qualification_candidate_run_id }}
       qualification_candidate_version: ${{ inputs.qualification_candidate_version }}
       candidate_artifact_name: ${{ inputs.candidate_artifact_name || 'non-release-candidate-channel' }}
-      qualification_scope: ${{ github.ref_name == 'canary' && 'canary-fast' || inputs.qualification_scope == '' && 'all' || inputs.qualification_scope == 'full' && 'all' || inputs.qualification_scope }}
+      qualification_scope: ${{ inputs.qualification_scope == '' && 'all' || inputs.qualification_scope == 'full' && 'all' || inputs.qualification_scope }}
       upgrade_selection: ${{ inputs.dry_run == 'true' && inputs.qualification_scope != 'full' && inputs.upgrade_selection || 'complete' }}
       qualification_timeout_seconds: ${{ inputs.dry_run == 'true' && inputs.qualification_scope != 'full' && inputs.qualification_timeout_seconds || '3600' }}
 

--- a/launcher/sugarsubstitute_launcher/launcher_ui_supervision.py
+++ b/launcher/sugarsubstitute_launcher/launcher_ui_supervision.py
@@ -29,6 +29,7 @@ from launcher.sugarsubstitute_launcher.crash_supervisor import (
     ApplicationCrashSupervisor,
 )
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from launcher.sugarsubstitute_launcher.platforms import LauncherOperatingSystem
 from launcher.sugarsubstitute_launcher.process import spawn_detached_process
 from launcher.sugarsubstitute_launcher.runtime_paths import frozen_support_path
 from sugarsubstitute_shared.windows_long_paths import subprocess_path
@@ -90,26 +91,42 @@ def _supervise(
     )
     return crash_owner.supervise(
         layout=layout,
-        command=_current_launcher_command(child_arguments),
+        command=_current_launcher_command(layout, child_arguments),
         environment=os.environ,
     )
 
 
-def _current_launcher_command(arguments: Sequence[str]) -> tuple[str, ...]:
-    """Return the current frozen executable or source module invocation."""
+def _current_launcher_command(
+    layout: InstallLayout,
+    arguments: Sequence[str],
+) -> tuple[str, ...]:
+    """Return the packaged UI child or source module invocation."""
 
     executable = subprocess_path(Path(sys.executable))
     if bool(getattr(sys, "frozen", False)):
-        ui_executable = subprocess_path(
-            Path(sys.executable).with_name("LauncherUi.exe")
-        )
-        return (ui_executable, *arguments)
+        installed_ui_executable = _installed_windows_ui_executable(layout)
+        if installed_ui_executable is not None:
+            executable = subprocess_path(installed_ui_executable)
+        return (executable, *arguments)
     return (
         executable,
         "-m",
         "launcher.sugarsubstitute_launcher",
         *arguments,
     )
+
+
+def _installed_windows_ui_executable(layout: InstallLayout) -> Path | None:
+    """Resolve the UI child only from an authoritative installed Windows bundle."""
+
+    if layout.target.operating_system is not LauncherOperatingSystem.WINDOWS:
+        return None
+    support_path = frozen_support_path()
+    if support_path is None:
+        return None
+    if support_path.resolve() != layout.launcher_support_path.resolve():
+        return None
+    return Path(sys.executable).with_name("LauncherUi.exe")
 
 
 def _current_native_runtime(layout: InstallLayout) -> tuple[Path, Path]:
@@ -135,10 +152,11 @@ def _start_current_crash_reporter(layout: InstallLayout, incident_id: str) -> No
 
     spawn_detached_process(
         _current_launcher_command(
+            layout,
             (
                 f"--install-root={subprocess_path(layout.root)}",
                 f"--show-crash-report={incident_id}",
-            )
+            ),
         ),
         environment=os.environ,
     )

--- a/launcher/sugarsubstitute_launcher/process.py
+++ b/launcher/sugarsubstitute_launcher/process.py
@@ -28,6 +28,9 @@ from sugarsubstitute_shared.application_launch_context import (
     application_launch_install_root,
 )
 from sugarsubstitute_shared.external_path_failure import external_long_path_error
+from sugarsubstitute_shared.crash_reporting.protocol import (
+    without_crash_supervision_environment,
+)
 from sugarsubstitute_shared.subprocess_environment import (
     clean_frozen_parent_environment,
     standard_child_process_dll_search_path,
@@ -166,7 +169,11 @@ def spawn_detached_process(
 def start_detached_handoff(command: Sequence[str]) -> None:
     """Start a handoff child process without keeping the current window around."""
 
-    start_detached(command, startup_timeout_seconds=HANDOFF_STARTUP_TIMEOUT_SECONDS)
+    start_detached(
+        command,
+        startup_timeout_seconds=HANDOFF_STARTUP_TIMEOUT_SECONDS,
+        environment=without_crash_supervision_environment(),
+    )
 
 
 def build_installed_launcher_handoff_command(

--- a/launcher/sugarsubstitute_launcher/startup_plan.py
+++ b/launcher/sugarsubstitute_launcher/startup_plan.py
@@ -114,7 +114,10 @@ def resolve_startup_candidate(
         layout = InstallLayout.from_root(explicit_install_root)
         return LauncherStartupCandidate(
             layout=layout,
-            installed_config_found=False,
+            installed_config_found=(
+                _matches_installed_executable(executable_path, layout.target)
+                and layout.config_path.is_file()
+            ),
         )
 
     target = detect_launcher_target()

--- a/launcher/sugarsubstitute_launcher/ui/experience_pages.py
+++ b/launcher/sugarsubstitute_launcher/ui/experience_pages.py
@@ -196,13 +196,13 @@ class ModelInterestPage(QFrame):
         layout.addStretch(1)
         footer = QHBoxLayout()
         footer.addStretch(1)
-        skip = PushButton(launcher_text("Skip model setup"), self)
-        skip.clicked.connect(self.skip_requested)
+        self.skip_button = PushButton(launcher_text("Skip model setup"), self)
+        self.skip_button.clicked.connect(self.skip_requested)
         self.primary_button = PrimaryPushButton(
             launcher_text("Find popular models"), self
         )
         self.primary_button.clicked.connect(self.continue_requested)
-        footer.addWidget(skip)
+        footer.addWidget(self.skip_button)
         footer.addWidget(self.primary_button)
         layout.addLayout(footer)
 

--- a/launcher/sugarsubstitute_launcher/ui/installer_qualification.py
+++ b/launcher/sugarsubstitute_launcher/ui/installer_qualification.py
@@ -51,6 +51,7 @@ class InstallerQualificationDriver(QObject):
         self._plan = plan
         window.handoff_completed.connect(self._record_handoff)
         window.execution.initial_failed.connect(self._record_initial_failure)
+        window.execution.initial_finished.connect(self._skip_optional_model_setup)
         window.execution.setup_failed.connect(self._record_setup_failure)
 
     def schedule(self) -> None:
@@ -99,6 +100,27 @@ class InstallerQualificationDriver(QObject):
                 error=str(error),
             )
             QCoreApplication.exit(1)
+
+    @Slot()
+    def _skip_optional_model_setup(self) -> None:
+        """Skip the visible optional model page during installer qualification."""
+
+        page = self._window.view.model_interest_page
+        if not page.isVisible():
+            return
+        button = page.skip_button
+        if not button.isVisible() or not button.isEnabled():
+            self._record_installation_failure(
+                phase="optional_model_setup",
+                details="The visible model setup page did not expose its Skip action.",
+            )
+            return
+        QTest.mouseClick(
+            button,
+            Qt.MouseButton.LeftButton,
+            pos=button.rect().center(),
+        )
+        self._plan.record("installer.model_setup.skipped")
 
     @Slot()
     def _record_handoff(self) -> None:

--- a/sugarsubstitute_shared/crash_reporting/protocol.py
+++ b/sugarsubstitute_shared/crash_reporting/protocol.py
@@ -41,6 +41,16 @@ CRASH_EXIT_RECEIPT_PATH_ENV = "SUGAR_SUBSTITUTE_CRASH_EXIT_RECEIPT_PATH"
 CRASHPAD_DATABASE_ENV = "SUGAR_SUBSTITUTE_CRASHPAD_DATABASE"
 CRASHPAD_HANDLER_ENV = "SUGAR_SUBSTITUTE_CRASHPAD_HANDLER"
 CRASHPAD_CLIENT_LIBRARY_ENV = "SUGAR_SUBSTITUTE_CRASHPAD_CLIENT_LIBRARY"
+_CRASH_SUPERVISION_ENVIRONMENT_NAMES = (
+    CRASH_RUN_ID_ENV,
+    CRASH_RUN_TOKEN_ENV,
+    CRASH_INCIDENT_ROOT_ENV,
+    CRASH_EXIT_INTENT_PATH_ENV,
+    CRASH_EXIT_RECEIPT_PATH_ENV,
+    CRASHPAD_DATABASE_ENV,
+    CRASHPAD_HANDLER_ENV,
+    CRASHPAD_CLIENT_LIBRARY_ENV,
+)
 
 
 class CleanExitOutcome(Enum):
@@ -207,6 +217,17 @@ class CrashRunContext:
         return intent is not None and receipt == intent
 
 
+def without_crash_supervision_environment(
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return an environment detached from the current crash-supervised run."""
+
+    detached = dict(os.environ if environment is None else environment)
+    for name in _CRASH_SUPERVISION_ENVIRONMENT_NAMES:
+        detached.pop(name, None)
+    return detached
+
+
 def _present(values: Mapping[str, str | None], key: str) -> str:
     """Return a field already proven present while satisfying static typing."""
 
@@ -318,4 +339,5 @@ __all__ = [
     "CRASH_RUN_TOKEN_ENV",
     "CleanExitOutcome",
     "CrashRunContext",
+    "without_crash_supervision_environment",
 ]

--- a/tests/launcher/application_launch/test_startup_plan.py
+++ b/tests/launcher/application_launch/test_startup_plan.py
@@ -88,6 +88,41 @@ def test_launcher_resolves_installed_exe_parent_as_install_root(
     assert resolved_root == layout.root
 
 
+def test_explicit_root_recognizes_its_installed_launcher(tmp_path: Path) -> None:
+    """An installer handoff should route the stable executable into the app."""
+
+    layout = InstallLayout.from_root(tmp_path / "SugarSubstitute")
+    LauncherConfig.from_layout(layout=layout).save(layout.config_path)
+    write_launcher_executable(layout)
+
+    candidate = resolve_startup_candidate(
+        explicit_install_root=layout.root,
+        executable_path=layout.executable_path,
+    )
+
+    assert candidate.layout == layout
+    assert candidate.installed_config_found is True
+
+
+def test_explicit_root_keeps_downloaded_setup_in_installer_mode(
+    tmp_path: Path,
+) -> None:
+    """A downloaded setup must not become an app launch because a config exists."""
+
+    layout = InstallLayout.from_root(tmp_path / "SugarSubstitute")
+    LauncherConfig.from_layout(layout=layout).save(layout.config_path)
+    setup_executable = tmp_path / "SugarSubstitute-Setup-Windows-x64.exe"
+    setup_executable.write_bytes(b"setup")
+
+    candidate = resolve_startup_candidate(
+        explicit_install_root=layout.root,
+        executable_path=setup_executable,
+    )
+
+    assert candidate.layout == layout
+    assert candidate.installed_config_found is False
+
+
 def test_launcher_resolves_install_root_from_frozen_support_bundle(
     tmp_path: Path,
 ) -> None:

--- a/tests/launcher/application_launch/test_supervised_handoff.py
+++ b/tests/launcher/application_launch/test_supervised_handoff.py
@@ -25,6 +25,16 @@ import pytest
 from launcher.sugarsubstitute_launcher import process
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from sugarsubstitute_shared.windows_long_paths import subprocess_path
+from sugarsubstitute_shared.crash_reporting.protocol import (
+    CRASHPAD_CLIENT_LIBRARY_ENV,
+    CRASHPAD_DATABASE_ENV,
+    CRASHPAD_HANDLER_ENV,
+    CRASH_EXIT_INTENT_PATH_ENV,
+    CRASH_EXIT_RECEIPT_PATH_ENV,
+    CRASH_INCIDENT_ROOT_ENV,
+    CRASH_RUN_ID_ENV,
+    CRASH_RUN_TOKEN_ENV,
+)
 
 
 def test_installer_handoff_builds_stable_launcher_command(tmp_path: Path) -> None:
@@ -75,3 +85,42 @@ def test_installer_handoff_starts_only_stable_launcher(
             f"--install-root={subprocess_path(layout.root)}",
         ]
     ]
+
+
+def test_detached_handoff_drops_completed_crash_supervision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A new stable launcher must not inherit a partial prior-run contract."""
+
+    crash_names = (
+        CRASH_RUN_ID_ENV,
+        CRASH_RUN_TOKEN_ENV,
+        CRASH_INCIDENT_ROOT_ENV,
+        CRASH_EXIT_INTENT_PATH_ENV,
+        CRASH_EXIT_RECEIPT_PATH_ENV,
+        CRASHPAD_DATABASE_ENV,
+        CRASHPAD_HANDLER_ENV,
+        CRASHPAD_CLIENT_LIBRARY_ENV,
+    )
+    for name in crash_names:
+        monkeypatch.setenv(name, f"inherited-{name}")
+    monkeypatch.setenv("SUGAR_SUBSTITUTE_UNRELATED", "preserved")
+    captured: dict[str, object] = {}
+
+    def _start_detached(command: object, **options: object) -> None:
+        """Capture the independent handoff environment."""
+
+        captured["command"] = command
+        captured.update(options)
+
+    monkeypatch.setattr(process, "start_detached", _start_detached)
+
+    process.start_detached_handoff(["SugarSubstitute.exe"])
+
+    environment = captured["environment"]
+    assert isinstance(environment, dict)
+    assert environment["SUGAR_SUBSTITUTE_UNRELATED"] == "preserved"
+    assert set(crash_names).isdisjoint(environment)
+    assert (
+        captured["startup_timeout_seconds"] == process.HANDOFF_STARTUP_TIMEOUT_SECONDS
+    )

--- a/tests/launcher/crash_supervisor/test_launcher_ui_supervision.py
+++ b/tests/launcher/crash_supervisor/test_launcher_ui_supervision.py
@@ -29,6 +29,7 @@ from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from launcher.sugarsubstitute_launcher.launcher_ui_supervision import (
     supervise_launcher_window,
 )
+from launcher.sugarsubstitute_launcher.platforms import WINDOWS_X64
 
 
 class RecordingSupervisor:
@@ -92,3 +93,67 @@ def test_setup_window_relaunches_as_supervised_source_child(
     assert "--handoff-geometry=10,20,1200,800" in command
     assert "--manifest-url=https://example.invalid/manifest.json" in command
     assert "--locale=ja" in command
+
+
+def test_frozen_standalone_setup_relaunches_its_single_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A downloaded one-file setup must not require an adjacent UI executable."""
+
+    setup_executable = tmp_path / "downloads" / "renamed-installer.exe"
+    layout = InstallLayout.from_root(
+        tmp_path / "SugarSubstitute",
+        target=WINDOWS_X64,
+    )
+    supervisor = RecordingSupervisor()
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(setup_executable))
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path / "_MEI1234"), raising=False)
+
+    supervise_launcher_window(
+        layout=layout,
+        arguments=parse_launcher_args([]),
+        repair=False,
+        supervisor=supervisor,
+    )
+
+    _call_layout, command, _environment = supervisor.calls[0]
+    assert command[0] == str(setup_executable)
+    assert "--launcher-ui-child" in command
+
+
+def test_frozen_installed_launcher_uses_its_ui_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The installed supervisor must delegate Qt ownership to its UI executable."""
+
+    layout = InstallLayout.from_root(
+        tmp_path / "SugarSubstitute",
+        target=WINDOWS_X64,
+    )
+    installed_launcher = layout.executable_path
+    ui_executable = installed_launcher.with_name("LauncherUi.exe")
+    layout.launcher_support_path.mkdir(parents=True)
+    ui_executable.write_bytes(b"launcher UI")
+    supervisor = RecordingSupervisor()
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(installed_launcher))
+    monkeypatch.setattr(
+        sys,
+        "_MEIPASS",
+        str(layout.launcher_support_path),
+        raising=False,
+    )
+
+    supervise_launcher_window(
+        layout=layout,
+        arguments=parse_launcher_args([]),
+        repair=False,
+        supervisor=supervisor,
+    )
+
+    _call_layout, command, _environment = supervisor.calls[0]
+    assert command[0] == str(ui_executable)
+    assert "--launcher-ui-child" in command

--- a/tests/launcher/test_localized_text.py
+++ b/tests/launcher/test_localized_text.py
@@ -14,25 +14,24 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Render fixed installer copy through one stable Qt translation context."""
+"""Verify launcher copy remains available across UI and supervisor processes."""
 
 from __future__ import annotations
 
-_CONTEXT = "LauncherMainWindow"
+import sys
+
+import pytest
+
+from launcher.sugarsubstitute_launcher.localized_text import launcher_text
 
 
-def launcher_text(source_text: str, *arguments: object) -> str:
-    """Translate fixed copy and substitute ordered `%1`-style arguments."""
+def test_launcher_text_falls_back_without_qt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The UI-free stable supervisor should retain English copy and arguments."""
 
-    try:
-        from PySide6.QtCore import QCoreApplication
-    except ImportError:
-        translated = source_text
-    else:
-        translated = QCoreApplication.translate(_CONTEXT, source_text)
-    for index, argument in enumerate(arguments, start=1):
-        translated = translated.replace(f"%{index}", str(argument))
-    return translated
+    monkeypatch.setitem(sys.modules, "PySide6.QtCore", None)
 
-
-__all__ = ["launcher_text"]
+    assert launcher_text("Installed version: %1", "1.2.3") == (
+        "Installed version: 1.2.3"
+    )

--- a/tests/qualification/installer/test_current_ui.py
+++ b/tests/qualification/installer/test_current_ui.py
@@ -30,6 +30,7 @@ import pytest
 from launcher.sugarsubstitute_launcher.ui.installer_qualification import (
     InstallerQualificationDriver,
 )
+from launcher.sugarsubstitute_launcher.ui.experience_pages import ModelInterestPage
 from sugarsubstitute_shared.installer_qualification import (
     InstallerQualificationPlan,
 )
@@ -43,6 +44,7 @@ from tools.ci.installer_ui_qualification import (
     run_current_installer_ui,
 )
 from tools.ci.verify_installer_lifecycle import verify_clean_install
+from tests.launcher.support import launcher_test_application
 
 
 def test_qualification_event_sequence_requires_real_ui_actions(tmp_path: Path) -> None:
@@ -133,6 +135,46 @@ def test_installer_qualification_fails_fast_when_runtime_setup_fails(
         )
         == "drive_onboarding"
     )
+
+
+def test_installer_qualification_skips_visible_optional_model_setup(
+    tmp_path: Path,
+) -> None:
+    """Qualification should click the production Skip action before runtime setup."""
+
+    application = launcher_test_application()
+    page = ModelInterestPage()
+    skipped: list[bool] = []
+    page.skip_requested.connect(lambda: skipped.append(True))
+    page.show()
+    application.processEvents()
+    plan = InstallerQualificationPlan(
+        token="qualification-token",
+        install_root=(tmp_path / "install").resolve(),
+        endpoint_host="127.0.0.1",
+        endpoint_port=8188,
+        event_log_path=(tmp_path / "events.jsonl").resolve(),
+        timeout_seconds=45.0,
+    )
+    driver = cast(
+        InstallerQualificationDriver,
+        SimpleNamespace(
+            _window=SimpleNamespace(
+                view=SimpleNamespace(model_interest_page=page),
+            ),
+            _plan=plan,
+        ),
+    )
+
+    InstallerQualificationDriver._skip_optional_model_setup(driver)
+    application.processEvents()
+
+    assert skipped == [True]
+    event = json.loads(plan.event_log_path.read_text(encoding="utf-8"))
+    assert event["event"] == "installer.model_setup.skipped"
+    page.close()
+    page.deleteLater()
+    application.processEvents()
 
 
 def test_qualification_event_sequence_rejects_missing_install_click(

--- a/tests/qualification/release/workflow/test_qualification.py
+++ b/tests/qualification/release/workflow/test_qualification.py
@@ -301,6 +301,7 @@ def test_focused_release_qualification_cannot_skip_publishing_gates() -> None:
     assert "github.event_name != 'workflow_dispatch'" in prepare_call
     assert "github.event.inputs.dry_run != 'true'" in prepare_call
     assert "github.event.inputs.qualification_scope == 'full'" in prepare_call
+    assert "github.ref_name == 'canary' && 'canary-fast'" not in prepare_call
     assert "if: inputs.run_tests" in prepublication_text
     assert (
         "candidate_run_id: ${{ needs.stage-candidate.outputs.candidate_run_id }}"

--- a/tests/qualification/release/workflow/test_release_train.py
+++ b/tests/qualification/release/workflow/test_release_train.py
@@ -51,7 +51,7 @@ def test_canary_isolated_release_train_contract() -> None:
     assert 'channel === "canary" ? "canary-latest"' in prepare_assets_text
     assert '"canary-v$version"' not in publication_text
     assert "release-qualification.yml" in release_text
-    assert "'canary-fast'" in release_text
+    assert "          - canary-fast" in release_text
     assert "Upload private non-release candidate channel" in candidate_text
     assert "validate-candidate-artifact:" in (
         PROJECT_ROOT / ".github" / "workflows" / "release-qualification.yml"


### PR DESCRIPTION
## Outcome
- correct one-file setup launcher supervision and installed handoff state
- automate the optional model page during installer qualification
- keep stable supervision UI-free
- restore full Windows, Linux, and macOS qualification for canary releases

## Local verification
- packaged Windows clean-install lifecycle qualification passed
- full parallel test suite passed
- isolated suite: 88 modules / 504 tests passed
- serial suite passed
- Ruff, strict mypy, architecture, and test-governance checks passed

This PR targets canary only. It does not modify or release main.