### PR TITLE
fix(startup): preserve first-run readiness across handoffs

### DIFF
--- a/launcher/sugarsubstitute_launcher/application_readiness_supervisor.py
+++ b/launcher/sugarsubstitute_launcher/application_readiness_supervisor.py
@@ -35,6 +35,7 @@ from sugarsubstitute_shared.application_readiness import (
     ApplicationReadinessSurface,
     READINESS_PATH_ENV,
     READINESS_TOKEN_ENV,
+    publish_application_readiness_receipt,
 )
 
 
@@ -60,11 +61,12 @@ class ApplicationReadinessError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class _ReadinessContract:
-    """Bind one receipt path and token to its lifecycle owner."""
+    """Separate one child proof from an optional caller-owned outer proof."""
 
-    receipt_path: Path
-    token: str
-    externally_owned: bool
+    child_receipt_path: Path
+    child_token: str
+    outer_receipt_path: Path | None
+    outer_token: str | None
 
 
 class CandidateProcess(Protocol):
@@ -128,10 +130,9 @@ class ApplicationReadinessSupervisor:
         """Return the running process after an accepted surface is responsive."""
 
         contract = self._readiness_contract(layout=layout, environment=environment)
-        receipt_path = contract.receipt_path
-        token = contract.token
-        if not contract.externally_owned:
-            receipt_path.unlink(missing_ok=True)
+        receipt_path = contract.child_receipt_path
+        token = contract.child_token
+        receipt_path.unlink(missing_ok=True)
         child_environment = dict(environment)
         child_environment[READINESS_PATH_ENV] = str(receipt_path)
         child_environment[READINESS_TOKEN_ENV] = token
@@ -156,8 +157,7 @@ class ApplicationReadinessSupervisor:
                         expected_pid=process.pid,
                     )
                     self._require_accepted_surface(receipt)
-                    if not contract.externally_owned:
-                        receipt_path.unlink()
+                    self._publish_outer_receipt(contract=contract, receipt=receipt)
                     return process
                 self._wait(_POLL_INTERVAL_SECONDS)
             raise ApplicationReadinessError(
@@ -167,6 +167,8 @@ class ApplicationReadinessSupervisor:
         except BaseException:
             stop_candidate_process(process)
             raise
+        finally:
+            receipt_path.unlink(missing_ok=True)
 
     def _readiness_contract(
         self,
@@ -184,14 +186,40 @@ class ApplicationReadinessSupervisor:
             )
         if external_path and external_token:
             return _ReadinessContract(
-                receipt_path=Path(external_path).expanduser().resolve(),
-                token=external_token,
-                externally_owned=True,
+                child_receipt_path=(
+                    layout.launcher_dir
+                    / "readiness"
+                    / f"candidate-{secrets.token_hex(16)}.json"
+                ),
+                child_token=self._token_factory(),
+                outer_receipt_path=Path(external_path).expanduser().resolve(),
+                outer_token=external_token,
             )
         return _ReadinessContract(
-            receipt_path=layout.launcher_dir / "readiness" / "candidate.json",
-            token=self._token_factory(),
-            externally_owned=False,
+            child_receipt_path=layout.launcher_dir / "readiness" / "candidate.json",
+            child_token=self._token_factory(),
+            outer_receipt_path=None,
+            outer_token=None,
+        )
+
+    @staticmethod
+    def _publish_outer_receipt(
+        *,
+        contract: _ReadinessContract,
+        receipt: ApplicationReadinessReceipt,
+    ) -> None:
+        """Project a validated child proof into its caller-owned contract."""
+
+        if contract.outer_receipt_path is None or contract.outer_token is None:
+            return
+        publish_application_readiness_receipt(
+            receipt_path=contract.outer_receipt_path,
+            receipt=ApplicationReadinessReceipt(
+                pid=receipt.pid,
+                token=contract.outer_token,
+                surface=receipt.surface,
+                parent_pid=receipt.parent_pid,
+            ),
         )
 
     @staticmethod
@@ -215,12 +243,17 @@ class ApplicationReadinessSupervisor:
             raise ApplicationReadinessError(
                 "Application readiness receipt is invalid."
             ) from error
-        if receipt.token != expected_token or expected_pid not in {
+        token_matched = receipt.token == expected_token
+        process_matched = expected_pid in {
             receipt.pid,
             receipt.parent_pid,
-        }:
+        }
+        if not token_matched or not process_matched:
             raise ApplicationReadinessError(
-                "Application readiness receipt did not match the launched process."
+                "Application readiness receipt did not match the launched process. "
+                f"Expected PID: {expected_pid}. Receipt PID: {receipt.pid}. "
+                f"Receipt parent PID: {receipt.parent_pid}. "
+                f"Token matched: {token_matched}."
             )
         return receipt
 

--- a/substitute/app/bootstrap/application_readiness.py
+++ b/substitute/app/bootstrap/application_readiness.py
@@ -18,10 +18,8 @@
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
-import secrets
 from substitute.app.bootstrap.surface_presentation import run_after_surface_paint
 
 from sugarsubstitute_shared.application_readiness import (
@@ -30,6 +28,7 @@ from sugarsubstitute_shared.application_readiness import (
     READINESS_PATH_ENV,
     READINESS_SCHEMA_VERSION,
     READINESS_TOKEN_ENV,
+    publish_application_readiness_receipt,
 )
 
 
@@ -75,27 +74,15 @@ def _write_readiness_receipt(
 ) -> None:
     """Atomically publish one process-bound application readiness receipt."""
 
-    readiness_path.parent.mkdir(parents=True, exist_ok=True)
-    temporary_path = readiness_path.with_name(
-        f".{readiness_path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
+    publish_application_readiness_receipt(
+        receipt_path=readiness_path,
+        receipt=ApplicationReadinessReceipt(
+            pid=os.getpid(),
+            token=readiness_token,
+            surface=surface,
+            parent_pid=os.getppid(),
+        ),
     )
-    payload = ApplicationReadinessReceipt(
-        pid=os.getpid(),
-        token=readiness_token,
-        surface=surface,
-        parent_pid=os.getppid(),
-    ).to_json()
-    try:
-        temporary_path.write_text(
-            json.dumps(payload, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        os.replace(temporary_path, readiness_path)
-    finally:
-        try:
-            temporary_path.unlink()
-        except FileNotFoundError:
-            pass
 
 
 def schedule_main_shell_readiness_receipt(window: object) -> bool:

--- a/sugarsubstitute_shared/application_readiness.py
+++ b/sugarsubstitute_shared/application_readiness.py
@@ -20,6 +20,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+import json
+import os
+from pathlib import Path
+import secrets
 from typing import Final
 
 
@@ -109,10 +113,32 @@ class ApplicationReadinessReceipt:
         )
 
 
+def publish_application_readiness_receipt(
+    *,
+    receipt_path: Path,
+    receipt: ApplicationReadinessReceipt,
+) -> None:
+    """Atomically publish one authenticated visible-surface receipt."""
+
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = receipt_path.with_name(
+        f".{receipt_path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
+    )
+    try:
+        temporary_path.write_text(
+            json.dumps(receipt.to_json(), sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temporary_path, receipt_path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
 __all__ = [
     "ApplicationReadinessReceipt",
     "ApplicationReadinessSurface",
     "READINESS_PATH_ENV",
     "READINESS_SCHEMA_VERSION",
     "READINESS_TOKEN_ENV",
+    "publish_application_readiness_receipt",
 ]

--- a/tests/launcher/application_readiness/test_outer_contract_restart.py
+++ b/tests/launcher/application_readiness/test_outer_contract_restart.py
@@ -1,0 +1,332 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Test nested readiness proofs across authorized application restarts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from launcher.sugarsubstitute_launcher.application_readiness_supervisor import (
+    ApplicationReadinessError,
+    ApplicationReadinessSupervisor,
+)
+from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from sugarsubstitute_shared.application_readiness import (
+    ApplicationReadinessReceipt,
+    ApplicationReadinessSurface,
+    READINESS_PATH_ENV,
+    READINESS_TOKEN_ENV,
+)
+
+
+class _CandidateProcess:
+    """Expose deterministic candidate process state for restart tests."""
+
+    def __init__(self, *, pid: int) -> None:
+        """Store one running process identity."""
+
+        self.pid = pid
+        self.return_code: int | None = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        """Return the configured process state."""
+
+        return self.return_code
+
+    def terminate(self) -> None:
+        """Record graceful termination and complete the process."""
+
+        self.terminated = True
+        self.return_code = 0
+
+    def kill(self) -> None:
+        """Record forced termination and complete the process."""
+
+        self.killed = True
+        self.return_code = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        """Return the completed process result."""
+
+        if self.return_code is None:
+            raise subprocess.TimeoutExpired("candidate", timeout or 0.0)
+        return self.return_code
+
+
+def _publish_test_receipt(
+    *,
+    receipt_path: Path,
+    pid: int,
+    token: str,
+    surface: ApplicationReadinessSurface,
+    parent_pid: int = 999,
+) -> None:
+    """Write one deterministic readiness receipt for a supervised child."""
+
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(
+        json.dumps(
+            ApplicationReadinessReceipt(
+                pid=pid,
+                token=token,
+                surface=surface,
+                parent_pid=parent_pid,
+            ).to_json()
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_supervisor_replaces_outer_receipt_across_authorized_restart(
+    tmp_path: Path,
+) -> None:
+    """An onboarding receipt must not poison the authorized main-shell restart."""
+
+    layout = InstallLayout.from_root(tmp_path / "install")
+    receipt_path = tmp_path / "qualification" / "candidate.json"
+    processes = (
+        _CandidateProcess(pid=321),
+        _CandidateProcess(pid=654),
+    )
+    child_environments: list[dict[str, str]] = []
+
+    def start(
+        _command: Sequence[str],
+        environment: Mapping[str, str],
+    ) -> tuple[_CandidateProcess, Path]:
+        """Return each authorized application process in launch order."""
+
+        child_environments.append(dict(environment))
+        return processes[len(child_environments) - 1], tmp_path / "startup.log"
+
+    surfaces = (
+        ApplicationReadinessSurface.ONBOARDING,
+        ApplicationReadinessSurface.MAIN_SHELL,
+    )
+
+    def publish_receipt(_seconds: float) -> None:
+        """Publish readiness for the application process currently starting."""
+
+        launch_index = len(child_environments) - 1
+        environment = child_environments[launch_index]
+        _publish_test_receipt(
+            receipt_path=Path(environment[READINESS_PATH_ENV]),
+            pid=processes[launch_index].pid,
+            token=environment[READINESS_TOKEN_ENV],
+            surface=surfaces[launch_index],
+        )
+
+    supervisor = ApplicationReadinessSupervisor(
+        accepted_surfaces=surfaces,
+        timeout_seconds=5,
+        process_starter=start,
+        monotonic=_increasing_clock(),
+        wait=publish_receipt,
+        token_factory=iter(("onboarding-token", "main-shell-token")).__next__,
+    )
+    outer_environment = {
+        READINESS_PATH_ENV: str(receipt_path),
+        READINESS_TOKEN_ENV: "outer-token",
+    }
+
+    supervisor.launch_until_ready(
+        layout=layout,
+        command=["python", "main.py"],
+        environment=outer_environment,
+    )
+    onboarding_receipt = ApplicationReadinessReceipt.from_json(
+        json.loads(receipt_path.read_text(encoding="utf-8"))
+    )
+    assert onboarding_receipt.pid == processes[0].pid
+    assert onboarding_receipt.token == "outer-token"
+    assert onboarding_receipt.surface is ApplicationReadinessSurface.ONBOARDING
+    assert child_environments[0][READINESS_PATH_ENV] != str(receipt_path)
+    assert child_environments[0][READINESS_TOKEN_ENV] == "onboarding-token"
+    processes[0].return_code = 0
+    second_result = supervisor.launch_until_ready(
+        layout=layout,
+        command=["python", "main.py"],
+        environment=outer_environment,
+    )
+
+    final_receipt = ApplicationReadinessReceipt.from_json(
+        json.loads(receipt_path.read_text(encoding="utf-8"))
+    )
+    assert second_result is processes[1]
+    assert final_receipt.pid == processes[1].pid
+    assert final_receipt.token == "outer-token"
+    assert final_receipt.surface is ApplicationReadinessSurface.MAIN_SHELL
+    assert child_environments[1][READINESS_PATH_ENV] != str(receipt_path)
+    assert child_environments[1][READINESS_TOKEN_ENV] == "main-shell-token"
+
+
+def test_invalid_restarted_child_cannot_replace_outer_receipt(tmp_path: Path) -> None:
+    """A failed restart proof must preserve the last truthful outer receipt."""
+
+    layout = InstallLayout.from_root(tmp_path / "install")
+    process = _CandidateProcess(pid=654)
+    receipt_path = tmp_path / "qualification" / "candidate.json"
+    original_receipt = ApplicationReadinessReceipt(
+        pid=321,
+        token="outer-token",
+        surface=ApplicationReadinessSurface.ONBOARDING,
+        parent_pid=999,
+    )
+    _publish_test_receipt(
+        receipt_path=receipt_path,
+        pid=original_receipt.pid,
+        token=original_receipt.token,
+        surface=original_receipt.surface,
+        parent_pid=original_receipt.parent_pid or 999,
+    )
+
+    def start(
+        _command: Sequence[str],
+        environment: Mapping[str, str],
+    ) -> tuple[_CandidateProcess, Path]:
+        """Publish a forged child receipt with the wrong process identity."""
+
+        _publish_test_receipt(
+            receipt_path=Path(environment[READINESS_PATH_ENV]),
+            pid=777,
+            token=environment[READINESS_TOKEN_ENV],
+            surface=ApplicationReadinessSurface.MAIN_SHELL,
+            parent_pid=778,
+        )
+        return process, tmp_path / "startup.log"
+
+    with pytest.raises(ApplicationReadinessError, match="launched process"):
+        ApplicationReadinessSupervisor(
+            accepted_surfaces=(
+                ApplicationReadinessSurface.MAIN_SHELL,
+                ApplicationReadinessSurface.ONBOARDING,
+            ),
+            timeout_seconds=5,
+            process_starter=start,
+            monotonic=_increasing_clock(),
+            wait=lambda _seconds: None,
+            token_factory=lambda: "private-restart-token",
+        ).launch_until_ready(
+            layout=layout,
+            command=["python", "main.py"],
+            environment={
+                READINESS_PATH_ENV: str(receipt_path),
+                READINESS_TOKEN_ENV: "outer-token",
+            },
+        )
+
+    preserved_receipt = ApplicationReadinessReceipt.from_json(
+        json.loads(receipt_path.read_text(encoding="utf-8"))
+    )
+    assert preserved_receipt == original_receipt
+    assert process.terminated is True
+
+
+def test_supervisor_replaces_outer_receipt_across_real_processes(
+    tmp_path: Path,
+) -> None:
+    """Exercise the onboarding-to-main-shell proof chain with real process IDs."""
+
+    layout = InstallLayout.from_root(tmp_path / "install")
+    receipt_path = tmp_path / "qualification" / "candidate.json"
+    supervisor = ApplicationReadinessSupervisor(
+        accepted_surfaces=(
+            ApplicationReadinessSurface.MAIN_SHELL,
+            ApplicationReadinessSurface.ONBOARDING,
+        ),
+        timeout_seconds=10,
+    )
+    script = (
+        "import os, time; "
+        "from pathlib import Path; "
+        "from sugarsubstitute_shared.application_readiness import "
+        "ApplicationReadinessReceipt, ApplicationReadinessSurface, "
+        "READINESS_PATH_ENV, READINESS_TOKEN_ENV, "
+        "publish_application_readiness_receipt; "
+        "publish_application_readiness_receipt("
+        "receipt_path=Path(os.environ[READINESS_PATH_ENV]), "
+        "receipt=ApplicationReadinessReceipt("
+        "pid=os.getpid(), parent_pid=os.getppid(), "
+        "token=os.environ[READINESS_TOKEN_ENV], "
+        "surface=ApplicationReadinessSurface(os.environ['TEST_SURFACE']))); "
+        "time.sleep(1)"
+    )
+    outer_environment = {
+        READINESS_PATH_ENV: str(receipt_path),
+        READINESS_TOKEN_ENV: "outer-token",
+    }
+
+    onboarding_process = supervisor.launch_until_ready(
+        layout=layout,
+        command=[sys.executable, "-c", script],
+        environment={
+            **outer_environment,
+            "TEST_SURFACE": ApplicationReadinessSurface.ONBOARDING.value,
+        },
+    )
+    onboarding_receipt = ApplicationReadinessReceipt.from_json(
+        json.loads(receipt_path.read_text(encoding="utf-8"))
+    )
+    assert onboarding_process.pid in {
+        onboarding_receipt.pid,
+        onboarding_receipt.parent_pid,
+    }
+    assert onboarding_process.wait(timeout=5) == 0
+    main_shell_process = supervisor.launch_until_ready(
+        layout=layout,
+        command=[sys.executable, "-c", script],
+        environment={
+            **outer_environment,
+            "TEST_SURFACE": ApplicationReadinessSurface.MAIN_SHELL.value,
+        },
+    )
+    try:
+        final_receipt = ApplicationReadinessReceipt.from_json(
+            json.loads(receipt_path.read_text(encoding="utf-8"))
+        )
+        assert main_shell_process.pid in {
+            final_receipt.pid,
+            final_receipt.parent_pid,
+        }
+        assert final_receipt.pid != onboarding_receipt.pid
+        assert final_receipt.token == "outer-token"
+        assert final_receipt.surface is ApplicationReadinessSurface.MAIN_SHELL
+    finally:
+        assert main_shell_process.wait(timeout=5) == 0
+
+
+def _increasing_clock(*, step: float = 0.1) -> Callable[[], float]:
+    """Return a callable deterministic monotonic clock."""
+
+    current = 0.0
+
+    def clock() -> float:
+        """Advance and return deterministic monotonic time."""
+
+        nonlocal current
+        current += step
+        return current
+
+    return clock

--- a/tests/launcher/application_readiness/test_supervisor.py
+++ b/tests/launcher/application_readiness/test_supervisor.py
@@ -76,6 +76,30 @@ class _CandidateProcess:
         return self.return_code
 
 
+def _publish_test_receipt(
+    *,
+    receipt_path: Path,
+    pid: int,
+    token: str,
+    surface: ApplicationReadinessSurface,
+    parent_pid: int = 999,
+) -> None:
+    """Write one deterministic readiness receipt for a supervised test child."""
+
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(
+        json.dumps(
+            ApplicationReadinessReceipt(
+                pid=pid,
+                token=token,
+                surface=surface,
+                parent_pid=parent_pid,
+            ).to_json()
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_supervisor_returns_only_after_matching_receipt(tmp_path: Path) -> None:
     """A running process is accepted only after its token and PID match."""
 
@@ -138,19 +162,15 @@ def test_supervisor_preserves_outer_readiness_receipt(tmp_path: Path) -> None:
         _command: Sequence[str],
         environment: Mapping[str, str],
     ) -> tuple[_CandidateProcess, Path]:
-        """Write the outer token to its caller-owned receipt path."""
+        """Write readiness through the supervisor's private child contract."""
 
-        receipt_path.parent.mkdir(parents=True, exist_ok=True)
-        receipt_path.write_text(
-            json.dumps(
-                ApplicationReadinessReceipt(
-                    pid=process.pid,
-                    token=environment[READINESS_TOKEN_ENV],
-                    surface=ApplicationReadinessSurface.MAIN_SHELL,
-                    parent_pid=999,
-                ).to_json()
-            ),
-            encoding="utf-8",
+        child_receipt_path = Path(environment[READINESS_PATH_ENV])
+        assert child_receipt_path != receipt_path
+        _publish_test_receipt(
+            receipt_path=child_receipt_path,
+            pid=process.pid,
+            token=environment[READINESS_TOKEN_ENV],
+            surface=ApplicationReadinessSurface.MAIN_SHELL,
         )
         return process, tmp_path / "startup.log"
 
@@ -286,25 +306,26 @@ def test_supervisor_rejects_onboarding_as_candidate_readiness(tmp_path: Path) ->
     layout = InstallLayout.from_root(tmp_path / "install")
     process = _CandidateProcess()
     receipt_path = tmp_path / "onboarding.json"
-    receipt_path.write_text(
-        json.dumps(
-            ApplicationReadinessReceipt(
-                pid=process.pid,
-                token="candidate-token",
-                surface=ApplicationReadinessSurface.ONBOARDING,
-                parent_pid=999,
-            ).to_json()
-        ),
-        encoding="utf-8",
-    )
+
+    def start(
+        _command: Sequence[str],
+        environment: Mapping[str, str],
+    ) -> tuple[_CandidateProcess, Path]:
+        """Publish onboarding through the private child proof contract."""
+
+        child_receipt_path = Path(environment[READINESS_PATH_ENV])
+        _publish_test_receipt(
+            receipt_path=child_receipt_path,
+            pid=process.pid,
+            token=environment[READINESS_TOKEN_ENV],
+            surface=ApplicationReadinessSurface.ONBOARDING,
+        )
+        return process, tmp_path / "startup.log"
 
     with pytest.raises(ApplicationReadinessError, match="main_shell"):
         ApplicationReadinessSupervisor(
             timeout_seconds=5,
-            process_starter=lambda _command, _environment: (
-                process,
-                tmp_path / "startup.log",
-            ),
+            process_starter=start,
             monotonic=_increasing_clock(),
             wait=lambda _seconds: None,
         ).launch_until_ready(
@@ -325,17 +346,21 @@ def test_supervisor_accepts_onboarding_for_normal_application_lifetime(
     layout = InstallLayout.from_root(tmp_path / "install")
     process = _CandidateProcess()
     receipt_path = tmp_path / "onboarding.json"
-    receipt_path.write_text(
-        json.dumps(
-            ApplicationReadinessReceipt(
-                pid=process.pid,
-                token="normal-launch-token",
-                surface=ApplicationReadinessSurface.ONBOARDING,
-                parent_pid=999,
-            ).to_json()
-        ),
-        encoding="utf-8",
-    )
+
+    def start(
+        _command: Sequence[str],
+        environment: Mapping[str, str],
+    ) -> tuple[_CandidateProcess, Path]:
+        """Publish onboarding through the private child proof contract."""
+
+        child_receipt_path = Path(environment[READINESS_PATH_ENV])
+        _publish_test_receipt(
+            receipt_path=child_receipt_path,
+            pid=process.pid,
+            token=environment[READINESS_TOKEN_ENV],
+            surface=ApplicationReadinessSurface.ONBOARDING,
+        )
+        return process, tmp_path / "startup.log"
 
     result = ApplicationReadinessSupervisor(
         accepted_surfaces=(
@@ -343,10 +368,7 @@ def test_supervisor_accepts_onboarding_for_normal_application_lifetime(
             ApplicationReadinessSurface.ONBOARDING,
         ),
         timeout_seconds=5,
-        process_starter=lambda _command, _environment: (
-            process,
-            tmp_path / "startup.log",
-        ),
+        process_starter=start,
         monotonic=_increasing_clock(),
         wait=lambda _seconds: None,
     ).launch_until_ready(


### PR DESCRIPTION
A clean install first paints onboarding, then restarts into the main shell. The outer installer receipt survived that transition, but the launcher reused it as the next child's private proof and rejected the stale onboarding PID before the new child could paint. This caused Repair on Windows, Linux, and macOS. Each supervised child now receives a fresh private readiness path and token. Only a validated painted child receipt is atomically projected into the caller-owned outer contract, so onboarding remains observable while a later main-shell process can replace it safely. Forged or unrelated child receipts still terminate the child and cannot replace the last truthful outer receipt. Includes deterministic restart coverage and a real two-process regression. All required local gates passed on commit 2ef3592b.