### PR TITLE
ci(release): qualify the atomic splash-to-shell handoff

### DIFF
--- a/ARCHITECTURE_DEBT.toml
+++ b/ARCHITECTURE_DEBT.toml
@@ -1338,7 +1338,7 @@ next_extraction = "Extract visible-source AST classification and pseudo-localiza
 id = "SS-ARCH-096"
 owner = "Windows installer automation"
 paths = ["tools/ci/drive_windows_installer.py"]
-fingerprint = "sha256:47e82958d2ca03e26672ac8c55cd26bffc1585a4149c81ed928fa49343065beb"
+fingerprint = "sha256:1f5943339b885992a88f19ff4d80eccda516ecf9acef3cad5eb28017f19b6c84"
 issue = "chore:SS-ARCH-096"
 review_by = 2026-12-15
 responsibilities = [
@@ -1349,19 +1349,3 @@ responsibilities = [
   "command-line orchestration",
 ]
 next_extraction = "Extract native process/desktop control and historical evidence projection from installer UI workflow automation."
-
-[[debts]]
-id = "SS-ARCH-097"
-owner = "installer UI qualification"
-paths = ["tools/ci/installer_ui_qualification.py"]
-fingerprint = "sha256:95b3a0139186c4194f8a97f790f6bd1a30b66af3e95883d5e5f8fa128a80b665"
-issue = "chore:SS-ARCH-097"
-review_by = 2026-12-15
-responsibilities = [
-  "qualification evidence preparation",
-  "installed candidate launch",
-  "shell and event-sequence verification",
-  "cross-platform process termination",
-  "readiness receipt and startup trace interpretation",
-]
-next_extraction = "Extract installed-candidate process lifecycle and evidence/trace verification from qualification workflow orchestration."

--- a/ARCHITECTURE_WAIVERS.toml
+++ b/ARCHITECTURE_WAIVERS.toml
@@ -1852,19 +1852,6 @@ next_limit = 564
 debt = "SS-ARCH-096"
 
 [[waivers]]
-id = "SS-WAIVER-R097"
-owner = "installer UI qualification"
-rule = "STRUCT003"
-path = "tools/ci/installer_ui_qualification.py"
-kind = "remediation"
-justification = "The assessed file mixes qualification evidence preparation, installed candidate launch, shell and event-sequence verification, cross-platform process termination, readiness receipt and startup trace interpretation. Current packaged-installer execution now has an independent owner; next extract installed-candidate process lifecycle and evidence/trace verification from qualification workflow orchestration."
-issue = "chore:SS-ARCH-097"
-review_by = 2026-12-15
-max_lines = 560
-next_limit = 500
-debt = "SS-ARCH-097"
-
-[[waivers]]
 id = "SS-WAIVER-S076"
 owner = "prompt abuse structural policy"
 rule = "STRUCT003"

--- a/tests/presentation/canvas/output/real_shell/test_reported_regressions_characterization.py
+++ b/tests/presentation/canvas/output/real_shell/test_reported_regressions_characterization.py
@@ -129,7 +129,12 @@ def test_two_cube_out_of_order_batches_replace_the_last_preview(
 
     harness.wait_for_output_count("alpha", 4)
     harness.wait_until(lambda: harness.preview_count() == 0)
-    harness.wait_until(lambda: len(harness.fingerprint().grid_target_frames) == 2)
+    harness.wait_until(
+        lambda: (
+            harness.fingerprint().active_source_tab_key == _UPSCALE_SOURCE
+            and len(harness.fingerprint().grid_target_frames) == 2
+        )
+    )
 
     state = harness.fingerprint()
     assert state.active_source_tab_key == _UPSCALE_SOURCE

--- a/tests/qualification/installer/test_current_ui.py
+++ b/tests/qualification/installer/test_current_ui.py
@@ -38,11 +38,9 @@ from substitute.presentation.onboarding.installer_qualification import (
     qualification_preflight_action,
 )
 from tools.ci.current_installer_execution import run_current_installer_ui
+from tools.ci.installer_evidence_verification import assert_qualification_event_sequence
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
-from tools.ci.installer_ui_qualification import (
-    assert_qualification_event_sequence,
-    prepare_qualification_evidence,
-)
+from tools.ci.installer_ui_qualification import prepare_qualification_evidence
 from tools.ci.verify_installer_lifecycle import verify_clean_install
 
 

--- a/tests/qualification/integration/installer_update/test_lifecycle_trace.py
+++ b/tests/qualification/integration/installer_update/test_lifecycle_trace.py
@@ -24,11 +24,38 @@ from pathlib import Path
 import pytest
 
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
-from tools.ci.installer_ui_qualification import assert_startup_trace_sequence
+from tools.ci.installer_evidence_verification import assert_startup_trace_sequence
 
 
 def test_lifecycle_requires_ordered_splash_to_main_shell_trace(tmp_path: Path) -> None:
-    """The install proof should accept only the production reveal sequence."""
+    """The install proof should accept the painted-shell handoff sequence."""
+
+    trace_path = tmp_path / "startup-trace.jsonl"
+    trace_path.write_text(
+        "\n".join(
+            (
+                json.dumps({"event": "launch_splash.started"}),
+                json.dumps({"event": "main_shell.shown"}),
+                json.dumps(
+                    {
+                        "event": "startup.visibility.first_event",
+                        "fields": {
+                            "event_type": "Paint",
+                            "label": "shell_frame",
+                        },
+                    }
+                ),
+                json.dumps({"event": "launch_splash.closed"}),
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert_startup_trace_sequence(trace_path)
+
+
+def test_lifecycle_rejects_splash_close_before_shell_paint(tmp_path: Path) -> None:
+    """A splash must remain until its replacement shell has actually painted."""
 
     trace_path = tmp_path / "startup-trace.jsonl"
     trace_path.write_text(
@@ -43,7 +70,30 @@ def test_lifecycle_requires_ordered_splash_to_main_shell_trace(tmp_path: Path) -
         encoding="utf-8",
     )
 
-    assert_startup_trace_sequence(trace_path)
+    with pytest.raises(InstallerLifecycleError, match="splash-to-shell sequence"):
+        assert_startup_trace_sequence(trace_path)
+
+
+def test_lifecycle_rejects_unpainted_shell_before_splash_close(
+    tmp_path: Path,
+) -> None:
+    """Calling show is not proof that the replacement surface reached the user."""
+
+    trace_path = tmp_path / "startup-trace.jsonl"
+    trace_path.write_text(
+        "\n".join(
+            json.dumps({"event": event})
+            for event in (
+                "launch_splash.started",
+                "main_shell.shown",
+                "launch_splash.closed",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InstallerLifecycleError, match="splash-to-shell sequence"):
+        assert_startup_trace_sequence(trace_path)
 
 
 def test_lifecycle_rejects_main_shell_without_completed_splash(tmp_path: Path) -> None:

--- a/tests/qualification/launcher/historical_launch/test_contract.py
+++ b/tests/qualification/launcher/historical_launch/test_contract.py
@@ -87,11 +87,18 @@ def test_historical_shell_requires_ordered_trace_and_live_handoff_process(
     trace_path.parent.mkdir(parents=True)
     trace_path.write_text(
         "".join(
-            json.dumps({"event": event}) + "\n"
-            for event in (
-                "launch_splash.started",
-                "launch_splash.closed",
-                "main_shell.shown",
+            json.dumps(payload) + "\n"
+            for payload in (
+                {"event": "launch_splash.started"},
+                {"event": "main_shell.shown"},
+                {
+                    "event": "startup.visibility.first_event",
+                    "fields": {
+                        "event_type": "Paint",
+                        "label": "shell_frame",
+                    },
+                },
+                {"event": "launch_splash.closed"},
             )
         ),
         encoding="utf-8",
@@ -135,11 +142,18 @@ def test_historical_shell_rejects_trace_without_live_app_owner(
     trace_path.parent.mkdir(parents=True)
     trace_path.write_text(
         "".join(
-            json.dumps({"event": event}) + "\n"
-            for event in (
-                "launch_splash.started",
-                "launch_splash.closed",
-                "main_shell.shown",
+            json.dumps(payload) + "\n"
+            for payload in (
+                {"event": "launch_splash.started"},
+                {"event": "main_shell.shown"},
+                {
+                    "event": "startup.visibility.first_event",
+                    "fields": {
+                        "event_type": "Paint",
+                        "label": "shell_frame",
+                    },
+                },
+                {"event": "launch_splash.closed"},
             )
         ),
         encoding="utf-8",

--- a/tools/ci/current_installer_execution.py
+++ b/tools/ci/current_installer_execution.py
@@ -24,7 +24,7 @@ import subprocess
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
 from sugarsubstitute_shared.installer_qualification import InstallerQualificationPlan
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
-from tools.ci.installer_ui_qualification import diagnostic_tail
+from tools.ci.installer_evidence_verification import diagnostic_tail
 
 
 _INSTALL_TIMEOUT_SECONDS = 3_600.0

--- a/tools/ci/drive_windows_installer.py
+++ b/tools/ci/drive_windows_installer.py
@@ -38,7 +38,7 @@ from launcher.sugarsubstitute_launcher.install_layout import InstallLayout  # no
 from tools.ci.historical_release_contract import (  # noqa: E402
     HISTORICAL_MANAGED_COMFY_OUTPUT_LOG_NAME,
 )
-from tools.ci.installer_ui_qualification import diagnostic_tail  # noqa: E402
+from tools.ci.installer_evidence_verification import diagnostic_tail  # noqa: E402
 
 _UI_PHASE_TIMEOUT_SECONDS = 60.0
 _PROVISIONING_TIMEOUT_SECONDS = 1_800.0

--- a/tools/ci/historical_launch_qualification.py
+++ b/tools/ci/historical_launch_qualification.py
@@ -29,10 +29,12 @@ from launcher.sugarsubstitute_launcher.install_layout import (
     default_install_root,
 )
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
-from tools.ci.installer_ui_qualification import (
-    InstalledCandidateLaunch,
+from tools.ci.installer_evidence_verification import (
     assert_startup_trace_sequence,
     diagnostic_tail,
+)
+from tools.ci.installer_ui_qualification import (
+    InstalledCandidateLaunch,
     installed_launch_has_progress,
     process_tree_diagnostics,
 )

--- a/tools/ci/installer_evidence_verification.py
+++ b/tools/ci/installer_evidence_verification.py
@@ -1,0 +1,152 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify durable installer interaction and startup-handoff evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
+
+_SHELL_FRAME_PAINT_EVENT = "main_shell.first_paint"
+_REQUIRED_STARTUP_EVENTS = (
+    "launch_splash.started",
+    "main_shell.shown",
+    _SHELL_FRAME_PAINT_EVENT,
+    "launch_splash.closed",
+)
+
+
+def assert_qualification_event_sequence(
+    event_log_path: Path,
+    *,
+    token: str,
+    required_events: tuple[str, ...],
+) -> None:
+    """Require token-bound production UI interactions in their expected order."""
+
+    try:
+        lines = event_log_path.read_text(
+            encoding="utf-8",
+            errors="replace",
+        ).splitlines()
+    except OSError as error:
+        raise InstallerLifecycleError(
+            f"Installer did not write its UI qualification log: {event_log_path}."
+        ) from error
+    events: list[str] = []
+    for line in lines:
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise InstallerLifecycleError(
+                f"Installer wrote malformed UI qualification JSON: {event_log_path}."
+            ) from error
+        if not isinstance(payload, dict) or payload.get("token") != token:
+            raise InstallerLifecycleError(
+                "Installer UI qualification evidence did not match this CI run."
+            )
+        event = payload.get("event")
+        if isinstance(event, str):
+            events.append(event)
+    if not _contains_ordered_events(events, required_events):
+        raise InstallerLifecycleError(
+            "Installer UI did not complete the required interaction sequence: "
+            + " -> ".join(required_events)
+            + ".\n"
+            + diagnostic_tail(event_log_path)
+        )
+
+
+def assert_startup_trace_sequence(trace_path: Path) -> None:
+    """Require the splash to remain until its replacement shell has painted."""
+
+    try:
+        lines = trace_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as error:
+        raise InstallerLifecycleError(
+            f"Button-launched child did not write its startup trace: {trace_path}."
+        ) from error
+    events: list[str] = []
+    for line in lines:
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise InstallerLifecycleError(
+                f"Button-launched child wrote malformed startup trace JSON: {trace_path}."
+            ) from error
+        if isinstance(payload, dict) and isinstance(payload.get("event"), str):
+            events.append(payload["event"])
+            if _is_shell_frame_paint(payload):
+                events.append(_SHELL_FRAME_PAINT_EVENT)
+    if not _contains_ordered_events(events, _REQUIRED_STARTUP_EVENTS):
+        raise InstallerLifecycleError(
+            "Open Substitute did not complete the required splash-to-shell sequence: "
+            + " -> ".join(_REQUIRED_STARTUP_EVENTS)
+            + ".\n"
+            + diagnostic_tail(trace_path)
+        )
+
+
+def diagnostic_tail(path: Path, *, maximum_lines: int = 80) -> str:
+    """Return a bounded diagnostic suffix when a qualification step fails."""
+
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return f"<missing diagnostics: {path}>"
+    return "\n".join(lines[-maximum_lines:])
+
+
+def _is_shell_frame_paint(payload: object) -> bool:
+    """Return whether one trace record proves the replacement shell painted."""
+
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("event") != "startup.visibility.first_event":
+        return False
+    fields = payload.get("fields")
+    return (
+        isinstance(fields, dict)
+        and fields.get("label") == "shell_frame"
+        and fields.get("event_type") == "Paint"
+    )
+
+
+def _contains_ordered_events(
+    events: list[str],
+    required_events: tuple[str, ...],
+) -> bool:
+    """Return whether every required event appears in order."""
+
+    if not required_events:
+        return True
+    next_index = 0
+    for event in events:
+        if event == required_events[next_index]:
+            next_index += 1
+            if next_index == len(required_events):
+                return True
+    return False
+
+
+__all__ = [
+    "assert_qualification_event_sequence",
+    "assert_startup_trace_sequence",
+    "diagnostic_tail",
+]

--- a/tools/ci/installer_ui_qualification.py
+++ b/tools/ci/installer_ui_qualification.py
@@ -44,6 +44,11 @@ from sugarsubstitute_shared.installer_qualification import (
     InstallerQualificationPlan,
     InstallerQualificationTarget,
 )
+from tools.ci.installer_evidence_verification import (
+    assert_qualification_event_sequence,
+    assert_startup_trace_sequence,
+    diagnostic_tail,
+)
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
 from tools.ci.installer_process_diagnostics import process_tree_diagnostics
 from tools.ci.installed_version_evidence import wait_for_installed_version
@@ -59,11 +64,6 @@ _TERMINAL_STARTUP_FAILURE_EVENTS = frozenset(
     }
 )
 _PROCESS_TERMINATION_TIMEOUT_SECONDS = 10.0
-_REQUIRED_STARTUP_EVENTS = (
-    "launch_splash.started",
-    "launch_splash.closed",
-    "main_shell.shown",
-)
 _FROZEN_LAUNCH_OVERRIDE_VARIABLES = (
     "PYTHONHOME",
     "PYTHONPATH",
@@ -276,47 +276,6 @@ def verify_main_shell_evidence(
             terminate_verified_process(candidate_launch.process.pid)
 
 
-def assert_qualification_event_sequence(
-    event_log_path: Path,
-    *,
-    token: str,
-    required_events: tuple[str, ...],
-) -> None:
-    """Require token-bound production UI interactions in their expected order."""
-
-    try:
-        lines = event_log_path.read_text(
-            encoding="utf-8",
-            errors="replace",
-        ).splitlines()
-    except OSError as error:
-        raise InstallerLifecycleError(
-            f"Installer did not write its UI qualification log: {event_log_path}."
-        ) from error
-    events: list[str] = []
-    for line in lines:
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError as error:
-            raise InstallerLifecycleError(
-                f"Installer wrote malformed UI qualification JSON: {event_log_path}."
-            ) from error
-        if not isinstance(payload, dict) or payload.get("token") != token:
-            raise InstallerLifecycleError(
-                "Installer UI qualification evidence did not match this CI run."
-            )
-        event = payload.get("event")
-        if isinstance(event, str):
-            events.append(event)
-    if not _contains_ordered_events(events, required_events):
-        raise InstallerLifecycleError(
-            "Installer UI did not complete the required interaction sequence: "
-            + " -> ".join(required_events)
-            + ".\n"
-            + diagnostic_tail(event_log_path)
-        )
-
-
 def terminate_verified_process(pid: int) -> None:
     """Terminate only the token-verified app process and its child processes."""
 
@@ -388,16 +347,6 @@ def _terminate_posix_process_tree(pid: int) -> None:
             + ", ".join(str(process_id) for process_id in unresolved)
             + "."
         )
-
-
-def diagnostic_tail(path: Path, *, maximum_lines: int = 80) -> str:
-    """Return a bounded diagnostic suffix when a qualification step fails."""
-
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError:
-        return f"<missing diagnostics: {path}>"
-    return "\n".join(lines[-maximum_lines:])
 
 
 def _wait_for_readiness_receipt(
@@ -564,51 +513,6 @@ def _path_signature(path: Path) -> tuple[bool, int]:
         return False, 0
 
 
-def assert_startup_trace_sequence(trace_path: Path) -> None:
-    """Require splash start, splash close, then main-shell reveal in that order."""
-
-    try:
-        lines = trace_path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError as error:
-        raise InstallerLifecycleError(
-            f"Button-launched child did not write its startup trace: {trace_path}."
-        ) from error
-    events: list[str] = []
-    for line in lines:
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError as error:
-            raise InstallerLifecycleError(
-                f"Button-launched child wrote malformed startup trace JSON: {trace_path}."
-            ) from error
-        if isinstance(payload, dict) and isinstance(payload.get("event"), str):
-            events.append(payload["event"])
-    if not _contains_ordered_events(events, _REQUIRED_STARTUP_EVENTS):
-        raise InstallerLifecycleError(
-            "Open Substitute did not complete the required splash-to-shell sequence: "
-            + " -> ".join(_REQUIRED_STARTUP_EVENTS)
-            + ".\n"
-            + diagnostic_tail(trace_path)
-        )
-
-
-def _contains_ordered_events(
-    events: list[str],
-    required_events: tuple[str, ...],
-) -> bool:
-    """Return whether every required event appears in order."""
-
-    if not required_events:
-        return True
-    next_index = 0
-    for event in events:
-        if event == required_events[next_index]:
-            next_index += 1
-            if next_index == len(required_events):
-                return True
-    return False
-
-
 def _windows_process_exists(pid: int) -> bool:
     """Return whether a Windows process still owns the supplied identifier."""
 
@@ -627,9 +531,6 @@ def _windows_process_exists(pid: int) -> bool:
 __all__ = [
     "InstalledCandidateLaunch",
     "InstallerQualificationEvidence",
-    "assert_qualification_event_sequence",
-    "assert_startup_trace_sequence",
-    "diagnostic_tail",
     "installed_launch_has_progress",
     "launch_installed_candidate",
     "prepare_qualification_evidence",


### PR DESCRIPTION
Corrects release qualification to require the production atomic handoff order: launch splash starts, the replacement main shell is shown and actually paints, then splash closure is acknowledged.

The previous verifier required the unsafe obsolete order and rejected successful candidate traces on Windows, Linux, and macOS. The evidence policy is now independently owned, the old order and unpainted-shell cases are regressions, and all repository gates pass locally.