### PR TITLE
ci(releases): wait for installer completion action

### DIFF
--- a/substitute/presentation/onboarding/installer_qualification.py
+++ b/substitute/presentation/onboarding/installer_qualification.py
@@ -268,6 +268,10 @@ class OnboardingQualificationDriver(QObject):
     def _click_terminal_action(self, object_name: str) -> None:
         """Click the final action without entering another nested Qt event wait."""
 
+        self._wait_until(
+            lambda: self._control_is_clickable(object_name),
+            f"clickable control {object_name}",
+        )
         control = self._clickable_control(object_name)
         QTest.mouseClick(
             control,
@@ -279,13 +283,19 @@ class OnboardingQualificationDriver(QObject):
         """Return one enabled, visible production control for qualification."""
 
         control = self._widget(QWidget, object_name)
-        if not control.isEnabled() or not control.isVisible():
+        if not self._control_is_clickable(object_name):
             raise RuntimeError(
                 "Installed onboarding control is not clickable: "
                 f"{object_name} enabled={control.isEnabled()} "
                 f"visible={control.isVisible()}."
             )
         return control
+
+    def _control_is_clickable(self, object_name: str) -> bool:
+        """Return whether one production control has completed visibility changes."""
+
+        control = self._widget(QWidget, object_name)
+        return control.isEnabled() and control.isVisible()
 
     def _mouse_click(self, control: QWidget) -> None:
         """Send a real Qt mouse click and service resulting queued work."""

--- a/tests/qualification/installer/test_plan.py
+++ b/tests/qualification/installer/test_plan.py
@@ -133,11 +133,24 @@ def test_terminal_onboarding_click_does_not_enter_nested_event_wait(
     """The Open action should return directly to the outer application event loop."""
 
     clicks: list[tuple[object, object, object]] = []
+    waits: list[str] = []
     center = object()
     control = SimpleNamespace(rect=lambda: SimpleNamespace(center=lambda: center))
+
+    def wait_until(predicate: object, description: str) -> None:
+        """Require the terminal control to become visible before its final click."""
+
+        assert callable(predicate)
+        assert predicate() is True
+        waits.append(description)
+
     driver = cast(
         OnboardingQualificationDriver,
-        SimpleNamespace(_clickable_control=lambda _name: control),
+        SimpleNamespace(
+            _clickable_control=lambda _name: control,
+            _control_is_clickable=lambda _name: True,
+            _wait_until=wait_until,
+        ),
     )
     monkeypatch.setattr(
         "substitute.presentation.onboarding.installer_qualification.QTest.mouseClick",
@@ -157,6 +170,7 @@ def test_terminal_onboarding_click_does_not_enter_nested_event_wait(
     )
 
     assert len(clicks) == 1
+    assert waits == ["clickable control OnboardingPrimaryButton"]
     clicked_control, _button, click_position = clicks[0]
     assert clicked_control is control
     assert click_position is center


### PR DESCRIPTION
## Outcome

- wait for the installed onboarding completion action to be visible and enabled before issuing the final qualification click
- preserve the non-nested terminal click behavior
- cover the readiness wait with a regression test

## Verification

- full repository format and lint
- architecture and test-governance checks
- strict mypy over substitute and tests
- full parallel test partition
- all 90 isolated modules
- serial test partition

This changes no dependency metadata or runtime installation policy. It makes no changes to SimpleSyrup or SugarCubes and adds no pins.