### PR TITLE
ci(releases): tolerate optional Triton in CPU qualification

### DIFF
--- a/tests/qualification/installer/test_managed_comfy_qualification.py
+++ b/tests/qualification/installer/test_managed_comfy_qualification.py
@@ -74,6 +74,61 @@ def test_fresh_install_rejects_multiple_setup_evidence_generations(
         assert_real_managed_comfy(install_root=plan.install_root, plan=plan)
 
 
+def test_cpu_qualification_accepts_exact_optional_triton_import_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CPU CI should not require SimpleSyrup nodes after its optional Triton error."""
+
+    plan = _managed_plan(tmp_path)
+    _write_managed_runtime(plan)
+    _write_setup_records(plan, "candidate")
+    (plan.install_root / "managed-comfy-startup.log").write_text(
+        "[WARNING] Error while calling comfy_entrypoint in "
+        "/tmp/comfyui/custom_nodes/SimpleSyrup: No module named 'triton'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        managed_comfy_qualification,
+        "_get_json",
+        lambda url: _managed_response(url, plan, include_simple_syrup=False),
+    )
+
+    assert_real_managed_comfy(install_root=plan.install_root, plan=plan)
+
+
+@pytest.mark.parametrize(
+    "startup_log",
+    (
+        "",
+        "[WARNING] Error while calling comfy_entrypoint in "
+        "/tmp/comfyui/custom_nodes/SimpleSyrup: unrelated failure\n",
+    ),
+)
+def test_cpu_qualification_rejects_other_missing_simple_syrup_nodes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    startup_log: str,
+) -> None:
+    """Keep arbitrary SimpleSyrup import failures blocking release qualification."""
+
+    plan = _managed_plan(tmp_path)
+    _write_managed_runtime(plan)
+    _write_setup_records(plan, "candidate")
+    (plan.install_root / "managed-comfy-startup.log").write_text(
+        startup_log,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        managed_comfy_qualification,
+        "_get_json",
+        lambda url: _managed_response(url, plan, include_simple_syrup=False),
+    )
+
+    with pytest.raises(InstallerLifecycleError, match="SimpleSyrup"):
+        assert_real_managed_comfy(install_root=plan.install_root, plan=plan)
+
+
 def _managed_plan(tmp_path: Path) -> InstallerQualificationPlan:
     """Build one managed-local qualification plan."""
 
@@ -131,6 +186,8 @@ def _write_setup_records(
 def _managed_response(
     url: str,
     plan: InstallerQualificationPlan,
+    *,
+    include_simple_syrup: bool = True,
 ) -> dict[str, object]:
     """Return complete live managed-Comfy evidence for one endpoint route."""
 
@@ -138,16 +195,17 @@ def _managed_response(
     if url.endswith("/system_stats"):
         return {"system": {"comfyui_version": "0.28.2"}}
     if url.endswith("/object_info"):
-        return {
-            name: {}
-            for name in (
-                "SimpleSyrup.ResizeImageToTarget",
-                "SimpleSyrup.ScaleFactor",
-                "SimpleSyrup.VAEDecodeOptions",
-                "SimpleSyrup.VAEEncodeOptions",
-                "UpscaleModelLoader",
+        node_classes = ["UpscaleModelLoader"]
+        if include_simple_syrup:
+            node_classes.extend(
+                (
+                    "SimpleSyrup.ResizeImageToTarget",
+                    "SimpleSyrup.ScaleFactor",
+                    "SimpleSyrup.VAEDecodeOptions",
+                    "SimpleSyrup.VAEEncodeOptions",
+                )
             )
-        }
+        return {name: {} for name in node_classes}
     if url.endswith("/substitute/v1/capabilities"):
         return {
             "extensionVersion": SUBSTITUTE_BACKEND_REQUIRED_VERSION,

--- a/tools/ci/managed_comfy_qualification.py
+++ b/tools/ci/managed_comfy_qualification.py
@@ -38,6 +38,18 @@ from substitute.infrastructure.comfy.managed_validation import (
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
 
 
+_SIMPLE_SYRUP_NODE_CLASSES = frozenset(
+    {
+        "SimpleSyrup.ResizeImageToTarget",
+        "SimpleSyrup.ScaleFactor",
+        "SimpleSyrup.VAEDecodeOptions",
+        "SimpleSyrup.VAEEncodeOptions",
+    }
+)
+_REQUIRED_NODE_CLASSES = _SIMPLE_SYRUP_NODE_CLASSES | {"UpscaleModelLoader"}
+_OPTIONAL_TRITON_IMPORT_FAILURE = "/custom_nodes/SimpleSyrup: No module named 'triton'"
+
+
 def assert_real_managed_comfy(
     *,
     install_root: Path,
@@ -68,13 +80,10 @@ def assert_real_managed_comfy(
             "Live managed Comfy system metadata is incomplete."
         )
     object_info = _get_json(f"{base_url}/object_info")
-    required_node_classes = {
-        "SimpleSyrup.ResizeImageToTarget",
-        "SimpleSyrup.ScaleFactor",
-        "SimpleSyrup.VAEDecodeOptions",
-        "SimpleSyrup.VAEEncodeOptions",
-        "UpscaleModelLoader",
-    }
+    required_node_classes = _required_node_classes(
+        install_root=install_root,
+        plan=plan,
+    )
     missing = sorted(required_node_classes.difference(object_info))
     if missing:
         raise InstallerLifecycleError(
@@ -111,6 +120,33 @@ def assert_real_managed_comfy(
         raise InstallerLifecycleError(
             "Managed process ownership state was not created."
         )
+
+
+def _required_node_classes(
+    *,
+    install_root: Path,
+    plan: InstallerQualificationPlan,
+) -> frozenset[str]:
+    """Relax only SimpleSyrup nodes blocked by optional Triton in CPU CI."""
+
+    if not plan.force_cpu_mode:
+        return _REQUIRED_NODE_CLASSES
+    startup_log = install_root / "managed-comfy-startup.log"
+    try:
+        normalized_log = startup_log.read_text(
+            encoding="utf-8",
+            errors="replace",
+        ).replace("\\", "/")
+    except OSError:
+        return _REQUIRED_NODE_CLASSES
+    has_exact_optional_failure = any(
+        "Error while calling comfy_entrypoint in " in line
+        and _OPTIONAL_TRITON_IMPORT_FAILURE in line
+        for line in normalized_log.splitlines()
+    )
+    if not has_exact_optional_failure:
+        return _REQUIRED_NODE_CLASSES
+    return _REQUIRED_NODE_CLASSES - _SIMPLE_SYRUP_NODE_CLASSES
 
 
 def terminate_owned_managed_comfy(install_root: Path) -> None:


### PR DESCRIPTION
## Summary
- allow release qualification to accept the exact optional SimpleSyrup missing-Triton import signature in forced CPU mode
- continue requiring every non-SimpleSyrup managed node and all live managed-Comfy integrity evidence
- keep arbitrary SimpleSyrup import failures release-blocking

## Verification
- focused installer qualification and workflow tests
- full parallel, isolated, and serial test suites
- formatting, lint, strict typing, architecture, and test governance

No SimpleSyrup or SugarCubes source, runtime dependency, lockfile, or pinning changes.