### PR TITLE
fix(startup): keep first-run and repair handoffs visibly usable

### DIFF
--- a/launcher/sugarsubstitute_launcher/application_lifecycle_supervisor.py
+++ b/launcher/sugarsubstitute_launcher/application_lifecycle_supervisor.py
@@ -28,6 +28,7 @@ from launcher.sugarsubstitute_launcher.crash_supervisor import (
     ApplicationCrashSupervisor,
 )
 from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from sugarsubstitute_shared.application_readiness import ApplicationReadinessSurface
 
 
 class ApplicationLifecycleSupervisor:
@@ -36,7 +37,12 @@ class ApplicationLifecycleSupervisor:
     def __init__(self) -> None:
         """Create the readiness and crash owners for one launch sequence."""
 
-        self._readiness = ApplicationReadinessSupervisor()
+        self._readiness = ApplicationReadinessSupervisor(
+            accepted_surfaces=(
+                ApplicationReadinessSurface.MAIN_SHELL,
+                ApplicationReadinessSurface.ONBOARDING,
+            )
+        )
         self._crash = ApplicationCrashSupervisor()
 
     def supervise(

--- a/launcher/sugarsubstitute_launcher/application_readiness_supervisor.py
+++ b/launcher/sugarsubstitute_launcher/application_readiness_supervisor.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import dataclass
 import json
 from pathlib import Path
@@ -88,7 +88,7 @@ class CandidateProcess(Protocol):
 
 
 class ApplicationReadinessSupervisor:
-    """Start a candidate and wait for its token-bound visible-shell receipt."""
+    """Start an application and require an accepted visible-surface receipt."""
 
     def __init__(
         self,
@@ -101,16 +101,22 @@ class ApplicationReadinessSupervisor:
         monotonic: Callable[[], float] = time.monotonic,
         wait: Callable[[float], object] | None = None,
         token_factory: Callable[[], str] | None = None,
+        accepted_surfaces: Collection[ApplicationReadinessSurface] = (
+            ApplicationReadinessSurface.MAIN_SHELL,
+        ),
     ) -> None:
-        """Store bounded process and clock collaborators."""
+        """Store bounded process, clock, and surface-policy collaborators."""
 
         if timeout_seconds <= 0:
             raise ValueError("Application readiness timeout must be positive.")
+        if not accepted_surfaces:
+            raise ValueError("At least one application readiness surface is required.")
         self._timeout_seconds = timeout_seconds
         self._process_starter = process_starter or _start_candidate_process
         self._monotonic = monotonic
         self._wait = wait or threading.Event().wait
         self._token_factory = token_factory or (lambda: secrets.token_urlsafe(32))
+        self._accepted_surfaces = frozenset(accepted_surfaces)
 
     def launch_until_ready(
         self,
@@ -119,7 +125,7 @@ class ApplicationReadinessSupervisor:
         command: Sequence[str],
         environment: Mapping[str, str],
     ) -> CandidateProcess:
-        """Return the running candidate only after its main shell is responsive."""
+        """Return the running process after an accepted surface is responsive."""
 
         contract = self._readiness_contract(layout=layout, environment=environment)
         receipt_path = contract.receipt_path
@@ -144,11 +150,12 @@ class ApplicationReadinessSupervisor:
                         terminated_process=process,
                     )
                 if receipt_path.exists():
-                    self._validate_receipt(
+                    receipt = self._validate_receipt(
                         receipt_path=receipt_path,
                         expected_token=token,
                         expected_pid=process.pid,
                     )
+                    self._require_accepted_surface(receipt)
                     if not contract.externally_owned:
                         receipt_path.unlink()
                     return process
@@ -193,8 +200,8 @@ class ApplicationReadinessSupervisor:
         receipt_path: Path,
         expected_token: str,
         expected_pid: int,
-    ) -> None:
-        """Fail closed unless a receipt belongs to the supervised process."""
+    ) -> ApplicationReadinessReceipt:
+        """Return a valid receipt that belongs to the supervised process."""
 
         try:
             payload = json.loads(receipt_path.read_text(encoding="utf-8"))
@@ -215,11 +222,23 @@ class ApplicationReadinessSupervisor:
             raise ApplicationReadinessError(
                 "Application readiness receipt did not match the launched process."
             )
-        if receipt.surface is not ApplicationReadinessSurface.MAIN_SHELL:
-            raise ApplicationReadinessError(
-                "SugarSubstitute did not reveal its main shell. "
-                f"Reported surface: {receipt.surface.value}."
-            )
+        return receipt
+
+    def _require_accepted_surface(
+        self,
+        receipt: ApplicationReadinessReceipt,
+    ) -> None:
+        """Fail unless the reported painted surface satisfies this launch policy."""
+
+        if receipt.surface in self._accepted_surfaces:
+            return
+        accepted = ", ".join(
+            sorted(surface.value for surface in self._accepted_surfaces)
+        )
+        raise ApplicationReadinessError(
+            "SugarSubstitute did not reveal an accepted visible surface. "
+            f"Expected: {accepted}. Reported: {receipt.surface.value}."
+        )
 
 
 def _start_candidate_process(

--- a/substitute/app/bootstrap/bootstrap_route_controller.py
+++ b/substitute/app/bootstrap/bootstrap_route_controller.py
@@ -28,7 +28,7 @@ from substitute.domain.onboarding import (
     ReadinessAssessment,
 )
 from substitute.app.bootstrap.startup_trace import trace_mark
-from substitute.shared.logging.logger import get_logger, log_exception
+from substitute.shared.logging.logger import get_logger, log_exception, log_warning
 
 _LOGGER = get_logger("app.bootstrap.bootstrap_route_controller")
 
@@ -60,6 +60,7 @@ class SplashCloseProtocol(Protocol):
 
 
 ShowBootstrapWindow = Callable[..., BootstrapRouteWindowProtocol]
+ScheduleAfterSurfacePaint = Callable[[object, Callable[[], None]], None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,6 +81,7 @@ class BootstrapRouteController:
         start_ready_app_process: Callable[[Sequence[str]], bool],
         launch_ready_shell: Callable[[InstallationContext], None],
         quit_app: Callable[[], None],
+        schedule_after_surface_paint: ScheduleAfterSurfacePaint,
     ) -> None:
         """Store ports needed to continue after onboarding or repair."""
 
@@ -87,6 +89,7 @@ class BootstrapRouteController:
         self._start_ready_app_process = start_ready_app_process
         self._launch_ready_shell = launch_ready_shell
         self._quit_app = quit_app
+        self._schedule_after_surface_paint = schedule_after_surface_paint
 
     def launch_after_onboarding_completion(self, completion: object) -> None:
         """Start a ready app process after setup saves configuration."""
@@ -124,9 +127,8 @@ class BootstrapRouteController:
         show_onboarding_window: ShowBootstrapWindow,
         show_repair_window: ShowBootstrapWindow,
     ) -> BootstrapRouteResult:
-        """Close splash, show the selected non-ready route, and wire signals."""
+        """Show the selected route and close its splash only after first paint."""
 
-        self._close_splash_before_route(splash)
         show_window = (
             show_onboarding_window
             if readiness_assessment.route is BootstrapRoute.ONBOARDING
@@ -142,17 +144,49 @@ class BootstrapRouteController:
             self.launch_after_onboarding_completion
         )
         onboarding_window.close_requested.connect(self._quit_app)
-        return BootstrapRouteResult(onboarding_window=onboarding_window, splash=None)
+        trace_mark(
+            "bootstrap_surface.shown",
+            route=readiness_assessment.route.value,
+        )
+        if splash is not None:
+            self._schedule_after_surface_paint(
+                onboarding_window,
+                lambda: self._complete_surface_handoff(
+                    splash=splash,
+                    route=readiness_assessment.route,
+                ),
+            )
+        return BootstrapRouteResult(
+            onboarding_window=onboarding_window,
+            splash=splash,
+        )
 
-    def _close_splash_before_route(self, splash: SplashCloseProtocol | None) -> None:
-        """Close the launch splash before showing onboarding or repair."""
+    def _complete_surface_handoff(
+        self,
+        *,
+        splash: SplashCloseProtocol,
+        route: BootstrapRoute,
+    ) -> None:
+        """Acknowledge replacement paint before asking the launch splash to close."""
 
-        if splash is None:
-            return
+        trace_mark("bootstrap_surface.first_paint", route=route.value)
         try:
-            splash.close()
+            close_result = splash.close()
         except Exception:
-            log_exception(_LOGGER, "Failed to close launch splash before routing")
+            log_exception(
+                _LOGGER,
+                "Failed to close launch splash after replacement surface paint",
+                route=route.value,
+            )
+            return
+        if close_result is False:
+            log_warning(
+                _LOGGER,
+                "Launch splash did not acknowledge closure after replacement surface paint",
+                route=route.value,
+            )
+            return
+        trace_mark("launch_splash.closed", route=route.value)
 
 
 def create_bootstrap_route_controller(
@@ -161,6 +195,7 @@ def create_bootstrap_route_controller(
     start_ready_app_process: Callable[[Sequence[str]], bool],
     launch_ready_shell: Callable[[InstallationContext], None],
     quit_app: Callable[[], None],
+    schedule_after_surface_paint: ScheduleAfterSurfacePaint,
 ) -> BootstrapRouteController:
     """Create the controller for non-ready bootstrap routes."""
 
@@ -169,6 +204,7 @@ def create_bootstrap_route_controller(
         start_ready_app_process=start_ready_app_process,
         launch_ready_shell=launch_ready_shell,
         quit_app=quit_app,
+        schedule_after_surface_paint=schedule_after_surface_paint,
     )
 
 

--- a/substitute/app/bootstrap/startup_route_flow.py
+++ b/substitute/app/bootstrap/startup_route_flow.py
@@ -27,6 +27,7 @@ from substitute.app.bootstrap.bootstrap_route_controller import (
     create_bootstrap_route_controller,
     trace_bootstrap_route,
 )
+from substitute.app.bootstrap.surface_presentation import run_after_surface_paint
 from substitute.domain.onboarding import (
     BootstrapRoute,
     InstallationContext,
@@ -83,6 +84,7 @@ def run_startup_route_flow(
         start_ready_app_process=start_ready_app_process,
         launch_ready_shell=launch_ready_shell,
         quit_app=quit_app,
+        schedule_after_surface_paint=run_after_surface_paint,
     )
     bootstrap_route_result = bootstrap_route_controller.show_onboarding_or_repair_route(
         readiness_assessment=readiness_assessment,

--- a/tests/app/bootstrap/route_flow/test_flow.py
+++ b/tests/app/bootstrap/route_flow/test_flow.py
@@ -147,6 +147,11 @@ def test_route_flow_shows_non_ready_route_and_returns_live_references(
         return repair_window
 
     monkeypatch.setattr(startup_route_flow, "trace_bootstrap_route", trace_route)
+    monkeypatch.setattr(
+        startup_route_flow,
+        "run_after_surface_paint",
+        lambda _window, callback: callback(),
+    )
 
     result = startup_route_flow.run_startup_route_flow(
         readiness_assessment=assessment,
@@ -168,7 +173,7 @@ def test_route_flow_shows_non_ready_route_and_returns_live_references(
 
     assert result.onboarding_window is repair_window
     assert result.route_controller is not None
-    assert result.splash is None
+    assert result.splash is splash
     assert result.update_splash_reference is True
     assert events == [
         ("trace", BootstrapRoute.REPAIR),
@@ -181,7 +186,6 @@ def test_route_flow_shows_non_ready_route_and_returns_live_references(
                 "shell_placement_present": False,
             },
         ),
-        ("splash_close", splash),
         (
             "show_repair",
             {
@@ -191,6 +195,7 @@ def test_route_flow_shows_non_ready_route_and_returns_live_references(
                 "initial_geometry": "geometry",
             },
         ),
+        ("splash_close", splash),
     ]
     assert repair_window.launch_requested.callbacks
     assert repair_window.close_requested.callbacks

--- a/tests/app/bootstrap/routing/test_route_controller.py
+++ b/tests/app/bootstrap/routing/test_route_controller.py
@@ -62,10 +62,14 @@ FORBIDDEN_BOOTSTRAP_ROUTE_IMPORT_PREFIXES = (
 def test_bootstrap_route_controller_shows_onboarding_and_wires_signals(
     tmp_path: Path,
 ) -> None:
-    """Onboarding route should close splash, show onboarding, and wire handoff signals."""
+    """Onboarding must paint before the preceding splash is closed."""
 
     events: list[str] = []
-    controller = _build_controller(events=events)
+    paint_callbacks: list[Callable[[], None]] = []
+    controller = _build_controller(
+        events=events,
+        paint_callbacks=paint_callbacks,
+    )
     context = _build_context(tmp_path)
     assessment = ReadinessAssessment(route=BootstrapRoute.ONBOARDING, issues=())
     onboarding_window = _RouteWindow()
@@ -93,8 +97,11 @@ def test_bootstrap_route_controller_shows_onboarding_and_wires_signals(
     )
 
     assert result.onboarding_window is cast(object, onboarding_window)
-    assert result.splash is None
-    assert events == ["splash_close", "show_onboarding"]
+    assert result.splash is splash
+    assert events == ["show_onboarding"]
+    assert len(paint_callbacks) == 1
+    paint_callbacks[0]()
+    assert events == ["show_onboarding", "splash_close"]
     assert onboarding_window.launch_requested.callbacks == [
         controller.launch_after_onboarding_completion
     ]
@@ -108,7 +115,11 @@ def test_bootstrap_route_controller_shows_repair_and_tolerates_splash_close_fail
     """Repair route should continue showing repair when splash close fails."""
 
     events: list[str] = []
-    controller = _build_controller(events=events)
+    paint_callbacks: list[Callable[[], None]] = []
+    controller = _build_controller(
+        events=events,
+        paint_callbacks=paint_callbacks,
+    )
     context = _build_context(tmp_path)
     assessment = ReadinessAssessment(route=BootstrapRoute.REPAIR, issues=())
     repair_window = _RouteWindow()
@@ -129,8 +140,54 @@ def test_bootstrap_route_controller_shows_repair_and_tolerates_splash_close_fail
     )
 
     assert result.onboarding_window is cast(object, repair_window)
-    assert result.splash is None
-    assert events == ["splash_close", "show_repair"]
+    assert result.splash is not None
+    assert events == ["show_repair"]
+    paint_callbacks[0]()
+    assert events == ["show_repair", "splash_close"]
+
+
+def test_bootstrap_route_controller_does_not_claim_unacknowledged_splash_close(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A rejected splash close must remain visible in diagnostics and owner state."""
+
+    import substitute.app.bootstrap.bootstrap_route_controller as route_controller
+
+    events: list[str] = []
+    trace_events: list[str] = []
+    warnings: list[str] = []
+    controller = _build_controller(events=events)
+    context = _build_context(tmp_path)
+    assessment = ReadinessAssessment(route=BootstrapRoute.REPAIR, issues=())
+
+    monkeypatch.setattr(
+        route_controller,
+        "trace_mark",
+        lambda event_name, **_fields: trace_events.append(event_name),
+    )
+    monkeypatch.setattr(
+        route_controller,
+        "log_warning",
+        lambda _logger, message, **_context: warnings.append(message),
+    )
+
+    result = controller.show_onboarding_or_repair_route(
+        readiness_assessment=assessment,
+        installation_context=context,
+        entrypoint_path=tmp_path / "main.py",
+        initial_geometry=None,
+        splash=_Splash(events, acknowledge=False),
+        show_onboarding_window=lambda **_kwargs: _fail_window("onboarding"),
+        show_repair_window=lambda **_kwargs: _RouteWindow(),
+    )
+
+    assert result.splash is not None
+    assert events == ["splash_close"]
+    assert trace_events == ["bootstrap_surface.shown", "bootstrap_surface.first_paint"]
+    assert warnings == [
+        "Launch splash did not acknowledge closure after replacement surface paint"
+    ]
 
 
 def test_bootstrap_route_controller_completion_relaunches_ready_app_with_no_comfy(
@@ -271,6 +328,7 @@ def test_create_bootstrap_route_controller_returns_controller(tmp_path: Path) ->
         start_ready_app_process=start_ready_app_process,
         launch_ready_shell=lambda _context: events.append("launch"),
         quit_app=lambda: events.append("quit"),
+        schedule_after_surface_paint=lambda _window, callback: callback(),
     )
 
     controller.launch_after_onboarding_completion(_build_context(tmp_path))
@@ -316,6 +374,7 @@ def test_startup_facade_delegates_non_ready_bootstrap_routes() -> None:
 def _build_controller(
     *,
     events: list[str],
+    paint_callbacks: list[Callable[[], None]] | None = None,
     launched_commands: list[tuple[str, ...]] | None = None,
     launched_contexts: list[InstallationContext] | None = None,
     launch_result: bool = True,
@@ -343,6 +402,11 @@ def _build_controller(
         start_ready_app_process=start_ready_app_process,
         launch_ready_shell=launch_ready_shell,
         quit_app=lambda: events.append("quit"),
+        schedule_after_surface_paint=lambda _window, callback: (
+            paint_callbacks.append(callback)
+            if paint_callbacks is not None
+            else callback()
+        ),
     )
 
 
@@ -431,15 +495,23 @@ class _RouteWindow:
 class _Splash:
     """Record splash close attempts."""
 
-    def __init__(self, events: list[str], *, fail: bool = False) -> None:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        fail: bool = False,
+        acknowledge: bool | None = None,
+    ) -> None:
         """Store close behavior for one fake splash."""
 
         self._events = events
         self._fail = fail
+        self._acknowledge = acknowledge
 
-    def close(self) -> None:
+    def close(self) -> bool | None:
         """Record splash close and optionally fail."""
 
         self._events.append("splash_close")
         if self._fail:
             raise RuntimeError("close failed")
+        return self._acknowledge

--- a/tests/launcher/application_launch/test_lifecycle_supervisor.py
+++ b/tests/launcher/application_launch/test_lifecycle_supervisor.py
@@ -1,0 +1,69 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify readiness policy for one normal installed-application lifetime."""
+
+from __future__ import annotations
+
+import pytest
+
+from launcher.sugarsubstitute_launcher import application_lifecycle_supervisor
+from sugarsubstitute_shared.application_readiness import ApplicationReadinessSurface
+
+
+def test_normal_lifecycle_accepts_every_painted_primary_application_surface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Normal launch must supervise main, setup, and repair application routes."""
+
+    captured_surfaces: list[frozenset[ApplicationReadinessSurface]] = []
+
+    class _ReadinessSupervisor:
+        """Capture normal-lifecycle readiness construction."""
+
+        def __init__(
+            self,
+            *,
+            accepted_surfaces: tuple[ApplicationReadinessSurface, ...],
+        ) -> None:
+            """Record the accepted painted surfaces."""
+
+            captured_surfaces.append(frozenset(accepted_surfaces))
+
+    class _CrashSupervisor:
+        """Stand in for unrelated crash supervision construction."""
+
+    monkeypatch.setattr(
+        application_lifecycle_supervisor,
+        "ApplicationReadinessSupervisor",
+        _ReadinessSupervisor,
+    )
+    monkeypatch.setattr(
+        application_lifecycle_supervisor,
+        "ApplicationCrashSupervisor",
+        _CrashSupervisor,
+    )
+
+    application_lifecycle_supervisor.ApplicationLifecycleSupervisor()
+
+    assert captured_surfaces == [
+        frozenset(
+            {
+                ApplicationReadinessSurface.MAIN_SHELL,
+                ApplicationReadinessSurface.ONBOARDING,
+            }
+        )
+    ]

--- a/tests/launcher/application_readiness/test_supervisor.py
+++ b/tests/launcher/application_readiness/test_supervisor.py
@@ -283,11 +283,13 @@ def test_supervisor_rejects_unrelated_receipt_process_chain(tmp_path: Path) -> N
 def test_supervisor_rejects_onboarding_as_candidate_readiness(tmp_path: Path) -> None:
     """Candidate activation must require the real main shell."""
 
+    layout = InstallLayout.from_root(tmp_path / "install")
+    process = _CandidateProcess()
     receipt_path = tmp_path / "onboarding.json"
     receipt_path.write_text(
         json.dumps(
             ApplicationReadinessReceipt(
-                pid=123,
+                pid=process.pid,
                 token="candidate-token",
                 surface=ApplicationReadinessSurface.ONBOARDING,
                 parent_pid=999,
@@ -296,12 +298,75 @@ def test_supervisor_rejects_onboarding_as_candidate_readiness(tmp_path: Path) ->
         encoding="utf-8",
     )
 
-    with pytest.raises(ApplicationReadinessError, match="main shell"):
-        ApplicationReadinessSupervisor._validate_receipt(
-            receipt_path=receipt_path,
-            expected_token="candidate-token",
-            expected_pid=123,
+    with pytest.raises(ApplicationReadinessError, match="main_shell"):
+        ApplicationReadinessSupervisor(
+            timeout_seconds=5,
+            process_starter=lambda _command, _environment: (
+                process,
+                tmp_path / "startup.log",
+            ),
+            monotonic=_increasing_clock(),
+            wait=lambda _seconds: None,
+        ).launch_until_ready(
+            layout=layout,
+            command=["python", "main.py"],
+            environment={
+                READINESS_PATH_ENV: str(receipt_path),
+                READINESS_TOKEN_ENV: "candidate-token",
+            },
         )
+
+
+def test_supervisor_accepts_onboarding_for_normal_application_lifetime(
+    tmp_path: Path,
+) -> None:
+    """A painted setup or repair surface must keep a normal launch usable."""
+
+    layout = InstallLayout.from_root(tmp_path / "install")
+    process = _CandidateProcess()
+    receipt_path = tmp_path / "onboarding.json"
+    receipt_path.write_text(
+        json.dumps(
+            ApplicationReadinessReceipt(
+                pid=process.pid,
+                token="normal-launch-token",
+                surface=ApplicationReadinessSurface.ONBOARDING,
+                parent_pid=999,
+            ).to_json()
+        ),
+        encoding="utf-8",
+    )
+
+    result = ApplicationReadinessSupervisor(
+        accepted_surfaces=(
+            ApplicationReadinessSurface.MAIN_SHELL,
+            ApplicationReadinessSurface.ONBOARDING,
+        ),
+        timeout_seconds=5,
+        process_starter=lambda _command, _environment: (
+            process,
+            tmp_path / "startup.log",
+        ),
+        monotonic=_increasing_clock(),
+        wait=lambda _seconds: None,
+    ).launch_until_ready(
+        layout=layout,
+        command=["python", "main.py"],
+        environment={
+            READINESS_PATH_ENV: str(receipt_path),
+            READINESS_TOKEN_ENV: "normal-launch-token",
+        },
+    )
+
+    assert result is process
+    assert process.terminated is False
+
+
+def test_supervisor_requires_at_least_one_visible_surface_policy() -> None:
+    """A launch owner cannot accidentally accept no usable application route."""
+
+    with pytest.raises(ValueError, match="At least one"):
+        ApplicationReadinessSupervisor(accepted_surfaces=())
 
 
 def test_supervisor_rejects_early_process_exit(tmp_path: Path) -> None:

--- a/tests/qualification/installer/test_candidate_upgrade.py
+++ b/tests/qualification/installer/test_candidate_upgrade.py
@@ -330,6 +330,42 @@ def test_stalled_installed_launcher_fails_at_progress_boundary(
     assert "process tree:\npid=123" in str(captured.value)
 
 
+def test_installer_automation_failure_ends_readiness_wait_immediately(
+    tmp_path: Path,
+) -> None:
+    """A failed packaged UI chain must not consume the remaining release timeout."""
+
+    event_log_path = tmp_path / "events.jsonl"
+    event_log_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "token": "qualification-token",
+                "event": "installer.qualification.failed",
+                "pid": 123,
+                "fields": {"error": "application entered repair"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        InstallerLifecycleError,
+        match="Installer automation reported a terminal failure",
+    ) as captured:
+        installer_ui_qualification._wait_for_readiness_receipt(
+            readiness_path=tmp_path / "readiness.json",
+            token="qualification-token",
+            timeout_seconds=3_600.0,
+            qualification_event_path=event_log_path,
+            diagnostic_paths=(event_log_path,),
+        )
+
+    assert "installer.qualification.failed" in str(captured.value)
+    assert "application entered repair" in str(captured.value)
+
+
 def test_failed_candidate_evidence_wait_terminates_only_owned_launcher(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tools/ci/installer_terminal_event_reader.py
+++ b/tools/ci/installer_terminal_event_reader.py
@@ -1,0 +1,102 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Read terminal events incrementally from packaged qualification journals."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+import json
+from pathlib import Path
+
+_TERMINAL_STARTUP_FAILURE_EVENTS = frozenset(
+    {
+        "startup.gui_task.failure",
+        "startup.managed.failure",
+    }
+)
+_TERMINAL_QUALIFICATION_FAILURE_EVENTS = frozenset({"installer.qualification.failed"})
+
+
+def read_terminal_startup_failure(
+    trace_path: Path,
+    *,
+    offset: int,
+) -> tuple[int, str | None]:
+    """Return the next terminal application-startup event after an offset."""
+
+    return _read_terminal_event(
+        trace_path,
+        offset=offset,
+        terminal_events=_TERMINAL_STARTUP_FAILURE_EVENTS,
+        expected_token=None,
+    )
+
+
+def read_terminal_qualification_failure(
+    event_log_path: Path,
+    *,
+    offset: int,
+    token: str,
+) -> tuple[int, str | None]:
+    """Return the next token-bound terminal installer event after an offset."""
+
+    return _read_terminal_event(
+        event_log_path,
+        offset=offset,
+        terminal_events=_TERMINAL_QUALIFICATION_FAILURE_EVENTS,
+        expected_token=token,
+    )
+
+
+def _read_terminal_event(
+    path: Path,
+    *,
+    offset: int,
+    terminal_events: Collection[str],
+    expected_token: str | None,
+) -> tuple[int, str | None]:
+    """Advance through complete JSONL records and return one matching event."""
+
+    try:
+        with path.open(encoding="utf-8", errors="replace") as journal:
+            journal.seek(offset)
+            while True:
+                line = journal.readline()
+                if not line:
+                    return journal.tell(), None
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(payload, dict):
+                    continue
+                if (
+                    expected_token is not None
+                    and payload.get("token") != expected_token
+                ):
+                    continue
+                event = payload.get("event")
+                if isinstance(event, str) and event in terminal_events:
+                    return journal.tell(), event
+    except OSError:
+        return offset, None
+
+
+__all__ = [
+    "read_terminal_qualification_failure",
+    "read_terminal_startup_failure",
+]

--- a/tools/ci/installer_ui_qualification.py
+++ b/tools/ci/installer_ui_qualification.py
@@ -51,18 +51,16 @@ from tools.ci.installer_evidence_verification import (
 )
 from tools.ci.installer_lifecycle_errors import InstallerLifecycleError
 from tools.ci.installer_process_diagnostics import process_tree_diagnostics
+from tools.ci.installer_terminal_event_reader import (
+    read_terminal_qualification_failure,
+    read_terminal_startup_failure,
+)
 from tools.ci.installed_version_evidence import wait_for_installed_version
 from tools.ci.managed_comfy_qualification import assert_real_managed_comfy
 
 _INSTALL_TIMEOUT_SECONDS = 3_600.0
 _LAUNCH_PROGRESS_TIMEOUT_SECONDS = 120.0
 _MANAGED_COMFY_OUTPUT_LOG_ENV = "SUGAR_SUBSTITUTE_STARTUP_HARNESS_COMFY_OUTPUT_LOG"
-_TERMINAL_STARTUP_FAILURE_EVENTS = frozenset(
-    {
-        "startup.gui_task.failure",
-        "startup.managed.failure",
-    }
-)
 _PROCESS_TERMINATION_TIMEOUT_SECONDS = 10.0
 _FROZEN_LAUNCH_OVERRIDE_VARIABLES = (
     "PYTHONHOME",
@@ -239,6 +237,7 @@ def verify_main_shell_evidence(
             timeout_seconds=verification_timeout,
             candidate_launch=candidate_launch,
             trace_path=evidence.trace_path,
+            qualification_event_path=evidence.event_log_path,
             diagnostic_paths=_evidence_diagnostic_paths(
                 install_root=install_root,
                 evidence=evidence,
@@ -356,6 +355,7 @@ def _wait_for_readiness_receipt(
     timeout_seconds: float,
     candidate_launch: InstalledCandidateLaunch | None = None,
     trace_path: Path | None = None,
+    qualification_event_path: Path | None = None,
     diagnostic_paths: tuple[Path, ...] = (),
 ) -> ApplicationReadinessReceipt:
     """Wait for a token-bound main-shell receipt or surface diagnostics."""
@@ -367,6 +367,7 @@ def _wait_for_readiness_receipt(
         started_at + _LAUNCH_PROGRESS_TIMEOUT_SECONDS,
     )
     trace_offset = 0
+    qualification_event_offset = 0
     while (now := time.monotonic()) < deadline:
         if candidate_launch is not None:
             return_code = candidate_launch.process.poll()
@@ -393,7 +394,7 @@ def _wait_for_readiness_receipt(
                     f"process tree:\n{process_diagnostics}\n\n{diagnostics}"
                 )
         if trace_path is not None:
-            trace_offset, terminal_event = _read_terminal_startup_failure(
+            trace_offset, terminal_event = read_terminal_startup_failure(
                 trace_path,
                 offset=trace_offset,
             )
@@ -403,6 +404,22 @@ def _wait_for_readiness_receipt(
                 )
                 raise InstallerLifecycleError(
                     "Application reported a terminal startup failure before the "
+                    f"main-shell receipt: {terminal_event}.\n{diagnostics}"
+                )
+        if qualification_event_path is not None:
+            qualification_event_offset, terminal_event = (
+                read_terminal_qualification_failure(
+                    qualification_event_path,
+                    offset=qualification_event_offset,
+                    token=token,
+                )
+            )
+            if terminal_event is not None:
+                diagnostics = "\n\n".join(
+                    f"{path}:\n{diagnostic_tail(path)}" for path in diagnostic_paths
+                )
+                raise InstallerLifecycleError(
+                    "Installer automation reported a terminal failure before the "
                     f"main-shell receipt: {terminal_event}.\n{diagnostics}"
                 )
         if readiness_path.is_file():
@@ -434,31 +451,6 @@ def _wait_for_readiness_receipt(
         "Application did not reveal a post-splash window before timeout.\n"
         + diagnostics
     )
-
-
-def _read_terminal_startup_failure(
-    trace_path: Path,
-    *,
-    offset: int,
-) -> tuple[int, str | None]:
-    """Read new trace records and return the first terminal failure event."""
-
-    try:
-        with trace_path.open(encoding="utf-8", errors="replace") as trace:
-            trace.seek(offset)
-            while True:
-                line = trace.readline()
-                if not line:
-                    return trace.tell(), None
-                try:
-                    payload = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                event = payload.get("event") if isinstance(payload, dict) else None
-                if event in _TERMINAL_STARTUP_FAILURE_EVENTS:
-                    return trace.tell(), str(event)
-    except OSError:
-        return offset, None
 
 
 def _evidence_diagnostic_paths(


### PR DESCRIPTION
## Outcome

- accepts painted setup and repair surfaces during normal installed-app supervision while keeping candidate update activation main-shell-only
- shows onboarding or repair before closing the launch splash and records close failures truthfully
- makes packaged qualification stop immediately on a terminal installer-automation failure instead of waiting out the release timeout

## Root cause

The application began reporting onboarding readiness honestly, but the normal launcher still applied the candidate-update policy that only accepts a main shell. It terminated the usable first-run application, entered Repair, and left clean-install qualification waiting for a main-shell receipt that could no longer be produced.

## Verification

- full parallel test suite
- all 93 isolated modules
- serial model-picker module
- repository format and lint
- strict mypy across 5,917 source files
- architecture governance
- test governance
- focused launcher, bootstrap, candidate-update, installer, and Qt paint qualification suites