### PR TITLE
fix(installer): complete canary setup and shutdown reliably

### DIFF
--- a/substitute/presentation/onboarding/installer_qualification.py
+++ b/substitute/presentation/onboarding/installer_qualification.py
@@ -184,25 +184,24 @@ class OnboardingQualificationDriver(QObject):
             self._wait_for_page("OnboardingIntegrationsPage")
             self._click("OnboardingPrimaryButton")
             self._wait_for_page("OnboardingProvisioningPage")
-            self._wait_until(
-                lambda: self._widget(
-                    QWidget,
-                    "OnboardingPrimaryButton",
-                ).isEnabled(),
-                "remote provisioning result",
-            )
-            if self._window._controller.completion is None:
-                raise RuntimeError("Remote setup did not reach its review action.")
-            self._activate_page_transition("OnboardingPrimaryButton")
-            self._wait_for_page("OnboardingCompletionPage")
-            if self._window._controller.completion is None:
-                raise RuntimeError(
-                    "Completion did not retain its ready application handoff."
-                )
+            self._wait_for_completion_page()
             self._plan.record("onboarding.completion.ready")
             self._click_terminal_action("OnboardingPrimaryButton")
         except Exception as error:
             self._record_failure(error)
+
+    def _wait_for_completion_page(self) -> None:
+        """Observe provisioning's automatic completion transition without advancing it."""
+
+        self._wait_until(
+            lambda: self._window._controller.completion is not None,
+            "onboarding completion",
+        )
+        self._wait_for_page("OnboardingCompletionPage")
+        if self._window._controller.completion is None:
+            raise RuntimeError(
+                "Completion did not retain its ready application handoff."
+            )
 
     def _configure_managed_target(self) -> None:
         """Enter the real managed workspace and endpoint selected for qualification."""
@@ -273,12 +272,6 @@ class OnboardingQualificationDriver(QObject):
         )
         control = self._widget(QAbstractButton, object_name)
         QTimer.singleShot(0, lambda: self._activate_terminal_action(control))
-
-    def _activate_page_transition(self, object_name: str) -> None:
-        """Activate a reused button without carrying a mouse release to its next page."""
-
-        control = cast(QAbstractButton, self._clickable_control(object_name))
-        control.click()
 
     def _activate_terminal_action(self, control: QAbstractButton) -> None:
         """Record and activate the close-owning action after automation returns."""

--- a/sugarsubstitute_shared/application_instance_socket.py
+++ b/sugarsubstitute_shared/application_instance_socket.py
@@ -29,6 +29,9 @@ from sugarsubstitute_shared.application_instance_protocol import (
 )
 
 
+_ACCEPT_POLL_SECONDS = 0.25
+
+
 class SocketInstanceConnection:
     """Frame messages over one local stream socket."""
 
@@ -93,11 +96,13 @@ class SocketInstanceListener:
         """Retain an already-listening socket."""
 
         self._listener = listener
+        self._listener.settimeout(_ACCEPT_POLL_SECONDS)
 
     def accept(self) -> ApplicationInstanceConnection:
         """Accept and authorize one same-user local connection."""
 
         connection, _address = self._listener.accept()
+        connection.settimeout(None)
         wrapped = SocketInstanceConnection(connection)
         if not wrapped.peer_is_current_user():
             wrapped.close()

--- a/tests/qualification/installer/test_plan.py
+++ b/tests/qualification/installer/test_plan.py
@@ -197,19 +197,26 @@ def test_terminal_onboarding_action_runs_on_outer_event_loop(
     ]
 
 
-def test_completion_transition_uses_direct_button_activation() -> None:
-    """A reused primary button must finish its current page before another click."""
+def test_successful_provisioning_observes_automatic_completion_transition() -> None:
+    """Qualification must not click the reused primary action after provisioning."""
 
-    activations: list[str] = []
-    control = SimpleNamespace(click=lambda: activations.append("control.click"))
+    events: list[str] = []
+    completion = object()
     driver = cast(
         OnboardingQualificationDriver,
-        SimpleNamespace(_clickable_control=lambda _name: control),
+        SimpleNamespace(
+            _window=SimpleNamespace(_controller=SimpleNamespace(completion=completion)),
+            _wait_until=lambda predicate, description: events.extend(
+                [description, f"ready={predicate()}"]
+            ),
+            _wait_for_page=lambda page: events.append(page),
+        ),
     )
 
-    OnboardingQualificationDriver._activate_page_transition(
-        driver,
-        "OnboardingPrimaryButton",
-    )
+    OnboardingQualificationDriver._wait_for_completion_page(driver)
 
-    assert activations == ["control.click"]
+    assert events == [
+        "onboarding completion",
+        "ready=True",
+        "OnboardingCompletionPage",
+    ]

--- a/tests/shared/application_instance_broker/test_socket_transport.py
+++ b/tests/shared/application_instance_broker/test_socket_transport.py
@@ -17,9 +17,11 @@
 """Verify socket transport shutdown behavior shared by Linux and macOS."""
 
 import socket
+import threading
 
 from sugarsubstitute_shared.application_instance_socket import (
     SocketInstanceConnection,
+    SocketInstanceListener,
 )
 
 
@@ -34,3 +36,29 @@ def test_connection_close_wakes_peer_blocked_on_receive() -> None:
         assert peer_socket.recv(1) == b""
     finally:
         peer_socket.close()
+
+
+def test_listener_accept_returns_periodically_while_idle() -> None:
+    """Let the broker observe shutdown even when native close cannot wake accept."""
+
+    listener_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener_socket.bind(("127.0.0.1", 0))
+    listener_socket.listen(1)
+    listener = SocketInstanceListener(listener_socket)
+    completed = threading.Event()
+
+    def accept_once() -> None:
+        """Record the listener's bounded idle poll."""
+
+        try:
+            listener.accept()
+        except TimeoutError:
+            completed.set()
+
+    accept_thread = threading.Thread(target=accept_once, daemon=True)
+    accept_thread.start()
+    returned_while_idle = completed.wait(1.0)
+    listener.close()
+    accept_thread.join(timeout=1.0)
+
+    assert returned_while_idle


### PR DESCRIPTION
## Summary
- observe the onboarding window's automatic provisioning-to-completion transition instead of clicking the reused launch action twice
- retain the terminal launch on the outer Qt event loop
- make local socket listener shutdown portable by bounding idle accept polling while preserving blocking accepted connections
- cover both lifecycle failures with regression tests

## Verification
- full repository Ruff format and lint
- architecture and test-governance checks
- strict mypy
- full parallel pytest suite
- all 90 isolated test modules
- serial test suite

## Dependency boundary
No SimpleSyrup, SugarCubes, dependency, lockfile, or pinning changes.