### PR TITLE
fix(installer): qualify Canary installs and historical updates

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: "Exact semantic version embedded into every native artifact"
+        description: "Exact release version embedded into every native artifact"
         required: true
         type: string
       channel:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       version:
-        description: "Exact semantic version embedded into the staged channel"
+        description: "Exact release version embedded into the staged channel"
         required: true
         type: string
       channel:

--- a/.github/workflows/release-current-install-qualification.yml
+++ b/.github/workflows/release-current-install-qualification.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       candidate_version:
-        description: "Exact semantic version contained in candidate assets"
+        description: "Exact release version contained in candidate assets"
         required: true
         type: string
       candidate_tag:

--- a/.github/workflows/release-prepublication.yml
+++ b/.github/workflows/release-prepublication.yml
@@ -95,7 +95,7 @@ jobs:
     uses: ./.github/workflows/tests.yml
 
   determine-version:
-    name: Resolve semantic release version
+    name: Resolve release version
     needs: tests
     if: >-
       always() && (

--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       candidate_version:
-        description: "Exact qualified semantic version"
+        description: "Exact qualified release version"
         required: true
         type: string
       candidate_channel:
@@ -66,14 +66,14 @@ jobs:
           node -e "const fs=require('node:fs'); const payload=JSON.parse(fs.readFileSync('.local-release-channel/manifest.json','utf8')); if(payload.channel!=='stable'||payload.version!==process.env.CANDIDATE_VERSION) process.exit(1)"
           (cd .local-release-channel && sha256sum --check checksums.txt)
 
-      - name: Re-resolve semantic release version after qualification
+      - name: Re-resolve release version after qualification
         if: github.ref_name == 'main'
         id: final-release-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/resolve-next-release-version.mjs
 
-      - name: Require semantic release version stability
+      - name: Require release version stability
         if: github.ref_name == 'main'
         env:
           CANDIDATE_VERSION: ${{ inputs.candidate_version }}
@@ -135,7 +135,7 @@ jobs:
           set -euo pipefail
           channel_dir="build/canary-channel"
           readback_dir="build/canary-readback"
-          canary_release_title="Canary ${CANDIDATE_VERSION/-canary./.}"
+          canary_release_title="Canary $CANDIDATE_VERSION"
           mkdir -p "$readback_dir"
           node -e "const fs=require('node:fs'); const payload=JSON.parse(fs.readFileSync('$channel_dir/manifest.json','utf8')); if(payload.channel!=='canary'||payload.version!==process.env.CANDIDATE_VERSION) process.exit(1)"
           (cd "$channel_dir" && sha256sum --check checksums.txt)

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       candidate_version:
-        description: "Exact semantic version already staged for qualification"
+        description: "Exact release version already staged for qualification"
         required: true
         type: string
       candidate_tag:
@@ -45,7 +45,7 @@ on:
   workflow_dispatch:
     inputs:
       candidate_version:
-        description: "Exact semantic version already staged for qualification"
+        description: "Exact release version already staged for qualification"
         required: true
         type: string
       candidate_tag:

--- a/.github/workflows/release-update-qualification.yml
+++ b/.github/workflows/release-update-qualification.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       candidate_version:
-        description: "Exact semantic version contained in candidate assets"
+        description: "Exact release version contained in candidate assets"
         required: true
         type: string
       candidate_tag:

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -19,7 +19,7 @@ on:
         type: string
     outputs:
       version:
-        description: "Resolved semantic release version"
+        description: "Resolved release version"
         value: ${{ jobs.resolve.outputs.version }}
       should_release:
         description: "Whether the source contains a releasable change"
@@ -39,7 +39,7 @@ env:
 
 jobs:
   resolve:
-    name: Resolve semantic release version
+    name: Resolve release version
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.release-version.outputs.version }}

--- a/launcher/sugarsubstitute_launcher/process.py
+++ b/launcher/sugarsubstitute_launcher/process.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from sugarsubstitute_shared.application_launch_context import (
     application_launch_install_root,
+    explicit_application_launch_install_root,
 )
 from sugarsubstitute_shared.external_path_failure import external_long_path_error
 from sugarsubstitute_shared.crash_reporting.protocol import (
@@ -215,6 +216,12 @@ def _command_working_directory(command: Sequence[str]) -> Path | None:
 def _app_startup_log_path(command: Sequence[str]) -> Path:
     """Resolve the startup log path from an installed app launch command."""
 
+    explicit_install_root = explicit_application_launch_install_root(command)
+    if explicit_install_root is not None:
+        return (
+            InstallLayout.from_root(explicit_install_root).logs_dir
+            / APP_STARTUP_LOG_NAME
+        )
     if len(command) >= 2:
         entrypoint = operational_path(command[1])
         if entrypoint.name.lower() == "main.py":

--- a/scripts/canary-release-version.cjs
+++ b/scripts/canary-release-version.cjs
@@ -17,11 +17,11 @@
 const CORE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
 /**
- * Add a monotonically increasing Canary identifier to the next Stable version.
+ * Add a legacy-launcher-compatible Canary identifier to the next Stable version.
  *
  * @param {string} nextStableVersion Exact semantic version expected for Stable.
  * @param {string} runNumber Positive GitHub Actions run number.
- * @returns {string} Canary semantic prerelease version.
+ * @returns {string} Dotted numeric Canary release version.
  */
 function createCanaryVersion(nextStableVersion, runNumber) {
   const normalizedVersion = String(nextStableVersion).trim();
@@ -32,7 +32,7 @@ function createCanaryVersion(nextStableVersion, runNumber) {
   if (!/^[1-9]\d*$/.test(normalizedRunNumber)) {
     throw new Error(`Expected a positive Canary run number: ${runNumber}`);
   }
-  return `${normalizedVersion}-canary.${normalizedRunNumber}`;
+  return `${normalizedVersion}.${normalizedRunNumber}`;
 }
 
 /**

--- a/scripts/release-notes-preamble.cjs
+++ b/scripts/release-notes-preamble.cjs
@@ -22,7 +22,7 @@ const DEFAULT_REPOSITORY = "Artificial-Sweetener/SugarSubstitute";
  * Build the installer guidance prepended to every GitHub Release description.
  *
  * @param {string} repository GitHub repository in owner/name form.
- * @param {string} version Semantic release version without a tag prefix.
+ * @param {string} version Release version without a tag prefix.
  * @param {string} channel Published release channel.
  * @returns {string} Markdown release guidance.
  */
@@ -97,13 +97,13 @@ function validateRepository(repository) {
 /**
  * Reject version values that cannot safely form the release tag and asset URLs.
  *
- * @param {string} version Candidate semantic version.
+ * @param {string} version Candidate release version.
  * @returns {string} Validated version without a tag prefix.
  */
 function validateVersion(version) {
   const normalized = String(version).trim().replace(/^v/, "");
-  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(normalized)) {
-    throw new Error(`Expected a semantic release version: ${version}`);
+  if (!/^\d+\.\d+\.\d+(?:\.\d+)*(?:-[0-9A-Za-z.-]+)?$/.test(normalized)) {
+    throw new Error(`Expected a release version: ${version}`);
   }
   return normalized;
 }

--- a/sugarsubstitute_shared/application_launch_context.py
+++ b/sugarsubstitute_shared/application_launch_context.py
@@ -22,12 +22,10 @@ from collections.abc import Sequence
 from pathlib import Path
 
 
-def application_launch_install_root(
+def explicit_application_launch_install_root(
     argv: Sequence[str],
-    *,
-    app_root: Path,
-) -> Path:
-    """Resolve the installation root before application bootstrap starts."""
+) -> Path | None:
+    """Resolve the explicit installation root carried by launch arguments."""
 
     prefix = "--install-root="
     for raw_argument in argv:
@@ -35,7 +33,20 @@ def application_launch_install_root(
             raw_path = raw_argument[len(prefix) :].strip()
             if raw_path:
                 return Path(raw_path).expanduser().resolve()
-    return app_root.resolve()
+    return None
 
 
-__all__ = ["application_launch_install_root"]
+def application_launch_install_root(
+    argv: Sequence[str],
+    *,
+    app_root: Path,
+) -> Path:
+    """Resolve the installation root before application bootstrap starts."""
+
+    return explicit_application_launch_install_root(argv) or app_root.resolve()
+
+
+__all__ = [
+    "application_launch_install_root",
+    "explicit_application_launch_install_root",
+]

--- a/tests/launcher/installation_workflow/first_run/test_launcher_installation.py
+++ b/tests/launcher/installation_workflow/first_run/test_launcher_installation.py
@@ -129,6 +129,23 @@ def test_start_detached_reports_immediate_app_startup_exit(tmp_path: Path) -> No
     assert "RuntimeError: boom" in startup_log.read_text(encoding="utf-8")
 
 
+def test_start_detached_uses_install_logs_for_setup_child(tmp_path: Path) -> None:
+    """A setup child writes diagnostics outside its read-only launch location."""
+
+    layout = InstallLayout.from_root(tmp_path / "install")
+    setup_child = tmp_path / "mounted-image" / "setup_child.py"
+    write_file(setup_child, "raise RuntimeError('setup boom')\n")
+
+    with pytest.raises(ProcessStartupError, match="exited before the setup window"):
+        start_detached(
+            [sys.executable, str(setup_child), f"--install-root={layout.root}"]
+        )
+
+    startup_log = layout.logs_dir / "app-startup.log"
+    assert startup_log.is_file()
+    assert "RuntimeError: setup boom" in startup_log.read_text(encoding="utf-8")
+
+
 def test_child_process_environment_removes_pyinstaller_runtime_state(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/qualification/release/payload/test_builder.py
+++ b/tests/qualification/release/payload/test_builder.py
@@ -60,19 +60,19 @@ def test_release_builder_rejects_launcher_unsafe_version(tmp_path: Path) -> None
         )
 
 
-def test_release_builder_accepts_semantic_prerelease_version(tmp_path: Path) -> None:
-    """Canary semantic versions must remain safe for release payload paths."""
+def test_release_builder_accepts_dotted_numeric_canary_version(tmp_path: Path) -> None:
+    """Canary versions remain safe for legacy launcher and payload paths."""
 
     repo_root = _write_fixture_repo(tmp_path)
 
     result = build_local_release_channel(
         repo_root=repo_root,
         output_dir=repo_root / ".local-release-channel",
-        version="0.21.0-canary.42",
+        version="0.21.0.42",
     )
 
     manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
-    assert manifest["version"] == "0.21.0-canary.42"
+    assert manifest["version"] == "0.21.0.42"
 
 
 def test_release_payload_cli_runs_by_file_path(tmp_path: Path) -> None:

--- a/tests/qualification/release/workflow/test_publication_security.py
+++ b/tests/qualification/release/workflow/test_publication_security.py
@@ -82,7 +82,7 @@ def test_release_notes_generator_rejects_unsafe_versions(tmp_path: Path) -> None
     )
 
     assert result.returncode != 0
-    assert "Expected a semantic release version" in result.stderr
+    assert "Expected a release version" in result.stderr
     assert not output_path.exists()
 
 

--- a/tests/qualification/release/workflow/test_release_train.py
+++ b/tests/qualification/release/workflow/test_release_train.py
@@ -65,10 +65,7 @@ def test_canary_isolated_release_train_contract() -> None:
     assert "git/refs/tags/canary-latest" in publication_text
     assert 'git/refs/tags/canary"' not in publication_text
     assert "--clobber" in publication_text
-    assert 'canary_release_title="Canary ${CANDIDATE_VERSION/-canary./.}"' in (
-        publication_text
-    )
-    assert "${CANDIDATE_VERSION/-canary-/.}" not in publication_text
+    assert 'canary_release_title="Canary $CANDIDATE_VERSION"' in publication_text
     assert "github.ref_name == 'main'" in publication_text
     assert "HEAD_BRANCH: ${{ github.head_ref }}" in policy_text
     assert '[ "$HEAD_BRANCH" != "canary" ]' in policy_text
@@ -114,7 +111,7 @@ def test_release_version_script_embeds_canary_channel(tmp_path: Path) -> None:
     javascript = (
         f"import {{ updateReleaseVersions }} from {json.dumps(script_url)}; "
         f"updateReleaseVersions(new URL({json.dumps(root_url)}), "
-        '"0.21.0-canary.42", "canary");'
+        '"0.21.0.42", "canary");'
     )
 
     run_node(
@@ -129,12 +126,12 @@ def test_release_version_script_embeds_canary_channel(tmp_path: Path) -> None:
     ).read_text(encoding="utf-8") == 'RELEASE_CHANNEL = "canary"\n'
     assert (
         json.loads((tmp_path / "package.json").read_text(encoding="utf-8"))["version"]
-        == "0.21.0-canary.42"
+        == "0.21.0.42"
     )
 
 
-def test_canary_version_derives_from_next_stable_release() -> None:
-    """Canary versions should identify their future Stable base and CI build."""
+def test_canary_version_remains_compatible_with_historical_launchers() -> None:
+    """Canary versions identify their Stable base using dotted numeric parts."""
 
     script = """
 const versions = require('./scripts/canary-release-version.cjs');
@@ -154,7 +151,7 @@ process.stdout.write(JSON.stringify({
 
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout) == {
-        "canary": "0.21.0-canary.142",
+        "canary": "0.21.0.142",
         "latest": "v0.20.1",
         "patch": "0.20.2",
         "minor": "0.21.0",
@@ -200,7 +197,7 @@ def test_canary_release_notes_direct_normal_users_to_stable(tmp_path: Path) -> N
             "--repository",
             "Artificial-Sweetener/Substitute-Test",
             "--version",
-            "0.21.0-canary.42",
+            "0.21.0.42",
             "--channel",
             "canary",
             "--output",
@@ -220,4 +217,4 @@ def test_canary_release_notes_direct_normal_users_to_stable(tmp_path: Path) -> N
     assert f"[Download the latest Stable release instead]({stable_url})" in notes
     assert "DO NOT download this Canary build for normal use" in notes
     assert "Canary builds are intended only for testers" in notes
-    assert "releases/download/canary-latest/SugarSubstitute-0.21.0-canary.42" in notes
+    assert "releases/download/canary-latest/SugarSubstitute-0.21.0.42" in notes


### PR DESCRIPTION
## Outcome

- write supervised setup diagnostics into the selected installation instead of a read-only macOS disk image
- emit dotted numeric Canary versions that every published historical launcher can compare
- keep the one-file/one-app public installer contract on every platform
- add regression coverage for setup children launched outside the installed payload and the Canary version contract

## Failures reproduced

- macOS clean install: setup supervision attempted to write app-startup.log inside the mounted DMG
- Windows 0.12.2 update: the legacy launcher rejected 0.23.0-canary.225 and fell back to the old app

## Verification

- focused release, installer, and historical-update tests
- full parallel tests
- all 88 isolated test modules
- serial test module
- Ruff format and lint
- strict mypy
- architecture and test-governance checks