### PR TITLE
fix(installer): keep setup and dependency progress visible

### DIFF
--- a/launcher/sugarsubstitute_launcher/process.py
+++ b/launcher/sugarsubstitute_launcher/process.py
@@ -120,14 +120,10 @@ def spawn_detached_process(
     *,
     environment: Mapping[str, str] | None = None,
 ) -> tuple[subprocess.Popen[bytes], Path]:
-    """Start a hidden app child and return its process and diagnostic log path."""
+    """Start an app child without a console and retain its diagnostic output."""
 
-    startupinfo = None
     creationflags = 0
     if sys.platform == "win32":
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        startupinfo.wShowWindow = 0
         creationflags = subprocess.CREATE_NO_WINDOW
 
     startup_log_path = _app_startup_log_path(command)
@@ -153,7 +149,6 @@ def spawn_detached_process(
                     close_fds=True,
                     creationflags=creationflags,
                     shell=False,
-                    startupinfo=startupinfo,
                 )
         except OSError as error:
             compatibility_error = external_long_path_error(

--- a/substitute/infrastructure/comfy/comfy_manager_runtime.py
+++ b/substitute/infrastructure/comfy/comfy_manager_runtime.py
@@ -26,6 +26,7 @@ from substitute.infrastructure.comfy.manager_environment import (
     manager_runtime_environment,
 )
 from substitute.infrastructure.process.hidden_process_runner import (
+    SilenceCallback,
     run_command,
     stream_command_collecting_output,
 )
@@ -76,6 +77,8 @@ class ComfyManagerCommandRunner:
         node_spec: str,
         on_line: LogCallback | None,
         timeout_seconds: int,
+        on_silence: SilenceCallback | None = None,
+        silence_notification_interval_seconds: float = 30.0,
     ) -> tuple[int, tuple[str, ...]] | None:
         """Install one exact Registry nodepack through the available ComfyCLI."""
 
@@ -86,6 +89,10 @@ class ComfyManagerCommandRunner:
             command,
             cwd=self._runtime.workspace,
             on_line=on_line,
+            on_silence=on_silence,
+            silence_notification_interval_seconds=(
+                silence_notification_interval_seconds
+            ),
             timeout_seconds=timeout_seconds,
             env=self._environment,
         )

--- a/substitute/infrastructure/comfy/nodepack_registry_installer.py
+++ b/substitute/infrastructure/comfy/nodepack_registry_installer.py
@@ -36,6 +36,7 @@ from substitute.shared.logging.logger import get_logger, log_info, log_warning
 
 LogCallback = Callable[[str], None]
 _LOGGER = get_logger("infrastructure.comfy.nodepack_registry_installer")
+_REGISTRY_SILENCE_FEEDBACK_SECONDS = 30.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,6 +74,14 @@ class ComfyNodepackRegistryInstaller:
         process_result = command_runner.install_registry_nodepack(
             node_spec=f"{nodepack.registry_id}@{nodepack.required_version}",
             on_line=on_log,
+            on_silence=lambda elapsed_seconds: self._emit(
+                on_log,
+                _registry_wait_message(
+                    nodepack=nodepack,
+                    elapsed_seconds=elapsed_seconds,
+                ),
+            ),
+            silence_notification_interval_seconds=(_REGISTRY_SILENCE_FEEDBACK_SECONDS),
             timeout_seconds=CLI_INSTALL_TIMEOUT_SECONDS,
         )
         if process_result is None:
@@ -146,6 +155,30 @@ def _bounded_output_tail(output: tuple[str, ...]) -> str:
 
     combined = " | ".join(line.strip() for line in output[-5:] if line.strip())
     return combined[-2_000:] or "<no output>"
+
+
+def _registry_wait_message(
+    *,
+    nodepack: CoreComfyNodepack,
+    elapsed_seconds: float,
+) -> str:
+    """Describe one still-running silent Registry operation."""
+
+    return (
+        "[ComfyNodepacks] Registry install still running for "
+        f"{nodepack.registry_id}@{nodepack.required_version} "
+        f"(elapsed={_format_elapsed(elapsed_seconds)})."
+    )
+
+
+def _format_elapsed(elapsed_seconds: float) -> str:
+    """Format elapsed process time as compact diagnostic output."""
+
+    whole_seconds = max(0, round(elapsed_seconds))
+    minutes, seconds = divmod(whole_seconds, 60)
+    if minutes == 0:
+        return f"{seconds}s"
+    return f"{minutes}m {seconds:02d}s"
 
 
 __all__ = ["ComfyNodepackRegistryInstaller", "RegistryInstallResult"]

--- a/substitute/infrastructure/process/hidden_process_runner.py
+++ b/substitute/infrastructure/process/hidden_process_runner.py
@@ -18,10 +18,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
+from queue import Empty, Queue
 import subprocess
 import sys
+from threading import Thread
+import time
+from typing import Final
 
 from substitute.shared.logging.logger import get_logger, log_info
 from sugarsubstitute_shared.external_path_failure import external_long_path_error
@@ -32,9 +37,18 @@ from sugarsubstitute_shared.windows_long_paths import (
 )
 
 LogCallback = Callable[[str], None]
+SilenceCallback = Callable[[float], None]
 CommandResult = subprocess.CompletedProcess[str]
 
 _LOGGER = get_logger(__name__)
+_STREAM_ENDED: Final[object] = object()
+
+
+@dataclass(frozen=True, slots=True)
+class _StreamReadFailure:
+    """Carry a background stream failure back to the calling thread."""
+
+    error: Exception
 
 
 def run_command(
@@ -138,10 +152,15 @@ def stream_command_collecting_output(
     *,
     cwd: Path,
     on_line: LogCallback | None,
+    on_silence: SilenceCallback | None = None,
+    silence_notification_interval_seconds: float = 30.0,
     timeout_seconds: int | None = None,
     env: Mapping[str, str] | None = None,
 ) -> tuple[int, tuple[str, ...]]:
     """Run one hidden subprocess while retaining merged stdout/stderr records."""
+
+    if on_silence is not None and silence_notification_interval_seconds <= 0:
+        raise ValueError("Silence notification interval must be positive.")
 
     process_cwd = operational_path(cwd)
     command_args = _process_command(command)
@@ -166,11 +185,22 @@ def stream_command_collecting_output(
     output_lines: list[str] = []
     try:
         if proc.stdout is not None:
-            for line in proc.stdout:
-                stripped = line.rstrip("\n")
-                output_lines.append(stripped)
-                if stripped and on_line is not None:
-                    on_line(stripped)
+            if on_silence is None:
+                _consume_output_lines(
+                    proc.stdout,
+                    output_lines=output_lines,
+                    on_line=on_line,
+                )
+            else:
+                _consume_output_lines_with_silence_feedback(
+                    proc.stdout,
+                    output_lines=output_lines,
+                    on_line=on_line,
+                    on_silence=on_silence,
+                    notification_interval_seconds=(
+                        silence_notification_interval_seconds
+                    ),
+                )
         proc.wait(timeout=timeout_seconds)
         return proc.returncode, tuple(output_lines)
     finally:
@@ -182,6 +212,86 @@ def creation_flags() -> int:
     """Return subprocess flags that avoid visible console windows on Windows."""
 
     return subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
+
+
+def _consume_output_lines(
+    stream: Iterable[str],
+    *,
+    output_lines: list[str],
+    on_line: LogCallback | None,
+) -> None:
+    """Consume merged process output without synthetic progress records."""
+
+    for line in stream:
+        _record_output_line(str(line), output_lines=output_lines, on_line=on_line)
+
+
+def _consume_output_lines_with_silence_feedback(
+    stream: Iterable[str],
+    *,
+    output_lines: list[str],
+    on_line: LogCallback | None,
+    on_silence: SilenceCallback,
+    notification_interval_seconds: float,
+) -> None:
+    """Report elapsed time while a live process emits no output records."""
+
+    events: Queue[object] = Queue()
+
+    def read_output() -> None:
+        """Transfer blocking stream iteration onto one bounded daemon reader."""
+
+        try:
+            for line in stream:
+                events.put(str(line))
+        except Exception as error:
+            events.put(_StreamReadFailure(error))
+        finally:
+            events.put(_STREAM_ENDED)
+
+    reader = Thread(
+        target=read_output,
+        name="hidden-process-output-reader",
+        daemon=True,
+    )
+    reader.start()
+    started_at = time.monotonic()
+    next_notification_at = started_at + notification_interval_seconds
+    while True:
+        wait_seconds = max(0.0, next_notification_at - time.monotonic())
+        try:
+            event = events.get(timeout=wait_seconds)
+        except Empty:
+            now = time.monotonic()
+            on_silence(max(0.0, now - started_at))
+            next_notification_at = now + notification_interval_seconds
+            continue
+        if event is _STREAM_ENDED:
+            reader.join()
+            return
+        if isinstance(event, _StreamReadFailure):
+            reader.join()
+            raise event.error
+        _record_output_line(
+            str(event),
+            output_lines=output_lines,
+            on_line=on_line,
+        )
+        next_notification_at = time.monotonic() + notification_interval_seconds
+
+
+def _record_output_line(
+    line: str,
+    *,
+    output_lines: list[str],
+    on_line: LogCallback | None,
+) -> None:
+    """Retain one exact output record and forward its visible text."""
+
+    stripped = line.rstrip("\n")
+    output_lines.append(stripped)
+    if stripped and on_line is not None:
+        on_line(stripped)
 
 
 def _command_label(command: Sequence[str]) -> str:
@@ -207,6 +317,7 @@ def _process_command(command: Sequence[str]) -> list[str]:
 __all__ = [
     "CommandResult",
     "LogCallback",
+    "SilenceCallback",
     "creation_flags",
     "run_command",
     "stream_command",

--- a/tests/crosscutting/ci/execution/inventory_policy.py
+++ b/tests/crosscutting/ci/execution/inventory_policy.py
@@ -40,6 +40,7 @@ EXECUTION_ADAPTER_FILES = frozenset(
         "substitute/infrastructure/execution/host_execution_diagnostics.py",
         "substitute/infrastructure/execution/thread_pool_admission.py",
         "substitute/infrastructure/execution/thread_pool_lane.py",
+        "substitute/infrastructure/process/hidden_process_runner.py",
         "substitute/application/execution/cancellation.py",
         "substitute/application/execution/policies.py",
         "substitute/application/execution/task_scope.py",

--- a/tests/infrastructure/comfy/nodepacks/test_registry_installer.py
+++ b/tests/infrastructure/comfy/nodepacks/test_registry_installer.py
@@ -27,7 +27,10 @@ from substitute.application.comfy_nodepacks.core_nodepack_reconciliation_plan im
     RegistryInstallOutcome,
 )
 from substitute.domain.comfy_manager import ComfyManagerKind, ComfyManagerRuntime
-from substitute.infrastructure.comfy.nodepack_manifest import CORE_COMFY_NODEPACKS
+from substitute.infrastructure.comfy.nodepack_manifest import (
+    CORE_COMFY_NODEPACKS,
+    CoreComfyNodepack,
+)
 from substitute.infrastructure.comfy.nodepack_registry_installer import (
     ComfyNodepackRegistryInstaller,
 )
@@ -128,6 +131,57 @@ def test_integrated_manager_module_is_used_when_comfy_cli_is_absent(
 
     assert result.outcome is RegistryInstallOutcome.INSTALLED
     assert observed[1:5] == ["-m", "cm_cli", "install", "--exit-on-fail"]
+
+
+@pytest.mark.parametrize("nodepack", CORE_COMFY_NODEPACKS)
+def test_silent_registry_install_reports_named_elapsed_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    nodepack: CoreComfyNodepack,
+) -> None:
+    """Keep both first-party Registry waits visibly alive during child silence."""
+
+    monkeypatch.setattr(
+        "substitute.infrastructure.comfy.comfy_manager_runtime.ComfyManagerCommandRunner._module_available",
+        lambda self, module_name: True,
+    )
+    observed_interval: list[float] = []
+
+    def fake_stream(
+        command: list[str],
+        **kwargs: Any,
+    ) -> tuple[int, tuple[str, ...]]:
+        """Drive two long-wait samples through the production callback."""
+
+        _ = command
+        observed_interval.append(kwargs["silence_notification_interval_seconds"])
+        on_silence = kwargs["on_silence"]
+        on_silence(30.0)
+        on_silence(150.0)
+        return 0, (f"[INSTALLED] {nodepack.registry_id}",)
+
+    monkeypatch.setattr(
+        "substitute.infrastructure.comfy.comfy_manager_runtime.stream_command_collecting_output",
+        fake_stream,
+    )
+    logs: list[str] = []
+
+    ComfyNodepackRegistryInstaller().install_exact(
+        manager_runtime=_runtime(tmp_path, tmp_path / "python.exe"),
+        nodepack=nodepack,
+        on_log=logs.append,
+        env={},
+    )
+
+    node_spec = f"{nodepack.registry_id}@{nodepack.required_version}"
+    assert observed_interval == [30.0]
+    assert logs == [
+        f"[ComfyNodepacks] Asking Comfy Registry for {node_spec}.",
+        f"[ComfyNodepacks] Registry install still running for {node_spec} "
+        "(elapsed=30s).",
+        f"[ComfyNodepacks] Registry install still running for {node_spec} "
+        "(elapsed=2m 30s).",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/infrastructure/process/hidden_process_runner/test_runner.py
+++ b/tests/infrastructure/process/hidden_process_runner/test_runner.py
@@ -22,6 +22,7 @@ import ast
 from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
 import subprocess
+import sys
 from typing import Any
 
 import pytest
@@ -143,6 +144,84 @@ def test_stream_command_collecting_output_retains_blank_lines(
     assert emitted == ["first", "second"]
 
 
+def test_collecting_process_reports_silence_until_real_output_arrives(
+    tmp_path: Path,
+) -> None:
+    """Report a live silent child without inventing child output records."""
+
+    release_marker = tmp_path / "release-child"
+    heartbeats: list[float] = []
+
+    def release_on_first_heartbeat(elapsed_seconds: float) -> None:
+        """Record the heartbeat and release the synchronized child process."""
+
+        heartbeats.append(elapsed_seconds)
+        release_marker.touch()
+
+    script = "\n".join(
+        (
+            "import pathlib, sys, time",
+            "marker = pathlib.Path(sys.argv[1])",
+            "while not marker.exists():",
+            "    time.sleep(0.001)",
+            "print('child output')",
+        )
+    )
+    exit_code, output_lines = hidden_process_runner.stream_command_collecting_output(
+        [sys.executable, "-c", script, str(release_marker)],
+        cwd=tmp_path,
+        on_line=None,
+        on_silence=release_on_first_heartbeat,
+        silence_notification_interval_seconds=0.02,
+        timeout_seconds=5,
+    )
+
+    assert exit_code == 0
+    assert heartbeats
+    assert heartbeats[0] >= 0.02
+    assert output_lines == ("child output",)
+
+
+def test_collecting_process_propagates_background_stream_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Return reader failures to the process-owning caller thread."""
+
+    process = _FakeProcess(returncode=0, lines=())
+    process.stdout = _FailingStdout(())
+    monkeypatch.setattr(
+        "substitute.infrastructure.process.hidden_process_runner.subprocess.Popen",
+        lambda *args, **kwargs: process,
+    )
+
+    with pytest.raises(OSError, match="stream failed"):
+        hidden_process_runner.stream_command_collecting_output(
+            ["python", "-m", "cm_cli"],
+            cwd=tmp_path,
+            on_line=None,
+            on_silence=lambda elapsed_seconds: None,
+            silence_notification_interval_seconds=0.02,
+        )
+
+    assert process.stdout.closed is True
+
+
+def test_collecting_process_rejects_nonpositive_silence_interval(
+    tmp_path: Path,
+) -> None:
+    """Reject an interval that would spin the caller thread continuously."""
+
+    with pytest.raises(ValueError, match="must be positive"):
+        hidden_process_runner.stream_command_collecting_output(
+            ["python", "-m", "cm_cli"],
+            cwd=tmp_path,
+            on_line=None,
+            on_silence=lambda elapsed_seconds: None,
+            silence_notification_interval_seconds=0,
+        )
+
+
 def test_run_command_check_raises_on_nonzero_exit(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -185,6 +264,15 @@ class _FakeStdout:
         """Record stream closure."""
 
         self.closed = True
+
+
+class _FailingStdout(_FakeStdout):
+    """Stdout stream that fails while the reader iterates it."""
+
+    def __iter__(self) -> Iterator[str]:
+        """Raise the simulated process-pipe read failure."""
+
+        raise OSError("stream failed")
 
 
 class _FakeProcess:

--- a/tests/launcher/application_launch/test_native_child_visibility.py
+++ b/tests/launcher/application_launch/test_native_child_visibility.py
@@ -1,0 +1,78 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Prove supervised Windows GUI children retain native window visibility."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+from launcher.sugarsubstitute_launcher.process import spawn_detached_process
+
+
+pytestmark = pytest.mark.platforms("windows")
+
+
+def test_spawned_qt_child_is_natively_visible(tmp_path: Path) -> None:
+    """Keep the first native show request visible across process supervision."""
+
+    install_root = tmp_path / "SugarSubstitute"
+    window_handle_path = tmp_path / "window-handle.txt"
+    child_script = tmp_path / "visible_qt_child.py"
+    child_script.write_text(
+        "\n".join(
+            (
+                "from pathlib import Path",
+                "import sys",
+                "import win32gui",
+                "from PySide6.QtWidgets import QApplication, QWidget",
+                "application = QApplication([])",
+                "window = QWidget()",
+                "window.setWindowTitle('SugarSubstitute visibility probe')",
+                "window.show()",
+                "application.processEvents()",
+                "visible = bool(win32gui.IsWindowVisible(int(window.winId())))",
+                "Path(sys.argv[1]).write_text('visible' if visible else 'hidden', encoding='utf-8')",
+                "raise SystemExit(0 if visible else 5)",
+            )
+        ),
+        encoding="utf-8",
+    )
+    environment = dict(os.environ)
+    environment["QT_QPA_PLATFORM"] = "windows"
+    process, _log_path = spawn_detached_process(
+        (
+            sys.executable,
+            str(child_script),
+            str(window_handle_path),
+            f"--install-root={install_root}",
+        ),
+        environment=environment,
+    )
+
+    try:
+        return_code = process.wait(timeout=10)
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=5)
+
+    assert return_code == 0
+    assert window_handle_path.read_text(encoding="utf-8") == "visible"

--- a/tools/architecture_governance/crash_boundary_inventory.py
+++ b/tools/architecture_governance/crash_boundary_inventory.py
@@ -117,6 +117,7 @@ REVIEWED_CRASH_BOUNDARY_ROWS: tuple[CrashBoundaryInventoryRow, ...] = (
     ("thread", "substitute/infrastructure/execution/host_execution_scheduler.py", "HostExecutionScheduler._ensure_workers_locked", "threading.Thread", 2, "managed_host_scheduler"),
     ("thread", "substitute/infrastructure/execution/long_lived_task.py", "LongLivedTaskHandle.__init__", "threading.Thread", 1, "managed_task_outcomes"),
     ("thread", "substitute/infrastructure/execution/process_output.py", "BinaryProcessOutput.__init__", "threading.Thread", 1, "bounded_process_output"),
+    ("thread", "substitute/infrastructure/process/hidden_process_runner.py", "_consume_output_lines_with_silence_feedback", "threading.Thread", 1, "bounded_process_output"),
     ("thread", "sugarsubstitute_shared/launch_splash/server.py", "SplashSessionServer.start", "threading.Thread", 1, "bounded_transport_thread"),
 )
 # fmt: on


### PR DESCRIPTION
## Summary
- keep silent Comfy Registry installs visibly active with periodic elapsed-time feedback
- preserve console-free Windows supervision without forcing installer and launcher GUI windows hidden
- add a real Windows Qt/Win32 regression that proves a supervised child HWND becomes visible

## Verification
- `python -m ruff format .`
- `python -m ruff check .`
- `python -m mypy --strict substitute tests`
- `python -m tools.check_architecture`
- `python -m tools.check_test_governance`
- `python -m pytest -n auto -q -m "not serial and not isolated"`
- `python -m tools.ci.run_isolated_test_modules --junit-dir=build/test-results/local-isolated`
- `python -m tools.ci.run_serial_test_modules --junit-dir=build/test-results/local-serial`