### PR TITLE
fix(installer): ship the onboarding wordmark

### DIFF
--- a/sugarsubstitute_shared/presentation/installer_resources.py
+++ b/sugarsubstitute_shared/presentation/installer_resources.py
@@ -1,0 +1,55 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Own installer visual-resource locations across source and packaged runtimes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH = Path("docs/readme/sugarsubstitute-logo.svg")
+INSTALLER_WORDMARK_RUNTIME_RELATIVE_PATH = Path(
+    "sugarsubstitute_shared/presentation/resources/sugarsubstitute-logo.svg"
+)
+
+
+def installer_wordmark_path() -> Path:
+    """Resolve the wordmark from a frozen launcher, app payload, or checkout."""
+
+    packaged_path = (
+        Path(getattr(sys, "_MEIPASS", ""))
+        / "launcher_assets"
+        / INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH.name
+    )
+    runtime_path = (
+        Path(__file__).resolve().parents[2] / INSTALLER_WORDMARK_RUNTIME_RELATIVE_PATH
+    )
+    source_path = (
+        Path(__file__).resolve().parents[2] / INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH
+    )
+    for candidate in (packaged_path, runtime_path, source_path):
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(f"Installer wordmark is missing: {runtime_path}")
+
+
+__all__ = [
+    "INSTALLER_WORDMARK_RUNTIME_RELATIVE_PATH",
+    "INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH",
+    "installer_wordmark_path",
+]

--- a/sugarsubstitute_shared/presentation/installer_surface.py
+++ b/sugarsubstitute_shared/presentation/installer_surface.py
@@ -18,9 +18,6 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QPaintEvent, QPainter
 from PySide6.QtSvgWidgets import QSvgWidget
@@ -38,6 +35,9 @@ from qfluentwidgets.common.style_sheet import (  # type: ignore[import-untyped]
 )
 
 from sugarsubstitute_shared.localization import app_text
+from sugarsubstitute_shared.presentation.installer_resources import (
+    installer_wordmark_path,
+)
 from sugarsubstitute_shared.presentation.localization import render_application_text
 
 
@@ -67,28 +67,6 @@ def expose_native_material(widget: QWidget) -> None:
     widget.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, False)
     widget.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
     widget.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground)
-
-
-def installer_wordmark_path() -> Path:
-    """Return the README wordmark from source or a frozen launcher bundle."""
-
-    packaged_path = (
-        Path(getattr(sys, "_MEIPASS", ""))
-        / "launcher_assets"
-        / "sugarsubstitute-logo.svg"
-    )
-    if packaged_path.is_file():
-        return packaged_path
-
-    source_path = (
-        Path(__file__).resolve().parents[2]
-        / "docs"
-        / "readme"
-        / "sugarsubstitute-logo.svg"
-    )
-    if source_path.is_file():
-        return source_path
-    raise FileNotFoundError(f"Installer wordmark is missing: {source_path}")
 
 
 def center_installer_window(window: QWidget) -> bool:

--- a/tests/qualification/release/payload/test_builder.py
+++ b/tests/qualification/release/payload/test_builder.py
@@ -115,6 +115,9 @@ def test_release_payload_contains_required_runtime_roots(tmp_path: Path) -> None
     assert "substitute/app/__init__.py" in archive_names
     assert "substitute/app/bootstrap/startup.py" in archive_names
     assert "sugarsubstitute_shared/__init__.py" in archive_names
+    assert (
+        "sugarsubstitute_shared/presentation/resources/sugarsubstitute-logo.svg"
+    ) in archive_names
     assert "third_party/manifest.toml" in archive_names
     assert set(RUNTIME_REQUIRED_ROOTS).issuperset(
         {archive_name.split("/", maxsplit=1)[0] for archive_name in archive_names}
@@ -488,6 +491,10 @@ def _write_fixture_repo(tmp_path: Path) -> Path:
     _write_file(
         repo_root / "sugarsubstitute_shared" / "__init__.py",
         '"""Shared infrastructure package."""\n',
+    )
+    _write_file(
+        repo_root / "docs" / "readme" / "sugarsubstitute-logo.svg",
+        "<svg/>\n",
     )
     _write_file(repo_root / "substitute" / "app" / "__init__.py", '"""Bootstrap."""\n')
     _write_file(

--- a/tests/shared/presentation/test_installer_resources.py
+++ b/tests/shared/presentation/test_installer_resources.py
@@ -1,0 +1,48 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify installer visual-resource resolution in every application layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+from sugarsubstitute_shared.presentation import installer_resources
+
+
+def test_installed_app_resolves_payload_wordmark(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Installed onboarding must resolve the wordmark shipped in the app ZIP."""
+
+    app_root = tmp_path / "app"
+    module_path = (
+        app_root / "sugarsubstitute_shared" / "presentation" / "installer_resources.py"
+    )
+    wordmark_path = (
+        app_root / installer_resources.INSTALLER_WORDMARK_RUNTIME_RELATIVE_PATH
+    )
+    wordmark_path.parent.mkdir(parents=True)
+    wordmark_path.write_text("<svg/>\n", encoding="utf-8")
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+    monkeypatch.setattr(installer_resources, "__file__", str(module_path))
+    monkeypatch.chdir(tmp_path)
+
+    assert installer_resources.installer_wordmark_path() == wordmark_path

--- a/tests/tools/pyinstaller_support/test_support.py
+++ b/tests/tools/pyinstaller_support/test_support.py
@@ -34,6 +34,9 @@ from tools.pyinstaller_support import (
     exclude_foreign_windows_icu_binaries,
     resolve_uv_executable,
 )
+from sugarsubstitute_shared.presentation.installer_resources import (
+    INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH,
+)
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -79,7 +82,7 @@ def test_build_launcher_data_files_includes_every_runtime_owner(
     assert data_files == (
         (str(icon_path.resolve()), "launcher_assets"),
         (
-            str(repo_root.resolve() / "docs" / "readme" / "sugarsubstitute-logo.svg"),
+            str(repo_root.resolve() / INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH),
             "launcher_assets",
         ),
         (str(tmp_path / "uv"), "launcher_assets"),

--- a/tools/pyinstaller_support.py
+++ b/tools/pyinstaller_support.py
@@ -28,6 +28,9 @@ from sugarsubstitute_shared.launcher_update.targets import (
     LauncherBundleTarget,
     detect_launcher_bundle_target,
 )
+from sugarsubstitute_shared.presentation.installer_resources import (
+    INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH,
+)
 
 
 PyInstallerDataFile = tuple[str, str]
@@ -49,11 +52,7 @@ def build_launcher_data_files(
     return (
         (str(app_icon_path.resolve()), "launcher_assets"),
         (
-            str(
-                (
-                    resolved_root / "docs" / "readme" / "sugarsubstitute-logo.svg"
-                ).resolve()
-            ),
+            str((resolved_root / INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH).resolve()),
             "launcher_assets",
         ),
         (resolved_uv, "launcher_assets"),

--- a/tools/release_assets/payload.py
+++ b/tools/release_assets/payload.py
@@ -23,6 +23,10 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from tools.release_assets.zip_support import iter_directory_entries, write_path_to_zip
+from sugarsubstitute_shared.presentation.installer_resources import (
+    INSTALLER_WORDMARK_RUNTIME_RELATIVE_PATH,
+    INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH,
+)
 
 
 APP_PAYLOAD_PREFIX = "SugarSubstitute-app-v"
@@ -121,6 +125,10 @@ def iter_payload_entries(repo_root: Path) -> Iterable[tuple[Path, str]]:
             relative_path = file_path.relative_to(repo_root)
             if not is_excluded(relative_path):
                 yield file_path, relative_path.as_posix()
+    yield (
+        repo_root / INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH,
+        INSTALLER_WORDMARK_RUNTIME_RELATIVE_PATH.as_posix(),
+    )
 
 
 def inspect_payload_zip(zip_path: Path) -> list[str]:
@@ -138,6 +146,8 @@ def validate_repo_root(repo_root: Path) -> None:
         for root_name in RUNTIME_REQUIRED_ROOTS
         if not (repo_root / root_name).exists()
     ]
+    if not (repo_root / INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH).is_file():
+        missing_roots.append(INSTALLER_WORDMARK_SOURCE_RELATIVE_PATH.as_posix())
     if missing_roots:
         raise FileNotFoundError(
             f"Repository root is missing payload roots: {', '.join(missing_roots)}"


### PR DESCRIPTION
## Outcome
- ships the installer wordmark inside the installed application payload
- resolves the same asset contract from frozen launchers, installed payloads, and source checkouts
- adds regression coverage for payload contents and installed-layout lookup

## Release failure addressed
The canary clean-install qualification reached onboarding on all three platforms, then the installed application crashed because the wordmark existed only in the launcher bundle and source checkout.

## Verification
- focused installer/resource and release-payload tests
- full Ruff format and lint
- strict mypy
- architecture and test-governance gates
- full parallel, isolated, and serial test suites

No SimpleSyrup, SugarCubes, requirement, lockfile, or dependency-pin changes.