### PR TITLE
fix(installer): complete canary setup handoff reliably

### DIFF
--- a/ARCHITECTURE_DEBT.toml
+++ b/ARCHITECTURE_DEBT.toml
@@ -1373,15 +1373,14 @@ next_extraction = "Extract native process/desktop control and historical evidenc
 id = "SS-ARCH-097"
 owner = "installer UI qualification"
 paths = ["tools/ci/installer_ui_qualification.py"]
-fingerprint = "sha256:e45336aefb7e3c6689a7ab4960fea36f1bec280c72fa289f7e53496dd6b4c54b"
+fingerprint = "sha256:95b3a0139186c4194f8a97f790f6bd1a30b66af3e95883d5e5f8fa128a80b665"
 issue = "chore:SS-ARCH-097"
 review_by = 2026-12-15
 responsibilities = [
   "qualification evidence preparation",
-  "current installer execution",
   "installed candidate launch",
   "shell and event-sequence verification",
   "cross-platform process termination",
   "readiness receipt and startup trace interpretation",
 ]
-next_extraction = "Extract installed-process lifecycle and evidence/trace verification from qualification workflow orchestration; durable installed-version evidence now has an independent owner."
+next_extraction = "Extract installed-candidate process lifecycle and evidence/trace verification from qualification workflow orchestration."

--- a/ARCHITECTURE_WAIVERS.toml
+++ b/ARCHITECTURE_WAIVERS.toml
@@ -1881,11 +1881,11 @@ owner = "installer UI qualification"
 rule = "STRUCT003"
 path = "tools/ci/installer_ui_qualification.py"
 kind = "remediation"
-justification = "The assessed file mixes qualification evidence preparation, current installer execution, installed candidate launch, shell and event-sequence verification, cross-platform process termination, readiness receipt and startup trace interpretation. Extract installed-process lifecycle and evidence/trace verification from qualification workflow orchestration; process identity diagnostics and durable installed-version evidence now have independent owners."
+justification = "The assessed file mixes qualification evidence preparation, installed candidate launch, shell and event-sequence verification, cross-platform process termination, readiness receipt and startup trace interpretation. Current packaged-installer execution now has an independent owner; next extract installed-candidate process lifecycle and evidence/trace verification from qualification workflow orchestration."
 issue = "chore:SS-ARCH-097"
 review_by = 2026-12-15
-max_lines = 632
-next_limit = 558
+max_lines = 560
+next_limit = 500
 debt = "SS-ARCH-097"
 
 [[waivers]]

--- a/launcher/sugarsubstitute_launcher/ui/installer_qualification.py
+++ b/launcher/sugarsubstitute_launcher/ui/installer_qualification.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QCoreApplication, QObject, QTimer, Qt, Slot
 from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QAbstractButton
 
 from sugarsubstitute_shared.installer_qualification import (
     InstallerQualificationPlan,
@@ -112,14 +113,15 @@ class InstallerQualificationDriver(QObject):
                 title=self._window.windowTitle(),
                 primary_action=button.text(),
             )
-            QTest.mouseClick(
-                button,
-                Qt.MouseButton.LeftButton,
-                pos=button.rect().center(),
-            )
-            self._plan.record("installer.install.clicked")
+            QTimer.singleShot(0, lambda: self._activate_install_action(button))
         except Exception as error:
             self._record_driver_failure(error)
+
+    def _activate_install_action(self, control: QAbstractButton) -> None:
+        """Record and activate the handoff-owning action outside a mouse event."""
+
+        self._plan.record("installer.install.clicked")
+        control.click()
 
     def _record_driver_failure(self, error: Exception) -> None:
         """Record one automation-contract failure and stop qualification."""

--- a/substitute/presentation/onboarding/installer_qualification.py
+++ b/substitute/presentation/onboarding/installer_qualification.py
@@ -193,7 +193,7 @@ class OnboardingQualificationDriver(QObject):
             )
             if self._window._controller.completion is None:
                 raise RuntimeError("Remote setup did not reach its review action.")
-            self._click("OnboardingPrimaryButton")
+            self._activate_page_transition("OnboardingPrimaryButton")
             self._wait_for_page("OnboardingCompletionPage")
             if self._window._controller.completion is None:
                 raise RuntimeError(
@@ -273,6 +273,12 @@ class OnboardingQualificationDriver(QObject):
         )
         control = self._widget(QAbstractButton, object_name)
         QTimer.singleShot(0, lambda: self._activate_terminal_action(control))
+
+    def _activate_page_transition(self, object_name: str) -> None:
+        """Activate a reused button without carrying a mouse release to its next page."""
+
+        control = cast(QAbstractButton, self._clickable_control(object_name))
+        control.click()
 
     def _activate_terminal_action(self, control: QAbstractButton) -> None:
         """Record and activate the close-owning action after automation returns."""

--- a/tests/launcher/installation_workflow/test_window_surface.py
+++ b/tests/launcher/installation_workflow/test_window_surface.py
@@ -195,7 +195,7 @@ def test_installer_qualification_clicks_visible_production_install_action(
     click_count = 0
 
     def _record_click() -> None:
-        """Count the production button signal emitted by QTest."""
+        """Count production activations and require pre-click evidence."""
 
         nonlocal click_count
         click_count += 1
@@ -203,6 +203,12 @@ def test_installer_qualification_clicks_visible_production_install_action(
             window._ui_state = LauncherUiState.PREPARE_INSTALL
             window.view.show_install_location()
             window._refresh_primary_button()
+            return
+        recorded_events = [
+            json.loads(line)["event"]
+            for line in event_log_path.read_text(encoding="utf-8").splitlines()
+        ]
+        assert recorded_events[-1] == "installer.install.clicked"
 
     window.view.primary_requested.connect(_record_click)
     window.show()

--- a/tests/qualification/installer/test_current_ui.py
+++ b/tests/qualification/installer/test_current_ui.py
@@ -37,11 +37,11 @@ from sugarsubstitute_shared.installer_qualification import (
 from substitute.presentation.onboarding.installer_qualification import (
     qualification_preflight_action,
 )
+from tools.ci.current_installer_execution import run_current_installer_ui
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
 from tools.ci.installer_ui_qualification import (
     assert_qualification_event_sequence,
     prepare_qualification_evidence,
-    run_current_installer_ui,
 )
 from tools.ci.verify_installer_lifecycle import verify_clean_install
 
@@ -195,7 +195,7 @@ def test_current_qualification_launches_normal_installer_ui(
         )()
 
     monkeypatch.setattr(
-        "tools.ci.installer_ui_qualification.subprocess.run",
+        "tools.ci.current_installer_execution.subprocess.run",
         _run,
     )
     installer = tmp_path / "SugarSubstitute Setup.exe"
@@ -214,6 +214,13 @@ def test_current_qualification_launches_normal_installer_ui(
     ]
     assert "--headless-install" not in captured_command
     assert captured_kwargs["timeout"] == 3_600.0
+    assert "capture_output" not in captured_kwargs
+    assert captured_kwargs["stdin"] is subprocess.DEVNULL
+    assert captured_kwargs["stderr"] is subprocess.STDOUT
+    output_stream = captured_kwargs["stdout"]
+    assert getattr(output_stream, "name", "").endswith(
+        ".installed-installer-output.log"
+    )
 
 
 def test_clean_qualification_uses_live_external_comfy_boundary(
@@ -289,7 +296,7 @@ def test_timed_out_current_installer_reports_process_bound_evidence(
         )
 
     monkeypatch.setattr(
-        "tools.ci.installer_ui_qualification.subprocess.run",
+        "tools.ci.current_installer_execution.subprocess.run",
         _timeout,
     )
 
@@ -330,7 +337,7 @@ def test_failed_current_installer_reports_process_bound_evidence(
     launcher_log.write_text("launcher rejected archive\n", encoding="utf-8")
 
     monkeypatch.setattr(
-        "tools.ci.installer_ui_qualification.subprocess.run",
+        "tools.ci.current_installer_execution.subprocess.run",
         lambda *_args, **_kwargs: SimpleNamespace(
             returncode=1,
             stdout="installer output",

--- a/tests/qualification/installer/test_plan.py
+++ b/tests/qualification/installer/test_plan.py
@@ -195,3 +195,21 @@ def test_terminal_onboarding_action_runs_on_outer_event_loop(
         "onboarding.open_substitute.clicked",
         "control.click",
     ]
+
+
+def test_completion_transition_uses_direct_button_activation() -> None:
+    """A reused primary button must finish its current page before another click."""
+
+    activations: list[str] = []
+    control = SimpleNamespace(click=lambda: activations.append("control.click"))
+    driver = cast(
+        OnboardingQualificationDriver,
+        SimpleNamespace(_clickable_control=lambda _name: control),
+    )
+
+    OnboardingQualificationDriver._activate_page_transition(
+        driver,
+        "OnboardingPrimaryButton",
+    )
+
+    assert activations == ["control.click"]

--- a/tests/qualification/release/workflow/test_installer_qualification.py
+++ b/tests/qualification/release/workflow/test_installer_qualification.py
@@ -62,6 +62,9 @@ def test_release_qualification_covers_clean_launch_and_upgrade_depth() -> None:
     ui_qualification_text = (
         PROJECT_ROOT / "tools" / "ci" / "installer_ui_qualification.py"
     ).read_text(encoding="utf-8")
+    current_installer_text = (
+        PROJECT_ROOT / "tools" / "ci" / "current_installer_execution.py"
+    ).read_text(encoding="utf-8")
     historical_qualification_text = (
         PROJECT_ROOT / "tools" / "ci" / "historical_install_qualification.py"
     ).read_text(encoding="utf-8")
@@ -69,7 +72,7 @@ def test_release_qualification_covers_clean_launch_and_upgrade_depth() -> None:
     assert "set_update_manifest" in lifecycle_text
     assert "install_candidate_over_historical_install" in lifecycle_text
     assert "INSTALLER_QUALIFICATION_PLAN_ENV" in ui_qualification_text
-    current_installer_path = ui_qualification_text.split(
+    current_installer_path = current_installer_text.split(
         "def run_current_installer_ui", maxsplit=1
     )[1].split("\ndef ", maxsplit=1)[0]
     assert '"--headless-install"' not in current_installer_path

--- a/tools/ci/current_installer_execution.py
+++ b/tools/ci/current_installer_execution.py
@@ -1,0 +1,128 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Run the current packaged installer without descendant-owned output pipes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from sugarsubstitute_shared.installer_qualification import InstallerQualificationPlan
+from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
+from tools.ci.installer_ui_qualification import diagnostic_tail
+
+
+_INSTALL_TIMEOUT_SECONDS = 3_600.0
+
+
+def run_current_installer_ui(
+    *,
+    installer_path: Path,
+    install_root: Path,
+    manifest_url: str | None,
+    environment: dict[str, str],
+    timeout_seconds: float = _INSTALL_TIMEOUT_SECONDS,
+) -> None:
+    """Launch packaged setup normally and let its real Install action run."""
+
+    command = [
+        str(installer_path.resolve()),
+        f"--install-root={install_root.resolve()}",
+    ]
+    if manifest_url is not None:
+        command.append(f"--manifest-url={manifest_url}")
+    output_path = install_root.resolve().parent / (
+        f".{install_root.resolve().name}-installer-output.log"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.unlink(missing_ok=True)
+    try:
+        with output_path.open("wb") as output:
+            result = subprocess.run(
+                command,
+                cwd=installer_path.resolve().parent,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=output,
+                stderr=subprocess.STDOUT,
+                timeout=timeout_seconds,
+                check=False,
+            )
+    except subprocess.TimeoutExpired as error:
+        diagnostics = _installer_failure_diagnostics(
+            install_root=install_root,
+            environment=environment,
+        )
+        raise InstallerLifecycleError(
+            f"Installer UI did not complete within {timeout_seconds:g} seconds.\n"
+            "installer output:\n"
+            f"{_installer_output(output_path, fallback=error.stdout)}\n"
+            f"{diagnostics}"
+        ) from error
+    if result.returncode != 0:
+        diagnostics = _installer_failure_diagnostics(
+            install_root=install_root,
+            environment=environment,
+        )
+        raise InstallerLifecycleError(
+            f"Installer UI exited with {result.returncode}.\n"
+            "installer output:\n"
+            f"{_installer_output(output_path, fallback=result.stdout)}\n"
+            f"{diagnostics}"
+        )
+
+
+def _installer_failure_diagnostics(
+    *,
+    install_root: Path,
+    environment: dict[str, str],
+) -> str:
+    """Expose token-bound UI events and launcher logs after a failed install."""
+
+    plan = InstallerQualificationPlan.from_environment(environment)
+    event_log = (
+        diagnostic_tail(plan.event_log_path)
+        if plan is not None
+        else "Qualification plan was not inherited."
+    )
+    launcher_log = diagnostic_tail(
+        InstallLayout.from_root(install_root).logs_dir / "launcher.log"
+    )
+    return f"qualification events:\n{event_log}\nlauncher log:\n{launcher_log}"
+
+
+def _installer_output(path: Path, *, fallback: bytes | str | None) -> str:
+    """Read file-backed setup output without waiting on descendant pipe handles."""
+
+    output = diagnostic_tail(path)
+    if output and not output.startswith("<missing diagnostics:"):
+        return output
+    return _timeout_output(fallback)
+
+
+def _timeout_output(output: bytes | str | None) -> str:
+    """Render bounded subprocess timeout output without losing byte diagnostics."""
+
+    if output is None:
+        return "<no output>"
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace")
+    return output
+
+
+__all__ = ["run_current_installer_ui"]

--- a/tools/ci/installer_ui_qualification.py
+++ b/tools/ci/installer_ui_qualification.py
@@ -160,76 +160,6 @@ def prepare_qualification_evidence(
     )
 
 
-def run_current_installer_ui(
-    *,
-    installer_path: Path,
-    install_root: Path,
-    manifest_url: str | None,
-    environment: dict[str, str],
-    timeout_seconds: float = _INSTALL_TIMEOUT_SECONDS,
-) -> None:
-    """Launch packaged setup normally and let its real Install action run."""
-
-    command = [
-        str(installer_path.resolve()),
-        f"--install-root={install_root.resolve()}",
-    ]
-    if manifest_url is not None:
-        command.append(f"--manifest-url={manifest_url}")
-    try:
-        result = subprocess.run(
-            command,
-            cwd=installer_path.resolve().parent,
-            env=environment,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=timeout_seconds,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as error:
-        diagnostics = _installer_failure_diagnostics(
-            install_root=install_root,
-            environment=environment,
-        )
-        raise InstallerLifecycleError(
-            f"Installer UI did not complete within {timeout_seconds:g} seconds.\n"
-            f"stdout:\n{_timeout_output(error.stdout)}\n"
-            f"stderr:\n{_timeout_output(error.stderr)}\n"
-            f"{diagnostics}"
-        ) from error
-    if result.returncode != 0:
-        diagnostics = _installer_failure_diagnostics(
-            install_root=install_root,
-            environment=environment,
-        )
-        raise InstallerLifecycleError(
-            f"Installer UI exited with {result.returncode}.\n"
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}\n"
-            f"{diagnostics}"
-        )
-
-
-def _installer_failure_diagnostics(
-    *,
-    install_root: Path,
-    environment: dict[str, str],
-) -> str:
-    """Expose token-bound UI events and launcher logs after a failed install."""
-
-    plan = InstallerQualificationPlan.from_environment(environment)
-    event_log = (
-        diagnostic_tail(plan.event_log_path)
-        if plan is not None
-        else "Qualification plan was not inherited."
-    )
-    launcher_log = diagnostic_tail(
-        InstallLayout.from_root(install_root).logs_dir / "launcher.log"
-    )
-    return f"qualification events:\n{event_log}\nlauncher log:\n{launcher_log}"
-
-
 def launch_installed_candidate(
     *,
     install_root: Path,
@@ -470,16 +400,6 @@ def diagnostic_tail(path: Path, *, maximum_lines: int = 80) -> str:
     return "\n".join(lines[-maximum_lines:])
 
 
-def _timeout_output(output: bytes | str | None) -> str:
-    """Render bounded subprocess timeout output without losing byte diagnostics."""
-
-    if output is None:
-        return "<no output>"
-    if isinstance(output, bytes):
-        return output.decode("utf-8", errors="replace")
-    return output
-
-
 def _wait_for_readiness_receipt(
     *,
     readiness_path: Path,
@@ -714,7 +634,6 @@ __all__ = [
     "launch_installed_candidate",
     "prepare_qualification_evidence",
     "process_tree_diagnostics",
-    "run_current_installer_ui",
     "terminate_verified_process",
     "verify_main_shell_evidence",
 ]

--- a/tools/ci/verify_installer_lifecycle.py
+++ b/tools/ci/verify_installer_lifecycle.py
@@ -53,9 +53,9 @@ from tools.ci.installer_lifecycle_errors import InstallerLifecycleError  # noqa:
 from tools.ci.external_comfy_readiness_server import (  # noqa: E402
     ExternalComfyReadinessServer,
 )
+from tools.ci.current_installer_execution import run_current_installer_ui  # noqa: E402
 from tools.ci.installer_ui_qualification import (  # noqa: E402
     prepare_qualification_evidence,
-    run_current_installer_ui,
     verify_main_shell_evidence,
 )
 from tools.ci.installed_version_evidence import assert_installed_version  # noqa: E402


### PR DESCRIPTION
## Outcome
- activates setup and completion handoff controls without synthetic mouse-release reentrancy
- writes packaged-installer qualification output to a file instead of descendant-inheritable pipes
- extracts current installer execution into its own CI owner and adds regression coverage

## Verification
- full local format, lint, architecture, test-governance, and strict type gates
- full parallel test suite
- all 90 isolated test modules
- serial test module

## Dependency boundary
No requirements, lockfiles, SimpleSyrup, SugarCubes, or runtime pinning changes.