### PR TITLE
fix(installer): keep setup details usable and recommendations installable

### DIFF
--- a/launcher/sugarsubstitute_launcher/ui/installer_view.py
+++ b/launcher/sugarsubstitute_launcher/ui/installer_view.py
@@ -290,13 +290,21 @@ class InstallerView(QWidget):
         if not isinstance(content_width, int):
             content_width = INSTALLER_CONTENT_MAX_WIDTH
         self.page_stack.setFixedWidth(content_width)
+        self._refresh_active_page_height()
+        self.page_stage.verticalScrollBar().setValue(0)
+
+    def _refresh_active_page_height(self) -> None:
+        """Allocate the current page's full height after dynamic content changes."""
+
+        page = self.page_stack.currentWidget()
+        if page is None:
+            return
         page_layout = page.layout()
         if page_layout is not None:
             page_layout.invalidate()
             page_layout.activate()
         page.updateGeometry()
         self.page_stack.setFixedHeight(page.sizeHint().height())
-        self.page_stage.verticalScrollBar().setValue(0)
 
     def _build_pages(self) -> None:
         """Build the bounded launcher pages owned by this process."""
@@ -488,6 +496,7 @@ class InstallerView(QWidget):
         self.details_button.setText(
             launcher_text("Hide details") if visible else launcher_text("Show details")
         )
+        self._refresh_active_page_height()
 
     def _retranslate_language_page(self) -> None:
         """Immediately preview the selected locale on the first page."""

--- a/substitute/infrastructure/model_recommendations/civitai_gateway.py
+++ b/substitute/infrastructure/model_recommendations/civitai_gateway.py
@@ -41,8 +41,10 @@ from substitute.infrastructure.model_recommendations.civitai_payload_parser impo
     parse_model,
     safe_thumbnail,
 )
+from substitute.infrastructure.execution.parallel_map import BoundedParallelMapper
 
 _API_ROOT = "https://civitai.com/api/v1"
+_ACCESS_CHECK_PARALLELISM = 8
 JsonFetcher = Callable[..., object]
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,6 +113,9 @@ class CivitaiFamilyRecommendationGateway:
                 raise CivitaiRecommendationError(
                     "CivitAI model recommendations returned an invalid response."
                 )
+            page_candidates: list[ModelRecommendation] = []
+            page_model_ids = {existing.model_id for existing in cards}
+            page_hashes = set(seen_hashes)
             for item in payload["items"]:
                 provider_position += 1
                 rank = provider_position
@@ -126,9 +131,19 @@ class CivitaiFamilyRecommendationGateway:
                 )
                 if (
                     card is None
-                    or card.model_id in {existing.model_id for existing in cards}
-                    or card.sha256.casefold() in seen_hashes
+                    or card.model_id in page_model_ids
+                    or card.sha256.casefold() in page_hashes
                 ):
+                    continue
+                page_candidates.append(card)
+                page_model_ids.add(card.model_id)
+                page_hashes.add(card.sha256.casefold())
+            for card, publicly_downloadable in zip(
+                page_candidates,
+                self._public_downloadability(page_candidates),
+                strict=True,
+            ):
+                if not publicly_downloadable:
                     continue
                 cards.append(card)
                 seen_hashes.add(card.sha256.casefold())
@@ -136,6 +151,30 @@ class CivitaiFamilyRecommendationGateway:
                     break
             next_url = _next_page(payload)
         return tuple(cards)
+
+    def _public_downloadability(
+        self,
+        recommendations: list[ModelRecommendation],
+    ) -> tuple[bool, ...]:
+        """Check recommendation access concurrently while preserving card order."""
+
+        if not recommendations:
+            return ()
+        with BoundedParallelMapper(
+            parallelism=min(_ACCESS_CHECK_PARALLELISM, len(recommendations))
+        ) as parallel_mapper:
+            return parallel_mapper.map(
+                self._recommendation_is_publicly_downloadable,
+                recommendations,
+            )
+
+    def _recommendation_is_publicly_downloadable(
+        self,
+        recommendation: ModelRecommendation,
+    ) -> bool:
+        """Return whether one recommendation can be downloaded without auth."""
+
+        return self._is_publicly_downloadable(recommendation.version_id)
 
     def resolve_model_page(
         self,
@@ -158,6 +197,35 @@ class CivitaiFamilyRecommendationGateway:
             thumbnail_policy=self._thumbnail_policy(),
             accepted_base_models=self._recognized_linked_base_models(family),
             target_version_id=version_id,
+        )
+
+    def _is_publicly_downloadable(self, version_id: int) -> bool:
+        """Return whether CivitAI permits this recommended download without auth."""
+
+        payload = self._request(
+            f"{_API_ROOT}/model-versions/mini/{version_id}",
+            purpose="model download access check",
+            include_api_key=False,
+        )
+        if not isinstance(payload, dict):
+            raise CivitaiRecommendationError(
+                "CivitAI model download access returned an invalid response."
+            )
+        availability = _text(payload.get("availability"))
+        requires_auth = payload.get("requireAuth")
+        checks_permission = payload.get("checkPermission")
+        if (
+            availability is None
+            or not isinstance(requires_auth, bool)
+            or not isinstance(checks_permission, bool)
+        ):
+            raise CivitaiRecommendationError(
+                "CivitAI model download access returned an invalid response."
+            )
+        return (
+            availability.casefold() == "public"
+            and not requires_auth
+            and not checks_permission
         )
 
     def _validate_provider_mapping(self, family: ModelFamilyDefinition) -> None:
@@ -220,7 +288,13 @@ class CivitaiFamilyRecommendationGateway:
         provider = self._thumbnail_policy_provider
         return CivitaiThumbnailPolicy() if provider is None else provider()
 
-    def _request(self, url: str, *, purpose: str) -> object:
+    def _request(
+        self,
+        url: str,
+        *,
+        purpose: str,
+        include_api_key: bool = True,
+    ) -> object:
         """Fetch provider JSON with bounded time and sanitized failures."""
 
         if not _is_civitai_api_url(url):
@@ -228,7 +302,11 @@ class CivitaiFamilyRecommendationGateway:
                 "CivitAI pagination returned an unsafe URL."
             )
         headers = {"Accept": "application/json", "User-Agent": "SugarSubstitute/1.0"}
-        api_key = self._api_key_provider() if self._api_key_provider else None
+        api_key = (
+            self._api_key_provider()
+            if include_api_key and self._api_key_provider
+            else None
+        )
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
         try:

--- a/substitute/presentation/onboarding/onboarding_completion_pages.py
+++ b/substitute/presentation/onboarding/onboarding_completion_pages.py
@@ -167,7 +167,7 @@ class ProvisioningPage(OnboardingPageFrame):
 
         self.details_surface = TerminalOutputView(
             self.details_container,
-            min_height=220,
+            min_height=120,
             max_height=280,
         )
         details_layout.addWidget(self.details_surface)

--- a/substitute/presentation/onboarding/onboarding_page_stage.py
+++ b/substitute/presentation/onboarding/onboarding_page_stage.py
@@ -97,7 +97,13 @@ class OnboardingPageStage(QScrollArea):
                 page_layout.invalidate()
                 page_layout.activate()
             page.updateGeometry()
-            page_height = page.sizeHint().height()
+            preferred_height = page.sizeHint().height()
+            minimum_height = page.minimumSizeHint().height()
+            page_height = (
+                min(preferred_height, viewport_height)
+                if minimum_height <= viewport_height
+                else preferred_height
+            )
             vertical_policy = (
                 Qt.ScrollBarPolicy.ScrollBarAsNeeded
                 if page_height > viewport_height

--- a/tests/infrastructure/model_recommendations/test_civitai_gateway.py
+++ b/tests/infrastructure/model_recommendations/test_civitai_gateway.py
@@ -127,6 +127,13 @@ class _RecordedProvider:
         self.urls.append(url)
         if url.endswith("/enums"):
             return {"BaseModel": list(self.base_models)}
+        if "/model-versions/mini/" in url:
+            version_id = int(urlparse(url).path.rsplit("/", maxsplit=1)[-1])
+            return {
+                "availability": "Public",
+                "requireAuth": False,
+                "checkPermission": False,
+            }
         if urlparse(url).path.endswith("/images"):
             version_id = int(parse_qs(urlparse(url).query)["modelVersionId"][0])
             return {"items": self.fallback_images.get(version_id, [])}
@@ -293,7 +300,10 @@ def test_gateway_fetches_a_large_portrait_when_model_payload_has_no_preview() ->
     assert cards[0].thumbnail_url == (
         "https://image.civitai.com/x/width=512/portrait.jpeg"
     )
-    image_query = parse_qs(urlparse(provider.urls[-1]).query)
+    image_url = next(
+        url for url in provider.urls if urlparse(url).path.endswith("/images")
+    )
+    image_query = parse_qs(urlparse(image_url).query)
     assert image_query["modelVersionId"] == ["70"]
     assert image_query["sort"] == ["Most Reactions"]
     assert image_query["nsfw"] == ["None"]

--- a/tests/infrastructure/model_recommendations/test_civitai_recommendation_access.py
+++ b/tests/infrastructure/model_recommendations/test_civitai_recommendation_access.py
@@ -1,0 +1,166 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify unauthenticated access policy for automatic CivitAI recommendations."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import pytest
+
+from substitute.domain.model_recommendations import (
+    ModelFamilyId,
+    ModelRecommendationQuery,
+)
+from substitute.infrastructure.model_recommendations import (
+    CivitaiFamilyRecommendationGateway,
+    CivitaiRecommendationError,
+)
+
+
+def _model(model_id: int) -> dict[str, object]:
+    """Build one family-compatible recommendation candidate."""
+
+    version_id = model_id * 10
+    return {
+        "id": model_id,
+        "name": f"Model {model_id}",
+        "type": "Checkpoint",
+        "nsfw": False,
+        "creator": {"username": "creator"},
+        "modelVersions": [
+            {
+                "id": version_id,
+                "name": f"Version {model_id}",
+                "baseModel": "Illustrious",
+                "availability": "Public",
+                "images": [
+                    {
+                        "id": model_id * 100,
+                        "url": f"https://image.civitai.com/model-{model_id}.jpeg",
+                        "nsfw": False,
+                        "nsfwLevel": 1,
+                        "type": "image",
+                        "width": 832,
+                        "height": 1216,
+                    }
+                ],
+                "files": [
+                    {
+                        "name": f"model-{model_id}.safetensors",
+                        "downloadUrl": (
+                            f"https://civitai.com/api/download/models/{version_id}"
+                        ),
+                        "sizeKB": 1024,
+                        "primary": True,
+                        "metadata": {"format": "SafeTensor"},
+                        "hashes": {"SHA256": f"{model_id:064x}"},
+                        "pickleScanResult": "Success",
+                        "virusScanResult": "Success",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+class _AccessProvider:
+    """Serve model candidates and exact per-version access declarations."""
+
+    def __init__(self, access_by_version: dict[int, object]) -> None:
+        """Store access payloads and observable request state."""
+
+        self.access_by_version = access_by_version
+        self.urls: list[str] = []
+        self.access_headers: list[dict[str, str]] = []
+
+    def __call__(self, url: str, **kwargs: object) -> object:
+        """Return the provider response owned by the requested route."""
+
+        self.urls.append(url)
+        path = urlparse(url).path
+        if path.endswith("/enums"):
+            return {"BaseModel": ["Illustrious"]}
+        if "/model-versions/mini/" in path:
+            headers = kwargs.get("headers")
+            assert isinstance(headers, dict)
+            self.access_headers.append(headers)
+            version_id = int(path.rsplit("/", maxsplit=1)[-1])
+            return self.access_by_version[version_id]
+        if path == "/api/v1/models/1":
+            return _model(1)
+        return {"items": [_model(1), _model(2)]}
+
+
+def _access(*, requires_authentication: bool) -> dict[str, object]:
+    """Return one current CivitAI minimal-version access declaration."""
+
+    return {
+        "availability": "Public",
+        "requireAuth": requires_authentication,
+        "checkPermission": False,
+    }
+
+
+def test_automatic_recommendations_exclude_api_key_downloads() -> None:
+    """Never suggest a model that first-run setup cannot download anonymously."""
+
+    provider = _AccessProvider(
+        {
+            10: _access(requires_authentication=True),
+            20: _access(requires_authentication=False),
+        }
+    )
+
+    cards = CivitaiFamilyRecommendationGateway(
+        fetch_json=provider,
+        api_key_provider=lambda: "configured-secret",
+    ).discover(
+        ModelRecommendationQuery(ModelFamilyId.SDXL),
+        limit=2,
+    )
+
+    assert [card.model_id for card in cards] == [2]
+    assert provider.access_headers
+    assert all("Authorization" not in headers for headers in provider.access_headers)
+
+
+def test_explicit_model_links_remain_available_for_api_key_downloads() -> None:
+    """Keep auth-capable user-selected downloads outside recommendation policy."""
+
+    provider = _AccessProvider({10: _access(requires_authentication=True)})
+
+    card = CivitaiFamilyRecommendationGateway(fetch_json=provider).resolve_model_page(
+        ModelFamilyId.SDXL,
+        "https://civitai.com/models/1?modelVersionId=10",
+    )
+
+    assert card is not None
+    assert card.version_id == 10
+    assert not provider.access_headers
+
+
+def test_automatic_recommendations_fail_closed_on_unknown_access() -> None:
+    """Do not surface a candidate when the provider omits its auth contract."""
+
+    provider = _AccessProvider({10: {}, 20: _access(requires_authentication=False)})
+
+    with pytest.raises(CivitaiRecommendationError):
+        CivitaiFamilyRecommendationGateway(fetch_json=provider).discover(
+            ModelRecommendationQuery(ModelFamilyId.SDXL),
+            limit=2,
+        )

--- a/tests/launcher/installation_workflow/test_window_surface.py
+++ b/tests/launcher/installation_workflow/test_window_surface.py
@@ -281,3 +281,48 @@ def test_launcher_page_fits_fixed_window_with_live_output_visible(
             assert abs(top_gap - bottom_gap) <= 2
     finally:
         close_and_delete_launcher_window(window)
+
+
+def test_progress_details_receive_their_declared_console_height(
+    tmp_path: Path,
+) -> None:
+    """Opening progress details should allocate the console's readable height."""
+
+    application = launcher_test_application()
+    window = LauncherMainWindow(
+        initial_layout=InstallLayout.from_root(tmp_path / "SugarSubstitute"),
+        continue_install=False,
+        repair=False,
+        update_check_enabled=True,
+        initial_release_source=release_source_for_test(),
+        workflow_factory=workflow_factory(),
+    )
+    window.show()
+    window.view.show_status_output()
+    application.processEvents()
+
+    try:
+        compact_page_height = window.view.page_stack.height()
+        window.view.details_button.click()
+        application.processEvents()
+
+        console = window.view.progress_log.log_view
+        assert window.view.details_button.isChecked() is True
+        assert console.isVisible() is True
+        assert console.height() >= console.minimumHeight()
+        assert window.view.page_stack.height() > compact_page_height
+        assert window.view.page_stack.contentsRect().contains(
+            console.mapTo(window.view.page_stack, console.rect().bottomRight())
+        )
+
+        window.view.details_button.click()
+        application.processEvents()
+        assert console.isVisible() is False
+        assert window.view.page_stack.height() == compact_page_height
+
+        window.view.details_button.click()
+        application.processEvents()
+        assert console.isVisible() is True
+        assert console.height() >= console.minimumHeight()
+    finally:
+        close_and_delete_launcher_window(window)

--- a/tests/presentation/onboarding/window/test_frame_composition.py
+++ b/tests/presentation/onboarding/window/test_frame_composition.py
@@ -211,7 +211,7 @@ def test_onboarding_window_builds_all_required_pages(
     assert window.provisioning_page.details_container.isHidden() is True
     assert window.provisioning_page.overall_progress_bar.maximum() == 100
     assert log_view.maximumHeight() == 280
-    assert log_view.minimumHeight() == 220
+    assert log_view.minimumHeight() == 120
     assert (
         window.integrations_page.danbooru_image_policy_combo.currentData()
         == "safe_only"

--- a/tests/presentation/onboarding/window/test_layout_and_theme.py
+++ b/tests/presentation/onboarding/window/test_layout_and_theme.py
@@ -22,7 +22,8 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-from PySide6.QtCore import QPoint, QRect
+from PySide6.QtCore import QPoint, QRect, QSize
+from PySide6.QtWidgets import QWidget
 from qfluentwidgets import Theme  # type: ignore[import-untyped]
 
 from substitute.presentation.onboarding.onboarding_controller import (
@@ -33,6 +34,9 @@ from substitute.presentation.onboarding.onboarding_models import (
     OnboardingFlowMode,
     OnboardingTargetMode,
 )
+from substitute.presentation.onboarding.onboarding_page_stage import (
+    OnboardingPageStage,
+)
 from substitute.presentation.onboarding.onboarding_window import (
     OnboardingWindow,
 )
@@ -42,6 +46,63 @@ from tests.support.qt.semantic_wait import wait_for_qt_condition
 from tests.presentation.theme.support import fluent_theme
 
 from .controller_double import _FakeController
+
+
+class _HeightNegotiationPage(QWidget):
+    """Expose explicit preferred and minimum heights to the real page stage."""
+
+    def __init__(self, *, preferred_height: int, minimum_height: int) -> None:
+        """Store the two dimensions exercised by stage height negotiation."""
+
+        super().__init__()
+        self._preferred_height = preferred_height
+        self._minimum_height = minimum_height
+
+    def sizeHint(self) -> QSize:  # noqa: N802
+        """Return the page's unconstrained preferred size."""
+
+        return QSize(800, self._preferred_height)
+
+    def minimumSizeHint(self) -> QSize:  # noqa: N802
+        """Return the smallest height that preserves the page's content."""
+
+        return QSize(800, self._minimum_height)
+
+
+@pytest.mark.parametrize(
+    ("minimum_height", "expects_scroll"),
+    ((400, False), (600, True)),
+)
+def test_page_stage_shrinks_flexible_pages_before_enabling_scroll(
+    minimum_height: int,
+    expects_scroll: bool,
+) -> None:
+    """Use the viewport for flexible content and scroll only rigid overflow."""
+
+    application = ensure_qt_application()
+    host = QWidget()
+    host.resize(1104, 548)
+    stage = OnboardingPageStage(host)
+    stage.setGeometry(host.rect())
+    page = _HeightNegotiationPage(
+        preferred_height=600,
+        minimum_height=minimum_height,
+    )
+    stage.add_page(page)
+    host.show()
+    application.processEvents()
+    stage.show_page(page)
+    application.processEvents()
+
+    viewport_height = stage.viewport().contentsRect().height()
+    if expects_scroll:
+        assert stage.page_stack.height() == 600
+        assert stage.verticalScrollBar().maximum() > 0
+    else:
+        assert stage.page_stack.height() == viewport_height
+        assert stage.verticalScrollBar().maximum() == 0
+        assert page.height() == viewport_height
+    host.close()
 
 
 def test_onboarding_pages_fit_fixed_window_layout_budget(

--- a/tests/presentation/onboarding/window/test_provisioning_presentation.py
+++ b/tests/presentation/onboarding/window/test_provisioning_presentation.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from PySide6.QtCore import Qt
 
 from substitute.application.onboarding import OnboardingProvisioningFailure
 from substitute.presentation.onboarding.onboarding_controller import (
@@ -298,7 +299,7 @@ def test_provisioning_live_output_stays_inside_status_panel(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Setup live output should remain bounded inside the status card."""
+    """Expanded setup output should fit the fixed window without page scrolling."""
 
     application = ensure_qt_application()
     monkeypatch.setattr(OnboardingWindow, "_center_on_screen", lambda self: None)
@@ -316,7 +317,6 @@ def test_provisioning_live_output_stays_inside_status_panel(
             _FakeController(draft, OnboardingFlowMode.FIRST_RUN),
         )
     )
-    window.resize(1220, 900)
     window._current_page = OnboardingPageId.PROVISIONING
     window.page_stack.setCurrentWidget(window.provisioning_page)
     window.page_stage.refresh_current_page_height()
@@ -361,7 +361,17 @@ def test_provisioning_live_output_stays_inside_status_panel(
     assert not window.provisioning_page.details_container.isHidden()
     assert window.provisioning_page.show_log_button.text() == "Hide setup log"
     assert window.provisioning_page.height() > page_height_before
-    assert window.page_stage.verticalScrollBar().maximum() > 0
+    console = window.provisioning_page.details_surface.log_view
+    assert console.height() >= console.minimumHeight()
+    assert (
+        window.page_stack.height()
+        <= window.page_stage.viewport().contentsRect().height()
+    )
+    assert window.page_stage.verticalScrollBar().maximum() == 0
+    assert window.page_stage.verticalScrollBarPolicy() is (
+        Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+    )
+    assert window.page_stage.verticalScrollBar().isHidden()
 
     window.provisioning_page.show_log_button.click()
     application.processEvents()


### PR DESCRIPTION
Fixes the launcher details panel height and keeps the expanded onboarding setup log inside the fixed installer window without a page scrollbar. Automatic onboarding recommendations now verify CivitAI's anonymous download-access contract before presentation, while explicit user-linked models and authenticated downloads remain supported. Verified with the full parallel, isolated, and serial test suites plus format, lint, strict typing, architecture, and test-governance gates.