### PR TITLE
fix(installer): preserve Windows upgrades across launcher changes

### DIFF
--- a/TEST_WAIVERS.toml
+++ b/TEST_WAIVERS.toml
@@ -1270,3 +1270,29 @@ fingerprint = "sha256:d1de72d9f4de487c84056c8c3a38b3e8fc59d9d6a1682dcea7b6675294
 rationale = "This Windows qualification starts the real native splash in a dedicated headless Qt process and measures external process-request-to-first-paint latency. It directly protects the source and packaged Windows startup contract; macOS and Linux use platform-native qframeless implementations that cannot construct a representative window under a headless Qt backend. Concurrent ordinary-suite load can consume the latency budget independently of splash startup behavior. The test owns a tmp_path evidence directory and an ephemeral authenticated loopback endpoint, so bounded fresh-process isolation preserves the speed, one-surface, and clean-exit assertions without requiring global serialization."
 issue = "chore:SS-TEST-WAIVER-C0277"
 review_by = 2026-12-15
+
+[[waivers]]
+id = "SS-TEST-WAIVER-C0278"
+owner = "Prompt-card native layout contract"
+kind = "classification"
+disposition = "process_isolated"
+rule = "ISOLATED001"
+candidates = ["ISOLATED001|tests/presentation/editor/node_card/prompt_mode/test_card_contract.py|isolated-module"]
+paths = ["tests/presentation/editor/node_card/prompt_mode/test_card_contract.py"]
+fingerprint = "sha256:d89d1855f36f1a66cf5fe8907a5c1efd37a03ae75f1b24a16ada9aead5b27628"
+rationale = "This native Qt module constructs production prompt cards and exercises their live prompt-editor layout and resize contracts. Its narrow-resize contract aborted with a Windows access violation only after prior native Qt work in an ordinary xdist worker, while the complete module passed in five independent fresh processes. It owns no shared file, port, environment, subprocess, or cross-process resource; process isolation is sufficient and global serialization would be inappropriate."
+issue = "chore:SS-TEST-WAIVER-C0278"
+review_by = 2026-12-15
+
+[[waivers]]
+id = "SS-TEST-WAIVER-C0279"
+owner = "Launcher successful-setup Qt contract"
+kind = "classification"
+disposition = "process_isolated"
+rule = "ISOLATED001"
+candidates = ["ISOLATED001|tests/launcher/installation_workflow/test_successful_setup.py|isolated-module"]
+paths = ["tests/launcher/installation_workflow/test_successful_setup.py"]
+fingerprint = "sha256:9ef61b73a29be9205121aa128de08dc7436410488ea6d724f74ca1988e75fc6a"
+rationale = "This native Qt module drives the production launcher installation workflow through automatic runtime setup and app handoff. Its continuation contract aborted with a Linux bus error only after prior native Qt work in an ordinary xdist worker, while the same commit passed the complete Linux fresh job and the module passed in five independent Windows fresh processes. It owns only tmp_path installation state and fake process boundaries; process isolation is sufficient and global serialization would be inappropriate."
+issue = "chore:SS-TEST-WAIVER-C0279"
+review_by = 2026-12-15

--- a/launcher/SugarSubstitute-Windows-x64.spec
+++ b/launcher/SugarSubstitute-Windows-x64.spec
@@ -167,7 +167,7 @@ ui_exe = EXE(
     codesign_identity=None,
     entitlements_file=None,
     icon=str(app_icon_path),
-    contents_directory="launcher-bin",
+    contents_directory=".",
 )
 coll = COLLECT(
     exe,

--- a/launcher/sugarsubstitute_launcher/launcher_ui_supervision.py
+++ b/launcher/sugarsubstitute_launcher/launcher_ui_supervision.py
@@ -126,7 +126,7 @@ def _installed_windows_ui_executable(layout: InstallLayout) -> Path | None:
         return None
     if support_path.resolve() != layout.launcher_support_path.resolve():
         return None
-    return Path(sys.executable).with_name("LauncherUi.exe")
+    return layout.launcher_support_path / "LauncherUi.exe"
 
 
 def _current_native_runtime(layout: InstallLayout) -> tuple[Path, Path]:

--- a/launcher/sugarsubstitute_launcher/repair_handoff.py
+++ b/launcher/sugarsubstitute_launcher/repair_handoff.py
@@ -53,9 +53,11 @@ def launch_prepared_repair_helper(
     request = PreparedRepairRequest.load(request_path)
     target = launcher_bundle_target_for_key(request.target_key)
     source = request.staged_launcher_dir / target.executable_relative_path
-    adjacent_repair = request.staged_launcher_dir / "Repair.exe"
-    if adjacent_repair.is_file():
-        source = adjacent_repair
+    support_repair = (
+        request.staged_launcher_dir / target.support_relative_path / "Repair.exe"
+    )
+    if support_repair.is_file():
+        source = support_repair
     if not source.is_file():
         raise RepairHandoffError(f"Prepared repair helper is missing: {source}")
     helper_dir = request.install_root / ".repair" / "helper" / request.version

--- a/sugarsubstitute_shared/launcher_update/staging.py
+++ b/sugarsubstitute_shared/launcher_update/staging.py
@@ -126,6 +126,15 @@ def validate_staged_bundle(
         raise LauncherBundleValidationError(
             "Launcher bundle is missing its runtime support directory."
         )
+    missing_files = [
+        str(path)
+        for path in target.required_file_relative_paths
+        if not (bundle_dir / path).is_file()
+    ]
+    if missing_files:
+        raise LauncherBundleValidationError(
+            "Launcher bundle is missing required files: " + ", ".join(missing_files)
+        )
     missing_roots = [
         str(path)
         for path in target.replacement_roots

--- a/sugarsubstitute_shared/launcher_update/targets.py
+++ b/sugarsubstitute_shared/launcher_update/targets.py
@@ -32,6 +32,7 @@ class LauncherBundleTarget:
     bundle_root: Path
     executable_relative_path: Path
     support_relative_path: Path
+    required_file_relative_paths: tuple[Path, ...]
     replacement_roots: tuple[Path, ...]
     executable_mode: int | None
 
@@ -41,10 +42,13 @@ WINDOWS_X64_BUNDLE = LauncherBundleTarget(
     bundle_root=Path("."),
     executable_relative_path=Path("SugarSubstitute.exe"),
     support_relative_path=Path("launcher-bin"),
+    required_file_relative_paths=(
+        Path("SugarSubstitute.exe"),
+        Path("launcher-bin") / "LauncherUi.exe",
+        Path("launcher-bin") / "Repair.exe",
+    ),
     replacement_roots=(
         Path("SugarSubstitute.exe"),
-        Path("LauncherUi.exe"),
-        Path("Repair.exe"),
         Path("launcher-bin"),
     ),
     executable_mode=None,
@@ -56,6 +60,9 @@ MACOS_ARM64_BUNDLE = LauncherBundleTarget(
         Path("SugarSubstitute.app") / "Contents" / "MacOS" / "SugarSubstitute"
     ),
     support_relative_path=(Path("SugarSubstitute.app") / "Contents" / "Frameworks"),
+    required_file_relative_paths=(
+        Path("SugarSubstitute.app") / "Contents" / "MacOS" / "SugarSubstitute",
+    ),
     replacement_roots=(Path("SugarSubstitute.app"),),
     executable_mode=0o755,
 )
@@ -64,6 +71,7 @@ LINUX_X64_BUNDLE = LauncherBundleTarget(
     bundle_root=Path("."),
     executable_relative_path=Path("SugarSubstitute"),
     support_relative_path=Path("launcher-bin"),
+    required_file_relative_paths=(Path("SugarSubstitute"),),
     replacement_roots=(Path("SugarSubstitute"), Path("launcher-bin")),
     executable_mode=0o755,
 )

--- a/tests/ci_test_policy.py
+++ b/tests/ci_test_policy.py
@@ -303,6 +303,12 @@ ISOLATED_TEST_MODULES = frozenset(
         "tests/presentation/editor/prompt_editor/projection/paint_cache/test_cache.py",
         "tests/shared/presentation/localization/test_qfluent_font_adapter.py",
         "tests/presentation/widgets/qfluent_menu_renderer/test_renderer.py",
+        # This real prompt-card layout owner is stable in a fresh native Qt
+        # process but can abort after unrelated Qt work in one reused worker.
+        "tests/presentation/editor/node_card/prompt_mode/test_card_contract.py",
+        # This launcher setup owner is stable in a fresh native Qt process but
+        # can abort after unrelated Qt work in one reused worker.
+        "tests/launcher/installation_workflow/test_successful_setup.py",
         # This real mouse-interaction owner is stable in a fresh native Qt
         # process but can lose delivery after unrelated Qt work in one worker.
         "tests/presentation/cube_picker/test_staging_removal.py",

--- a/tests/launcher/crash_supervisor/test_launcher_ui_supervision.py
+++ b/tests/launcher/crash_supervisor/test_launcher_ui_supervision.py
@@ -134,7 +134,7 @@ def test_frozen_installed_launcher_uses_its_ui_executable(
         target=WINDOWS_X64,
     )
     installed_launcher = layout.executable_path
-    ui_executable = installed_launcher.with_name("LauncherUi.exe")
+    ui_executable = layout.launcher_support_path / "LauncherUi.exe"
     layout.launcher_support_path.mkdir(parents=True)
     ui_executable.write_bytes(b"launcher UI")
     supervisor = RecordingSupervisor()

--- a/tests/launcher/installation_workflow/first_run/support.py
+++ b/tests/launcher/installation_workflow/first_run/support.py
@@ -100,8 +100,8 @@ def write_valid_launcher_bundle_zip(path: Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(path, "w") as archive:
         archive.writestr("SugarSubstitute.exe", b"launcher")
-        archive.writestr("LauncherUi.exe", b"launcher UI")
-        archive.writestr("Repair.exe", b"repair launcher")
+        archive.writestr("launcher-bin/LauncherUi.exe", b"launcher UI")
+        archive.writestr("launcher-bin/Repair.exe", b"repair launcher")
         archive.writestr("launcher-bin/python312.dll", b"dll")
     return path
 

--- a/tests/launcher/installation_workflow/first_run/test_launcher_installation.py
+++ b/tests/launcher/installation_workflow/first_run/test_launcher_installation.py
@@ -71,7 +71,9 @@ def test_first_run_installs_launcher_bundle_and_builds_continue_command(
     )
 
     assert result.layout.executable_path.read_bytes() == b"launcher"
-    assert (result.layout.root / "Repair.exe").read_bytes() == b"repair launcher"
+    assert (
+        result.layout.launcher_support_path / "Repair.exe"
+    ).read_bytes() == b"repair launcher"
     assert (
         result.layout.root / "launcher-bin" / "python312.dll"
     ).read_bytes() == b"dll"

--- a/tests/launcher/repair/test_execution_service.py
+++ b/tests/launcher/repair/test_execution_service.py
@@ -154,9 +154,9 @@ def _write_launcher(path: Path) -> None:
 
     path.mkdir(parents=True)
     (path / "SugarSubstitute.exe").write_bytes(b"new-launcher")
-    (path / "LauncherUi.exe").write_bytes(b"new-launcher-ui")
-    (path / "Repair.exe").write_bytes(b"new-repair")
     (path / "launcher-bin").mkdir()
+    (path / "launcher-bin" / "LauncherUi.exe").write_bytes(b"new-launcher-ui")
+    (path / "launcher-bin" / "Repair.exe").write_bytes(b"new-repair")
     (path / "launcher-bin" / "runtime.dll").write_bytes(b"new-support")
 
 
@@ -194,9 +194,9 @@ def _write_old_install(layout: InstallLayout) -> None:
     layout.runtime_python.write_bytes(b"old-python")
     layout.executable_path.parent.mkdir(parents=True, exist_ok=True)
     layout.executable_path.write_bytes(b"old-launcher")
-    (layout.root / "LauncherUi.exe").write_bytes(b"old-launcher-ui")
-    (layout.root / "Repair.exe").write_bytes(b"old-repair")
     layout.launcher_support_path.mkdir()
+    (layout.launcher_support_path / "LauncherUi.exe").write_bytes(b"old-launcher-ui")
+    (layout.launcher_support_path / "Repair.exe").write_bytes(b"old-repair")
     (layout.launcher_support_path / "runtime.dll").write_bytes(b"old-support")
     protected = (
         layout.user_dir / "projects" / "work.json",
@@ -236,8 +236,10 @@ def test_execution_commits_exact_version_and_preserves_all_user_comfy_data(
     ) == '__version__ = "1.2.3"\n'
     assert layout.runtime_python.read_bytes() == b"candidate-python"
     assert layout.executable_path.read_bytes() == b"new-launcher"
-    assert (layout.root / "LauncherUi.exe").read_bytes() == b"new-launcher-ui"
-    assert (layout.root / "Repair.exe").read_bytes() == b"new-repair"
+    assert (
+        layout.launcher_support_path / "LauncherUi.exe"
+    ).read_bytes() == b"new-launcher-ui"
+    assert (layout.launcher_support_path / "Repair.exe").read_bytes() == b"new-repair"
     assert {path: path.read_bytes() for path in protected_paths} == before
 
 
@@ -282,8 +284,10 @@ def test_execution_rolls_back_every_component_after_final_validation_failure(
     ) == '__version__ = "0.9.0"\n'
     assert layout.runtime_python.read_bytes() == b"old-python"
     assert layout.executable_path.read_bytes() == b"old-launcher"
-    assert (layout.root / "LauncherUi.exe").read_bytes() == b"old-launcher-ui"
-    assert (layout.root / "Repair.exe").read_bytes() == b"old-repair"
+    assert (
+        layout.launcher_support_path / "LauncherUi.exe"
+    ).read_bytes() == b"old-launcher-ui"
+    assert (layout.launcher_support_path / "Repair.exe").read_bytes() == b"old-repair"
     assert (layout.launcher_support_path / "runtime.dll").read_bytes() == b"old-support"
 
 

--- a/tests/launcher/repair/test_handoff.py
+++ b/tests/launcher/repair/test_handoff.py
@@ -40,8 +40,8 @@ def test_handoff_copies_verified_repair_exe_and_binds_live_caller(
     app = staging / "app"
     launcher = staging / "launcher"
     app.mkdir(parents=True)
-    launcher.mkdir()
-    (launcher / "Repair.exe").write_bytes(b"one-file-helper")
+    (launcher / "launcher-bin").mkdir(parents=True)
+    (launcher / "launcher-bin" / "Repair.exe").write_bytes(b"one-file-helper")
     request = PreparedRepairRequest(
         install_root=root,
         scope=RepairScope.APPLICATION,

--- a/tests/launcher/update_activation/transaction/support.py
+++ b/tests/launcher/update_activation/transaction/support.py
@@ -34,9 +34,11 @@ def _write_installed_layout(root: Path) -> Path:
 
     root.mkdir(parents=True)
     (root / "SugarSubstitute.exe").write_text("old launcher", encoding="utf-8")
-    (root / "LauncherUi.exe").write_text("old launcher UI", encoding="utf-8")
-    (root / "Repair.exe").write_text("old repair", encoding="utf-8")
     (root / "launcher-bin").mkdir()
+    (root / "launcher-bin" / "LauncherUi.exe").write_text(
+        "old launcher UI", encoding="utf-8"
+    )
+    (root / "launcher-bin" / "Repair.exe").write_text("old repair", encoding="utf-8")
     (root / "launcher-bin" / "runtime.txt").write_text("old", encoding="utf-8")
     for relative_path in (
         "app/preserve.txt",
@@ -78,8 +80,8 @@ def _write_bundle(path: Path, *, marker: str) -> Path:
 
     with zipfile.ZipFile(path, "w") as bundle:
         bundle.writestr("SugarSubstitute.exe", marker)
-        bundle.writestr("LauncherUi.exe", f"{marker} UI")
-        bundle.writestr("Repair.exe", f"{marker} repair")
+        bundle.writestr("launcher-bin/LauncherUi.exe", f"{marker} UI")
+        bundle.writestr("launcher-bin/Repair.exe", f"{marker} repair")
         bundle.writestr("launcher-bin/runtime.txt", "new")
     return path
 
@@ -89,9 +91,13 @@ def _write_bundle_tree(path: Path, *, marker: str) -> None:
 
     path.mkdir(parents=True)
     (path / "SugarSubstitute.exe").write_text(marker, encoding="utf-8")
-    (path / "LauncherUi.exe").write_text(f"{marker} UI", encoding="utf-8")
-    (path / "Repair.exe").write_text(f"{marker} repair", encoding="utf-8")
     (path / "launcher-bin").mkdir()
+    (path / "launcher-bin" / "LauncherUi.exe").write_text(
+        f"{marker} UI", encoding="utf-8"
+    )
+    (path / "launcher-bin" / "Repair.exe").write_text(
+        f"{marker} repair", encoding="utf-8"
+    )
     (path / "launcher-bin" / "runtime.txt").write_text("new", encoding="utf-8")
 
 

--- a/tests/launcher/update_activation/transaction/test_promotion_rollback.py
+++ b/tests/launcher/update_activation/transaction/test_promotion_rollback.py
@@ -51,7 +51,9 @@ def test_transaction_replaces_only_launcher_and_preserves_install_data(
     LauncherUpdateTransaction(wait_timeout_seconds=0).apply(request_path=request_path)
 
     assert (install_root / "SugarSubstitute.exe").read_text() == "new launcher"
-    assert (install_root / "LauncherUi.exe").read_text() == "new launcher UI"
+    assert (
+        install_root / "launcher-bin" / "LauncherUi.exe"
+    ).read_text() == "new launcher UI"
     assert (install_root / "launcher-bin" / "runtime.txt").read_text() == "new"
     for relative_path in (
         "app/preserve.txt",
@@ -100,7 +102,9 @@ def test_transaction_rolls_back_both_bundle_roots_on_copy_failure(
         )
 
     assert (install_root / "SugarSubstitute.exe").read_text() == "old launcher"
-    assert (install_root / "LauncherUi.exe").read_text() == "old launcher UI"
+    assert (
+        install_root / "launcher-bin" / "LauncherUi.exe"
+    ).read_text() == "old launcher UI"
     assert (install_root / "launcher-bin" / "runtime.txt").read_text() == "old"
 
 
@@ -121,15 +125,14 @@ def test_transaction_recovers_interrupted_backup_before_retry(
     backup_root = update_root / "backup"
     backup_root.mkdir(parents=True)
     (install_root / "SugarSubstitute.exe").replace(backup_root / "SugarSubstitute.exe")
-    (install_root / "LauncherUi.exe").replace(backup_root / "LauncherUi.exe")
     (install_root / "launcher-bin").replace(backup_root / "launcher-bin")
     (install_root / "SugarSubstitute.exe").write_text(
         "interrupted partial", encoding="utf-8"
     )
-    (install_root / "LauncherUi.exe").write_text(
+    (install_root / "launcher-bin").mkdir()
+    (install_root / "launcher-bin" / "LauncherUi.exe").write_text(
         "interrupted partial UI", encoding="utf-8"
     )
-    (install_root / "launcher-bin").mkdir()
     (install_root / "launcher-bin" / "runtime.txt").write_text(
         "interrupted partial", encoding="utf-8"
     )
@@ -153,7 +156,9 @@ def test_transaction_recovers_interrupted_backup_before_retry(
         )
 
     assert (install_root / "SugarSubstitute.exe").read_text() == "old launcher"
-    assert (install_root / "LauncherUi.exe").read_text() == "old launcher UI"
+    assert (
+        install_root / "launcher-bin" / "LauncherUi.exe"
+    ).read_text() == "old launcher UI"
     assert (install_root / "launcher-bin" / "runtime.txt").read_text() == "old"
 
 

--- a/tests/launcher/update_activation/transaction/test_staging_validation.py
+++ b/tests/launcher/update_activation/transaction/test_staging_validation.py
@@ -61,7 +61,9 @@ def test_stager_verifies_and_persists_complete_bundle(tmp_path: Path) -> None:
     assert request.install_root == install_root.resolve()
     assert request.version == "0.11.0"
     assert (request.staged_bundle_dir / "SugarSubstitute.exe").read_text() == "new"
-    assert (request.staged_bundle_dir / "LauncherUi.exe").read_text() == "new UI"
+    assert (
+        request.staged_bundle_dir / "launcher-bin" / "LauncherUi.exe"
+    ).read_text() == "new UI"
     assert (request.staged_bundle_dir / "launcher-bin" / "runtime.txt").is_file()
 
 

--- a/tests/presentation/canvas/output/host/test_floating_grid_reflow.py
+++ b/tests/presentation/canvas/output/host/test_floating_grid_reflow.py
@@ -72,7 +72,10 @@ def test_floating_and_docked_hosts_choose_same_physical_grid_topology(
         window.resize(1000, 500)
         window.show()
         canvas.workspace.resize(1000, 500)
-        harness.wait_until(lambda: _matches_grid(harness.fingerprint(), docked))
+        harness.wait_until(
+            lambda: _matches_grid(harness.fingerprint(), docked),
+            timeout_ms=5000,
+        )
         floating = harness.fingerprint()
 
         assert _topology(floating) == _topology(docked)

--- a/tests/qualification/release/payload/test_builder.py
+++ b/tests/qualification/release/payload/test_builder.py
@@ -239,8 +239,13 @@ def test_local_release_channel_writes_optional_launcher_bundle_asset(
     )
     with zipfile.ZipFile(launcher_zip) as archive:
         assert "SugarSubstitute.exe" in archive.namelist()
-        assert "LauncherUi.exe" in archive.namelist()
+        assert "launcher-bin/LauncherUi.exe" in archive.namelist()
+        assert "launcher-bin/Repair.exe" in archive.namelist()
         assert "launcher-bin/python312.dll" in archive.namelist()
+        assert {name.split("/", maxsplit=1)[0] for name in archive.namelist()} == {
+            "SugarSubstitute.exe",
+            "launcher-bin",
+        }
     assert result.installer_assets["windows_x64_exe"].filename == installer_exe.name
     assert installer_exe.read_text(encoding="utf-8") == "setup"
     assert macos_launcher["filename"] == (

--- a/tests/qualification/windows/launcher/test_update_transaction_long_paths.py
+++ b/tests/qualification/windows/launcher/test_update_transaction_long_paths.py
@@ -51,12 +51,14 @@ def test_transaction_promotes_launcher_inside_long_install_root(
             "old launcher",
             encoding="utf-8",
         )
-        (install_root / "LauncherUi.exe").write_text(
+        (install_root / "launcher-bin").mkdir()
+        (install_root / "launcher-bin" / "LauncherUi.exe").write_text(
             "old launcher UI",
             encoding="utf-8",
         )
-        (install_root / "Repair.exe").write_text("old repair", encoding="utf-8")
-        (install_root / "launcher-bin").mkdir()
+        (install_root / "launcher-bin" / "Repair.exe").write_text(
+            "old repair", encoding="utf-8"
+        )
         (install_root / "launcher-bin" / "runtime.txt").write_text(
             "old runtime",
             encoding="utf-8",
@@ -66,12 +68,14 @@ def test_transaction_promotes_launcher_inside_long_install_root(
             "new launcher",
             encoding="utf-8",
         )
-        (staged_root / "LauncherUi.exe").write_text(
+        (staged_root / "launcher-bin").mkdir()
+        (staged_root / "launcher-bin" / "LauncherUi.exe").write_text(
             "new launcher UI",
             encoding="utf-8",
         )
-        (staged_root / "Repair.exe").write_text("new repair", encoding="utf-8")
-        (staged_root / "launcher-bin").mkdir()
+        (staged_root / "launcher-bin" / "Repair.exe").write_text(
+            "new repair", encoding="utf-8"
+        )
         (staged_root / "launcher-bin" / "runtime.txt").write_text(
             "new runtime",
             encoding="utf-8",
@@ -91,7 +95,7 @@ def test_transaction_promotes_launcher_inside_long_install_root(
         assert (install_root / "SugarSubstitute.exe").read_text(
             encoding="utf-8"
         ) == "new launcher"
-        assert (install_root / "LauncherUi.exe").read_text(
+        assert (install_root / "launcher-bin" / "LauncherUi.exe").read_text(
             encoding="utf-8"
         ) == "new launcher UI"
         assert (install_root / "launcher-bin" / "runtime.txt").read_text(

--- a/tools/release_assets/launcher_archive.py
+++ b/tools/release_assets/launcher_archive.py
@@ -50,18 +50,20 @@ def build_installed_launcher_zip(
     ) as archive:
         for source_path in iter_directory_entries(resolved_bundle_dir):
             relative_path = source_path.relative_to(resolved_bundle_dir)
+            archive_path = _archive_relative_path(relative_path, target=target)
             executable_permissions = (
                 0o755
-                if relative_path == target.executable_relative_path
+                if archive_path == target.executable_relative_path
                 and target.operating_system is not LauncherOperatingSystem.WINDOWS
                 else None
             )
             write_path_to_zip(
                 archive=archive,
                 source_path=source_path,
-                archive_name=relative_path.as_posix(),
+                archive_name=archive_path.as_posix(),
                 permissions=executable_permissions,
             )
+    validate_installed_launcher_archive(resolved_output_path, target=target)
     return resolved_output_path
 
 
@@ -110,10 +112,26 @@ def validate_installed_launcher_bundle(
             "Installed launcher bundle must include "
             f"{target.support_relative_path}: {launcher_bundle_dir}"
         )
-    replacement_roots = launcher_bundle_target_for_key(target.key).replacement_roots
+    bundle_target = launcher_bundle_target_for_key(target.key)
+    replacement_roots = bundle_target.replacement_roots
+    required_source_files = tuple(
+        _source_relative_path(path, target=target)
+        for path in bundle_target.required_file_relative_paths
+    )
+    missing_files = [
+        str(path)
+        for path in required_source_files
+        if not (launcher_bundle_dir / path).is_file()
+    ]
+    if missing_files:
+        raise FileNotFoundError(
+            "Installed launcher build is missing required files "
+            f"{', '.join(missing_files)}: {launcher_bundle_dir}"
+        )
     allowed_roots = {
         replacement_root.parts[0] for replacement_root in replacement_roots
     }
+    allowed_roots.update(path.parts[0] for path in required_source_files)
     for replacement_root in replacement_roots:
         replacement_path = launcher_bundle_dir / replacement_root
         if not replacement_path.exists():
@@ -144,7 +162,8 @@ def validate_installed_launcher_archive(
         names = set(archive.namelist())
     executable_name = target.executable_relative_path.as_posix()
     support_prefix = target.support_relative_path.as_posix().rstrip("/") + "/"
-    replacement_roots = launcher_bundle_target_for_key(target.key).replacement_roots
+    bundle_target = launcher_bundle_target_for_key(target.key)
+    replacement_roots = bundle_target.replacement_roots
     if executable_name not in names:
         raise FileNotFoundError(
             f"Launcher archive is missing {executable_name}: {archive_path}"
@@ -167,3 +186,49 @@ def validate_installed_launcher_archive(
             "Launcher archive is missing replacement roots "
             f"{', '.join(missing_roots)}: {archive_path}"
         )
+    missing_files = [
+        path.as_posix()
+        for path in bundle_target.required_file_relative_paths
+        if path.as_posix() not in names
+    ]
+    if missing_files:
+        raise FileNotFoundError(
+            "Launcher archive is missing required files "
+            f"{', '.join(missing_files)}: {archive_path}"
+        )
+    allowed_roots = {path.parts[0] for path in replacement_roots}
+    unexpected_roots = sorted(
+        {
+            Path(name).parts[0]
+            for name in names
+            if Path(name).parts and Path(name).parts[0] not in allowed_roots
+        }
+    )
+    if unexpected_roots:
+        raise ValueError(
+            "Launcher archive contains unexpected roots: " + ", ".join(unexpected_roots)
+        )
+
+
+def _archive_relative_path(relative_path: Path, *, target: LauncherTarget) -> Path:
+    """Map Windows helper builds into the legacy-authorized support root."""
+
+    if (
+        target.operating_system is LauncherOperatingSystem.WINDOWS
+        and relative_path.parent == Path(".")
+        and relative_path.name in {"LauncherUi.exe", "Repair.exe"}
+    ):
+        return target.support_relative_path / relative_path.name
+    return relative_path
+
+
+def _source_relative_path(relative_path: Path, *, target: LauncherTarget) -> Path:
+    """Map an installed archive path back to its PyInstaller build location."""
+
+    if (
+        target.operating_system is LauncherOperatingSystem.WINDOWS
+        and relative_path.parent == target.support_relative_path
+        and relative_path.name in {"LauncherUi.exe", "Repair.exe"}
+    ):
+        return Path(relative_path.name)
+    return relative_path


### PR DESCRIPTION
## Outcome

- keeps Windows launcher update archives compatible with every historical launcher validator
- packages LauncherUi.exe and Repair.exe under launcher-bin while preserving both helper workflows
- validates required helper files and rejects unrecognized archive roots
- adds regression coverage for installation, update promotion, rollback, repair, long paths, and release payload layout

## Verification

- full parallel test suite
- all 88 isolated test modules
- serial test module
- architecture and test governance
- repository-wide Ruff and strict mypy
- real PyInstaller bundle/package smoke with nested LauncherUi.exe