### PR TITLE
fix(installer): recover managed nodepacks when Registry fails

### DIFF
--- a/substitute/application/comfy_nodepacks/core_nodepack_reconciliation_plan.py
+++ b/substitute/application/comfy_nodepacks/core_nodepack_reconciliation_plan.py
@@ -98,6 +98,7 @@ def plan_after_registry_attempt(
     if outcome in {
         RegistryInstallOutcome.VERSION_UNAVAILABLE,
         RegistryInstallOutcome.REGISTRY_UNREACHABLE,
+        RegistryInstallOutcome.FAILED,
     }:
         return CoreNodepackAction.INSTALL_FALLBACK
     return CoreNodepackAction.FAIL

--- a/substitute/infrastructure/comfy/nodepack_registry_installer.py
+++ b/substitute/infrastructure/comfy/nodepack_registry_installer.py
@@ -32,7 +32,7 @@ from substitute.infrastructure.comfy.nodepack_manifest import (
     CLI_INSTALL_TIMEOUT_SECONDS,
     CoreComfyNodepack,
 )
-from substitute.shared.logging.logger import get_logger, log_info
+from substitute.shared.logging.logger import get_logger, log_info, log_warning
 
 LogCallback = Callable[[str], None]
 _LOGGER = get_logger("infrastructure.comfy.nodepack_registry_installer")
@@ -85,10 +85,17 @@ class ComfyNodepackRegistryInstaller:
                 output,
             )
         exit_code, output = process_result
-        return RegistryInstallResult(
-            _classify_registry_result(exit_code=exit_code, output=output),
-            output,
-        )
+        outcome = _classify_registry_result(exit_code=exit_code, output=output)
+        if outcome is RegistryInstallOutcome.FAILED:
+            log_warning(
+                _LOGGER,
+                "Comfy Registry exact install failed",
+                nodepack=nodepack.registry_id,
+                required_version=nodepack.required_version,
+                exit_code=exit_code,
+                output_tail=_bounded_output_tail(output),
+            )
+        return RegistryInstallResult(outcome, output)
 
     @staticmethod
     def _emit(callback: LogCallback | None, message: str) -> None:
@@ -132,6 +139,13 @@ def _classify_registry_result(
     if any(marker in combined for marker in unreachable_markers):
         return RegistryInstallOutcome.REGISTRY_UNREACHABLE
     return RegistryInstallOutcome.FAILED
+
+
+def _bounded_output_tail(output: tuple[str, ...]) -> str:
+    """Return bounded Registry diagnostics suitable for durable failure logs."""
+
+    combined = " | ".join(line.strip() for line in output[-5:] if line.strip())
+    return combined[-2_000:] or "<no output>"
 
 
 __all__ = ["ComfyNodepackRegistryInstaller", "RegistryInstallResult"]

--- a/tests/application/comfy_nodepacks/test_reconciliation_plan.py
+++ b/tests/application/comfy_nodepacks/test_reconciliation_plan.py
@@ -215,7 +215,11 @@ def test_initial_plan_protects_local_work_and_prefers_registry(
             False,
             CoreNodepackAction.INSTALL_FALLBACK,
         ),
-        (RegistryInstallOutcome.FAILED, False, CoreNodepackAction.FAIL),
+        (
+            RegistryInstallOutcome.FAILED,
+            False,
+            CoreNodepackAction.INSTALL_FALLBACK,
+        ),
     ),
 )
 def test_registry_result_requires_disk_evidence_before_completion(
@@ -224,7 +228,7 @@ def test_registry_result_requires_disk_evidence_before_completion(
     matches: bool,
     expected: CoreNodepackAction,
 ) -> None:
-    """Use inspected CNR state as authority and fallback only on availability failures."""
+    """Use inspected CNR state as authority before applying the trusted fallback."""
 
     assert (
         plan_after_registry_attempt(

--- a/tests/infrastructure/comfy/nodepacks/test_reconciler_acquisition.py
+++ b/tests/infrastructure/comfy/nodepacks/test_reconciler_acquisition.py
@@ -208,6 +208,32 @@ def test_fallback_install_is_later_adopted_by_exact_registry_update(
     assert available_registry.calls == [(tmp_path, next_release)]
 
 
+def test_trusted_fallback_repairs_owned_install_after_registry_cli_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Converge an owned stale install when Manager returns an unknown failure."""
+
+    nodepack = CORE_COMFY_NODEPACKS[0]
+    _select_nodepacks(monkeypatch, nodepack)
+    root = tmp_path / nodepack.expected_folder
+    _materialize_nodepack(root, nodepack, version="1.9.0", tracking=True)
+    registry = _RegistryInstaller(RegistryInstallOutcome.FAILED)
+    fallback = _FallbackInstaller()
+    _patch_dependencies(monkeypatch, [], satisfied=True)
+
+    _reconciler(registry=registry, fallback=fallback).ensure(
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
+        refresh_nodepacks=(nodepack.nodepack_id,),
+        on_log=None,
+        env=None,
+    )
+
+    assert registry.calls == [(tmp_path, nodepack)]
+    assert fallback.calls == [(root, nodepack)]
+    assert _project_version(root) == nodepack.required_version
+
+
 def test_queued_registry_update_must_reach_exact_disk_state(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/infrastructure/comfy/nodepacks/test_registry_installer.py
+++ b/tests/infrastructure/comfy/nodepacks/test_registry_installer.py
@@ -200,6 +200,34 @@ def test_missing_manager_cli_is_an_availability_failure(
     assert result.outcome is RegistryInstallOutcome.REGISTRY_UNREACHABLE
 
 
+def test_unknown_registry_failure_is_written_to_durable_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Retain bounded Manager output when an unknown failure needs fallback."""
+
+    monkeypatch.setattr(
+        "substitute.infrastructure.comfy.comfy_manager_runtime.ComfyManagerCommandRunner._module_available",
+        lambda self, module_name: True,
+    )
+    monkeypatch.setattr(
+        "substitute.infrastructure.comfy.comfy_manager_runtime.stream_command_collecting_output",
+        lambda *args, **kwargs: (1, ("first detail", "final manager failure")),
+    )
+
+    result = ComfyNodepackRegistryInstaller().install_exact(
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
+        nodepack=CORE_COMFY_NODEPACKS[0],
+        on_log=None,
+        env={},
+    )
+
+    assert result.outcome is RegistryInstallOutcome.FAILED
+    assert "exit_code=1" in caplog.text
+    assert "output_tail=first detail | final manager failure" in caplog.text
+
+
 def _runtime(workspace: Path, python: Path) -> ComfyManagerRuntime:
     """Build one validated integrated Manager runtime fixture."""
 


### PR DESCRIPTION
## Outcome

Managed installation and historical upgrades now recover Substitute-owned nodepacks from their exact trusted pinned release when Comfy Registry returns an unknown failure after an exact-version request.

The existing safety guards still block dirty checkouts, unmanaged Git checkouts, and unrecognized folders. Unknown Registry failures are retained in durable diagnostics.

## Verification

- Full Ruff format and lint
- Strict mypy across substitute and tests
- Architecture and test governance
- Full parallel test suite
- All isolated test modules
- Serial test suite