### PR TITLE
ci(releases): complete installer onboarding handoff

### DIFF
--- a/substitute/presentation/onboarding/installer_qualification.py
+++ b/substitute/presentation/onboarding/installer_qualification.py
@@ -25,7 +25,7 @@ from typing import Literal, TypeAlias, TypeVar, cast
 
 from PySide6.QtCore import QCoreApplication, QObject, QTimer, Qt, Slot
 from PySide6.QtTest import QTest
-from PySide6.QtWidgets import QApplication, QWidget
+from PySide6.QtWidgets import QAbstractButton, QApplication, QWidget
 from qfluentwidgets import LineEdit, RadioButton  # type: ignore[import-untyped]
 
 from substitute.presentation.onboarding.onboarding_window import OnboardingWindow
@@ -201,7 +201,6 @@ class OnboardingQualificationDriver(QObject):
                 )
             self._plan.record("onboarding.completion.ready")
             self._click_terminal_action("OnboardingPrimaryButton")
-            self._plan.record("onboarding.open_substitute.clicked")
         except Exception as error:
             self._record_failure(error)
 
@@ -266,18 +265,20 @@ class OnboardingQualificationDriver(QObject):
         self._mouse_click(control)
 
     def _click_terminal_action(self, object_name: str) -> None:
-        """Click the final action without entering another nested Qt event wait."""
+        """Schedule the final action on the outer Qt event loop."""
 
         self._wait_until(
             lambda: self._control_is_clickable(object_name),
             f"clickable control {object_name}",
         )
-        control = self._clickable_control(object_name)
-        QTest.mouseClick(
-            control,
-            Qt.MouseButton.LeftButton,
-            pos=control.rect().center(),
-        )
+        control = self._widget(QAbstractButton, object_name)
+        QTimer.singleShot(0, lambda: self._activate_terminal_action(control))
+
+    def _activate_terminal_action(self, control: QAbstractButton) -> None:
+        """Record and activate the close-owning action after automation returns."""
+
+        self._plan.record("onboarding.open_substitute.clicked")
+        control.click()
 
     def _clickable_control(self, object_name: str) -> QWidget:
         """Return one enabled, visible production control for qualification."""

--- a/tests/qualification/installer/test_plan.py
+++ b/tests/qualification/installer/test_plan.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
+from PySide6.QtWidgets import QAbstractButton
 
 
 from sugarsubstitute_shared.installer_qualification import (
@@ -127,15 +128,17 @@ def test_managed_qualification_applies_explicit_cpu_choice(tmp_path: Path) -> No
     }
 
 
-def test_terminal_onboarding_click_does_not_enter_nested_event_wait(
+def test_terminal_onboarding_action_runs_on_outer_event_loop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The Open action should return directly to the outer application event loop."""
+    """The Open action should not destroy its widget during a synthetic mouse event."""
 
-    clicks: list[tuple[object, object, object]] = []
+    events: list[str] = []
     waits: list[str] = []
-    center = object()
-    control = SimpleNamespace(rect=lambda: SimpleNamespace(center=lambda: center))
+    control = SimpleNamespace(click=lambda: events.append("control.click"))
+    plan = SimpleNamespace(
+        record=lambda event: events.append(event),
+    )
 
     def wait_until(predicate: object, description: str) -> None:
         """Require the terminal control to become visible before its final click."""
@@ -144,17 +147,34 @@ def test_terminal_onboarding_click_does_not_enter_nested_event_wait(
         assert predicate() is True
         waits.append(description)
 
+    def activate_terminal(candidate: object) -> None:
+        """Invoke the production activation helper from the scheduled callback."""
+
+        OnboardingQualificationDriver._activate_terminal_action(
+            driver,
+            cast(QAbstractButton, candidate),
+        )
+
+    def schedule_terminal(_delay: int, callback: object) -> None:
+        """Run the captured callback after recording its event-loop handoff."""
+
+        assert callable(callback)
+        events.append("scheduled")
+        callback()
+
     driver = cast(
         OnboardingQualificationDriver,
         SimpleNamespace(
-            _clickable_control=lambda _name: control,
+            _activate_terminal_action=activate_terminal,
             _control_is_clickable=lambda _name: True,
             _wait_until=wait_until,
+            _widget=lambda _type, _name: control,
+            _plan=plan,
         ),
     )
     monkeypatch.setattr(
-        "substitute.presentation.onboarding.installer_qualification.QTest.mouseClick",
-        lambda clicked, button, *, pos: clicks.append((clicked, button, pos)),
+        "substitute.presentation.onboarding.installer_qualification.QTimer.singleShot",
+        schedule_terminal,
     )
     monkeypatch.setattr(
         OnboardingQualificationDriver,
@@ -169,8 +189,9 @@ def test_terminal_onboarding_click_does_not_enter_nested_event_wait(
         "OnboardingPrimaryButton",
     )
 
-    assert len(clicks) == 1
     assert waits == ["clickable control OnboardingPrimaryButton"]
-    clicked_control, _button, click_position = clicks[0]
-    assert clicked_control is control
-    assert click_position is center
+    assert events == [
+        "scheduled",
+        "onboarding.open_substitute.clicked",
+        "control.click",
+    ]


### PR DESCRIPTION
## Summary
- schedule the terminal onboarding action on the outer Qt event loop
- avoid destroying the onboarding button during a synthetic mouse press/release
- retain explicit qualification evidence before the supervised restart

## Verification
- full format, lint, architecture, test-governance, and strict typing gates
- full parallel test suite
- all 90 isolated test modules
- serial test module

No dependency, SimpleSyrup, SugarCubes, or pinning changes.