### PR TITLE
fix(installer): complete macOS onboarding launch qualification

### DIFF
--- a/.github/workflows/release-current-install-qualification.yml
+++ b/.github/workflows/release-current-install-qualification.yml
@@ -131,7 +131,7 @@ jobs:
             ${{ runner.temp }}/.candidate-certificate/requests.jsonl
             ${{ runner.temp }}/SugarSubstitute-clean/launcher/logs/**
             ${{ runner.temp }}/SugarSubstitute-clean/launcher/readiness/**
-            ${{ runner.temp }}/SugarSubstitute-clean/appdata/diagnostics/logs/**
+            ${{ runner.temp }}/SugarSubstitute-clean/appdata/diagnostics/**
           if-no-files-found: warn
           include-hidden-files: true
           retention-days: 7
@@ -202,7 +202,7 @@ jobs:
             ${{ runner.temp }}/.candidate-certificate/requests.jsonl
             ${{ runner.temp }}/SugarSubstitute-clean/launcher/logs/**
             ${{ runner.temp }}/SugarSubstitute-clean/launcher/readiness/**
-            ${{ runner.temp }}/SugarSubstitute-clean/appdata/diagnostics/logs/**
+            ${{ runner.temp }}/SugarSubstitute-clean/appdata/diagnostics/**
           if-no-files-found: warn
           include-hidden-files: true
           retention-days: 7

--- a/launcher/sugarsubstitute_launcher/crash_supervisor.py
+++ b/launcher/sugarsubstitute_launcher/crash_supervisor.py
@@ -151,8 +151,8 @@ class ApplicationCrashSupervisor:
             context.crashpad_database,
             prepared.started_at_ns,
         )
-        if context.validates_clean_exit() and minidump is None:
-            _discard_clean_run_artifacts(context)
+        if context.validates_clean_exit() and return_code == 0:
+            _discard_clean_run_artifacts(context, minidump=minidump)
             return return_code
 
         incident = self._resolve_incident(
@@ -339,9 +339,24 @@ def _newest_minidump(database: Path, started_at_ns: int) -> Path | None:
     return max(candidates, default=(0, None), key=lambda item: item[0])[1]
 
 
-def _discard_clean_run_artifacts(context: CrashRunContext) -> None:
+def _discard_clean_run_artifacts(
+    context: CrashRunContext,
+    *,
+    minidump: Path | None,
+) -> None:
     """Remove only known per-run files after authenticated clean termination."""
 
+    if minidump is not None:
+        minidump.unlink(missing_ok=True)
+        crashpad_attachment_directory = (
+            context.crashpad_database / "attachments" / minidump.stem
+        )
+        crashpad_fault_log = crashpad_attachment_directory / "python-fault.log"
+        crashpad_fault_log.unlink(missing_ok=True)
+        try:
+            crashpad_attachment_directory.rmdir()
+        except OSError:
+            pass
     for path in (context.exit_intent_path, context.exit_receipt_path):
         path.unlink(missing_ok=True)
     lifecycle_directory = context.exit_intent_path.parent

--- a/substitute/presentation/onboarding/installer_qualification.py
+++ b/substitute/presentation/onboarding/installer_qualification.py
@@ -175,7 +175,7 @@ class OnboardingQualificationDriver(QObject):
                     "Completion did not retain its ready application handoff."
                 )
             self._plan.record("onboarding.completion.ready")
-            self._click("OnboardingPrimaryButton")
+            self._click_terminal_action("OnboardingPrimaryButton")
             self._plan.record("onboarding.open_substitute.clicked")
         except Exception as error:
             self._record_failure(error)
@@ -237,6 +237,22 @@ class OnboardingQualificationDriver(QObject):
     def _click(self, object_name: str) -> None:
         """Click one enabled, visible production control."""
 
+        control = self._clickable_control(object_name)
+        self._mouse_click(control)
+
+    def _click_terminal_action(self, object_name: str) -> None:
+        """Click the final action without entering another nested Qt event wait."""
+
+        control = self._clickable_control(object_name)
+        QTest.mouseClick(
+            control,
+            Qt.MouseButton.LeftButton,
+            pos=control.rect().center(),
+        )
+
+    def _clickable_control(self, object_name: str) -> QWidget:
+        """Return one enabled, visible production control for qualification."""
+
         control = self._widget(QWidget, object_name)
         if not control.isEnabled() or not control.isVisible():
             raise RuntimeError(
@@ -244,7 +260,7 @@ class OnboardingQualificationDriver(QObject):
                 f"{object_name} enabled={control.isEnabled()} "
                 f"visible={control.isVisible()}."
             )
-        self._mouse_click(control)
+        return control
 
     def _mouse_click(self, control: QWidget) -> None:
         """Send a real Qt mouse click and service resulting queued work."""

--- a/tests/launcher/crash_supervisor/test_supervisor.py
+++ b/tests/launcher/crash_supervisor/test_supervisor.py
@@ -81,6 +81,53 @@ def test_supervisor_accepts_only_authenticated_clean_completion(tmp_path: Path) 
     )
 
 
+def test_supervisor_accepts_clean_completion_with_zero_exit_wrapper_dump(
+    tmp_path: Path,
+) -> None:
+    """A signed zero exit should reject a macOS PyInstaller shutdown dump."""
+
+    layout = InstallLayout.from_root(tmp_path / "install")
+    reports: list[str] = []
+    script = (
+        "import os; "
+        "from sugarsubstitute_shared.crash_reporting.protocol import "
+        "CrashRunContext, CleanExitOutcome; "
+        "c=CrashRunContext.from_environment(); "
+        "assert c is not None; "
+        "c.write_exit_intent(CleanExitOutcome.CLOSED, process_id=os.getpid()); "
+        "c.write_exit_receipt(CleanExitOutcome.CLOSED, process_id=os.getpid())"
+    )
+
+    def start_with_wrapper_dump(
+        command: Sequence[str],
+        environment: Mapping[str, str],
+    ) -> tuple[subprocess.Popen[bytes], Path]:
+        """Model the dump emitted while a macOS PyInstaller wrapper exits cleanly."""
+
+        dump = Path(environment[CRASHPAD_DATABASE_ENV]) / "pending" / "wrapper.dmp"
+        dump.parent.mkdir(parents=True)
+        dump.write_bytes(b"macOS PyInstaller wrapper shutdown")
+        return _start_process(command, environment)
+
+    return_code = ApplicationCrashSupervisor(
+        process_starter=start_with_wrapper_dump,
+        reporter_starter=lambda _layout, incident_id: reports.append(incident_id),
+        time_ns=lambda: 0,
+    ).supervise(
+        layout=layout,
+        command=(sys.executable, "-c", script),
+        environment=os.environ,
+    )
+
+    assert return_code == 0
+    assert reports == []
+    assert tuple((layout.appdata_dir / "diagnostics" / "crashpad").rglob("*.dmp")) == ()
+    assert (
+        CrashIncidentStore(layout.appdata_dir / "diagnostics" / "crashes").pending()
+        == ()
+    )
+
+
 def test_supervisor_reports_hard_exit_even_when_exit_code_is_zero(
     tmp_path: Path,
 ) -> None:

--- a/tests/qualification/installer/test_plan.py
+++ b/tests/qualification/installer/test_plan.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
+import pytest
+
 
 from sugarsubstitute_shared.installer_qualification import (
     INSTALLER_QUALIFICATION_PLAN_ENV,
@@ -123,3 +125,38 @@ def test_managed_qualification_applies_explicit_cpu_choice(tmp_path: Path) -> No
         "port": 48188,
         "workspace": str((tmp_path / "comfyui").resolve()),
     }
+
+
+def test_terminal_onboarding_click_does_not_enter_nested_event_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Open action should return directly to the outer application event loop."""
+
+    clicks: list[tuple[object, object, object]] = []
+    center = object()
+    control = SimpleNamespace(rect=lambda: SimpleNamespace(center=lambda: center))
+    driver = cast(
+        OnboardingQualificationDriver,
+        SimpleNamespace(_clickable_control=lambda _name: control),
+    )
+    monkeypatch.setattr(
+        "substitute.presentation.onboarding.installer_qualification.QTest.mouseClick",
+        lambda clicked, button, *, pos: clicks.append((clicked, button, pos)),
+    )
+    monkeypatch.setattr(
+        OnboardingQualificationDriver,
+        "_process_events",
+        lambda *_args, **_kwargs: pytest.fail(
+            "terminal handoff must not start a nested Qt event wait"
+        ),
+    )
+
+    OnboardingQualificationDriver._click_terminal_action(
+        driver,
+        "OnboardingPrimaryButton",
+    )
+
+    assert len(clicks) == 1
+    clicked_control, _button, click_position = clicks[0]
+    assert clicked_control is control
+    assert click_position is center

--- a/tests/qualification/release/workflow/test_qualification.py
+++ b/tests/qualification/release/workflow/test_qualification.py
@@ -259,6 +259,8 @@ def test_release_dry_run_qualifies_temporary_bytes_without_publishing() -> None:
     assert '--timeout-seconds "$env:QUALIFICATION_TIMEOUT_SECONDS"' in historical_proof
     assert "clean-install-diagnostics-${{ runner.os }}" in qualification_text
     assert current_install_text.count(".candidate-certificate/requests.jsonl") == 2
+    assert current_install_text.count("appdata/diagnostics/**") == 2
+    assert "appdata/diagnostics/logs/**" not in current_install_text
     assert "Restore checksum-addressed standalone artifact" not in qualification_text
     assert "cache_managed_comfy_artifacts.py" not in qualification_text
     assert "standalone_variant" not in qualification_text


### PR DESCRIPTION
Fixes the macOS clean-install qualification hang by allowing the terminal Open SugarSubstitute click to return directly to the outer Qt event loop, where the supervised restart can complete. Also retains the complete crash-diagnostics tree for future clean-install failures.\n\nVerification:\n- Focused installer/onboarding/bootstrap tests\n- Targeted Ruff format/lint\n- Strict mypy for changed Python files\n- macOS-only packaged clean-install qualification in progress