### PR TITLE
fix(startup): keep splash failures from blocking launch

### DIFF
--- a/launcher/sugarsubstitute_launcher/update_orchestrator.py
+++ b/launcher/sugarsubstitute_launcher/update_orchestrator.py
@@ -51,6 +51,10 @@ from launcher.sugarsubstitute_launcher.update_policy import (
     decide_update_check,
 )
 from launcher.sugarsubstitute_launcher.update_state import LauncherUpdateState
+from launcher.sugarsubstitute_launcher.update_progress import (
+    LauncherUpdateProgress,
+    ResilientLauncherUpdateProgress,
+)
 from launcher.sugarsubstitute_launcher.update_rollback_reporting import (
     record_update_rollback,
 )
@@ -58,10 +62,6 @@ from launcher.sugarsubstitute_launcher.update_activity import (
     application_dependencies_activity,
     application_install_activity,
     launcher_update_activity,
-)
-from sugarsubstitute_shared.launch_splash import (
-    SplashActivity,
-    SplashSessionMessageError,
 )
 from sugarsubstitute_shared.launcher_update.models import LauncherBundleAsset
 from sugarsubstitute_shared.launcher_update.staging import LauncherBundleStager
@@ -78,19 +78,6 @@ _LOGGER = logging.getLogger(__name__)
 
 class LauncherMinimumVersionError(RuntimeError):
     """Report a required launcher update that cannot be completed safely."""
-
-
-class LauncherUpdateProgress(Protocol):
-    """Receive user-visible launcher update progress."""
-
-    def append_log(self, line: str) -> None:
-        """Append one update progress line."""
-
-    def start_activity(self, activity: SplashActivity) -> None:
-        """Start or replace one independently animated update activity."""
-
-    def clear_activity(self) -> None:
-        """Stop the current update activity."""
 
 
 class AppPayloadInstallerProtocol(Protocol):
@@ -146,23 +133,6 @@ class PreLaunchUpdateResult:
     attempted_version: str | None = None
 
 
-class NullLauncherUpdateProgress:
-    """Ignore update progress when no splash or UI surface is available."""
-
-    def append_log(self, line: str) -> None:
-        """Discard one progress line."""
-
-        _ = line
-
-    def start_activity(self, activity: SplashActivity) -> None:
-        """Discard one update activity."""
-
-        _ = activity
-
-    def clear_activity(self) -> None:
-        """Complete a no-op update activity clear."""
-
-
 class LauncherUpdateOrchestrator:
     """Coordinate manifest checks, payload install, and update state writes."""
 
@@ -196,7 +166,7 @@ class LauncherUpdateOrchestrator:
     ) -> PreLaunchUpdateResult:
         """Run a best-effort update before launching the installed app."""
 
-        progress = progress or NullLauncherUpdateProgress()
+        progress = ResilientLauncherUpdateProgress(progress)
         check_policy = decide_update_check(
             config=config,
             no_update_check=no_update_check,
@@ -290,23 +260,17 @@ class LauncherUpdateOrchestrator:
                 layout=layout,
                 successful_state=successful_state,
             )
-            _start_update_activity(
-                progress,
-                application_install_activity(manifest.version),
-            )
+            progress.start_activity(application_install_activity(manifest.version))
             try:
                 install_result = self._payload_installer.install(
                     layout=layout,
                     manifest=manifest,
                 )
-                _start_update_activity(
-                    progress,
-                    application_dependencies_activity(),
-                )
+                progress.start_activity(application_dependencies_activity())
                 activation.prepare_runtime()
                 self._runtime_reconciler.reconcile(layout=layout, progress=progress)
             except BaseException as error:
-                _clear_update_activity(progress)
+                progress.clear_activity()
                 activation.rollback()
                 self._rollback_reporter(
                     install_root=layout.root,
@@ -315,7 +279,7 @@ class LauncherUpdateOrchestrator:
                     error=error,
                 )
                 raise
-            _clear_update_activity(progress)
+            progress.clear_activity()
             progress.append_log(
                 launcher_text(
                     "Installed SugarSubstitute %1.",
@@ -378,10 +342,7 @@ class LauncherUpdateOrchestrator:
             if minimum_comparison < 0:
                 raise LauncherMinimumVersionError(error_message)
             raise RuntimeError(error_message)
-        _start_update_activity(
-            progress,
-            launcher_update_activity(manifest.version),
-        )
+        progress.start_activity(launcher_update_activity(manifest.version))
         try:
             request_path = self._launcher_bundle_stager.stage(
                 install_root=layout.root,
@@ -395,47 +356,20 @@ class LauncherUpdateOrchestrator:
                 ),
             )
         except (ConnectionError, TimeoutError, URLError):
-            _clear_update_activity(progress)
+            progress.clear_activity()
             raise
         except Exception as error:
-            _clear_update_activity(progress)
+            progress.clear_activity()
             if minimum_comparison < 0:
                 raise LauncherMinimumVersionError(
                     "The required launcher update could not be staged."
                 ) from error
             raise
-        _clear_update_activity(progress)
+        progress.clear_activity()
         progress.append_log(
             launcher_text("The launcher will restart to finish updating.")
         )
         return request_path
-
-
-def _start_update_activity(
-    progress: LauncherUpdateProgress,
-    activity: SplashActivity,
-) -> None:
-    """Start optional splash activity without changing update authority."""
-
-    try:
-        progress.start_activity(activity)
-    except (OSError, RuntimeError, SplashSessionMessageError) as error:
-        _LOGGER.warning(
-            "Could not start optional launcher update activity: %s",
-            type(error).__name__,
-        )
-
-
-def _clear_update_activity(progress: LauncherUpdateProgress) -> None:
-    """Clear optional splash activity without masking update outcomes."""
-
-    try:
-        progress.clear_activity()
-    except (OSError, RuntimeError, SplashSessionMessageError) as error:
-        _LOGGER.warning(
-            "Could not clear optional launcher update activity: %s",
-            type(error).__name__,
-        )
 
 
 def _utc_now() -> datetime:

--- a/launcher/sugarsubstitute_launcher/update_progress.py
+++ b/launcher/sugarsubstitute_launcher/update_progress.py
@@ -1,0 +1,93 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Keep optional launcher update feedback outside update authority."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import logging
+from typing import Protocol
+
+from sugarsubstitute_shared.launch_splash import SplashActivity
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LauncherUpdateProgress(Protocol):
+    """Receive user-visible launcher update progress."""
+
+    def append_log(self, line: str) -> None:
+        """Append one update progress line."""
+
+    def start_activity(self, activity: SplashActivity) -> None:
+        """Start or replace one independently animated update activity."""
+
+    def clear_activity(self) -> None:
+        """Stop the current update activity."""
+
+
+class ResilientLauncherUpdateProgress:
+    """Report update progress without granting the surface update authority."""
+
+    def __init__(self, target: LauncherUpdateProgress | None) -> None:
+        """Store the optional presentation target."""
+
+        self._target = target
+
+    def append_log(self, line: str) -> None:
+        """Append one line when the presentation target remains available."""
+
+        target = self._target
+        if target is None:
+            return
+        self._deliver("append_log", lambda: target.append_log(line))
+
+    def start_activity(self, activity: SplashActivity) -> None:
+        """Start one activity when the presentation target remains available."""
+
+        target = self._target
+        if target is None:
+            return
+        self._deliver("start_activity", lambda: target.start_activity(activity))
+
+    def clear_activity(self) -> None:
+        """Clear activity state when the presentation target remains available."""
+
+        target = self._target
+        if target is None:
+            return
+        self._deliver("clear_activity", target.clear_activity)
+
+    def _deliver(self, operation: str, delivery: Callable[[], None]) -> None:
+        """Contain presentation failure and preserve the update transaction."""
+
+        try:
+            delivery()
+        except Exception as error:
+            _LOGGER.warning(
+                "Launcher update progress delivery failed; continuing update | "
+                "operation=%s progress_type=%s error_type=%s error=%s",
+                operation,
+                type(self._target).__name__,
+                type(error).__name__,
+                error,
+                exc_info=True,
+            )
+
+
+__all__ = ["LauncherUpdateProgress", "ResilientLauncherUpdateProgress"]

--- a/tests/infrastructure/launcher/update_orchestration/test_progress_resilience.py
+++ b/tests/infrastructure/launcher/update_orchestration/test_progress_resilience.py
@@ -1,0 +1,173 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Prove optional update feedback cannot change launcher update outcomes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from launcher.sugarsubstitute_launcher.config import LauncherConfig
+from launcher.sugarsubstitute_launcher.install_layout import InstallLayout
+from launcher.sugarsubstitute_launcher.manifest import ReleaseAsset, ReleaseManifest
+from launcher.sugarsubstitute_launcher.payload_models import AppPayloadInstallResult
+from launcher.sugarsubstitute_launcher.runtime_models import RuntimeProvisioningResult
+from launcher.sugarsubstitute_launcher.update_orchestrator import (
+    LauncherUpdateOrchestrator,
+)
+from launcher.sugarsubstitute_launcher.update_state import LauncherUpdateState
+from sugarsubstitute_shared.launch_splash import SplashActivity
+
+
+def test_disconnected_splash_does_not_block_current_installed_app(
+    tmp_path: Path,
+) -> None:
+    """Launch the current app even when its splash stops acknowledging logs."""
+
+    layout = InstallLayout.from_root(tmp_path / "SugarSubstitute")
+    config = LauncherConfig.from_layout(layout=layout)
+    LauncherUpdateState(installed_app_version="0.4.0").save(layout.state_path)
+
+    result = LauncherUpdateOrchestrator().run(
+        layout=layout,
+        config=config,
+        release_source=_ReleaseSource(_manifest(version="0.4.0")),
+        no_update_check=False,
+        progress=_DisconnectedProgress(),
+    )
+
+    assert result.checked_manifest is True
+    assert result.installed_update is False
+    assert result.skipped_reason == "installed_current"
+    assert result.failure_reason is None
+
+
+def test_disconnected_splash_does_not_discard_prepared_update(
+    tmp_path: Path,
+) -> None:
+    """Return activation authority after update feedback delivery fails."""
+
+    layout = InstallLayout.from_root(tmp_path / "SugarSubstitute")
+    config = LauncherConfig.from_layout(layout=layout)
+
+    result = LauncherUpdateOrchestrator(
+        payload_installer=_PayloadInstaller(version="0.4.0"),
+        runtime_reconciler=_RuntimeReconciler(),
+    ).run(
+        layout=layout,
+        config=config,
+        release_source=_ReleaseSource(_manifest(version="0.4.0")),
+        no_update_check=False,
+        progress=_DisconnectedProgress(),
+    )
+
+    assert result.checked_manifest is True
+    assert result.installed_update is True
+    assert result.failure_reason is None
+    assert result.pending_activation is not None
+    assert result.attempted_version == "0.4.0"
+
+
+def _manifest(*, version: str) -> ReleaseManifest:
+    """Create one minimal stable release manifest."""
+
+    return ReleaseManifest(
+        schema_version=1,
+        channel="stable",
+        version=version,
+        minimum_launcher_version="0.1.0",
+        app=ReleaseAsset(
+            filename=f"SugarSubstitute-app-v{version}.zip",
+            url="file:///release.zip",
+            sha256="0" * 64,
+            size_bytes=1,
+        ),
+        launchers={},
+        installers={},
+    )
+
+
+class _ReleaseSource:
+    """Return one configured release manifest."""
+
+    def __init__(self, manifest: ReleaseManifest) -> None:
+        """Store the manifest."""
+
+        self._manifest = manifest
+
+    def load_manifest(self) -> ReleaseManifest:
+        """Return the configured manifest."""
+
+        return self._manifest
+
+
+class _PayloadInstaller:
+    """Return a successful payload installation."""
+
+    def __init__(self, *, version: str) -> None:
+        """Store the installed version."""
+
+        self._version = version
+
+    def install(
+        self,
+        *,
+        layout: InstallLayout,
+        manifest: ReleaseManifest,
+    ) -> AppPayloadInstallResult:
+        """Return the prepared payload result."""
+
+        _ = manifest
+        return AppPayloadInstallResult(version=self._version, app_dir=layout.app_dir)
+
+
+class _RuntimeReconciler:
+    """Complete runtime reconciliation without external work."""
+
+    def reconcile(
+        self,
+        *,
+        layout: InstallLayout,
+        progress: object,
+    ) -> RuntimeProvisioningResult:
+        """Return one prepared runtime result."""
+
+        _ = progress
+        return RuntimeProvisioningResult(
+            python_executable=layout.runtime_python,
+            requirements_path=layout.app_dir / "requirements.txt",
+        )
+
+
+class _DisconnectedProgress:
+    """Represent a splash host that rejects every progress message."""
+
+    def append_log(self, line: str) -> None:
+        """Reject one update log message."""
+
+        _ = line
+        raise OSError("splash disconnected")
+
+    def start_activity(self, activity: SplashActivity) -> None:
+        """Reject one update activity message."""
+
+        _ = activity
+        raise OSError("splash disconnected")
+
+    def clear_activity(self) -> None:
+        """Reject one activity-clear message."""
+
+        raise OSError("splash disconnected")


### PR DESCRIPTION
## Outcome
- keeps launcher update progress presentation outside update and launch authority
- allows a current app or prepared update to launch when the splash host stops acknowledging messages
- preserves structured diagnostics for failed progress delivery

## Proven regression
The staged 0.23.0.250 candidate passed clean install on Windows, macOS, and Linux, but historical Windows updates from 0.21.1, 0.21.2, and 0.22.0 all opened Repair because a splash log acknowledgement failed after the update. The new regression fails at that exact boundary before this change and proves both current-app and prepared-update outcomes survive a disconnected splash.

## Verification
- full format and lint
- strict mypy
- architecture and test governance
- full parallel suite
- all 93 isolated modules
- serial model-picker module