### PR TITLE
fix(startup): retry interrupted core nodepack downloads

### DIFF
--- a/substitute/infrastructure/comfy/pinned_nodepack_source.py
+++ b/substitute/infrastructure/comfy/pinned_nodepack_source.py
@@ -22,6 +22,8 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 import shutil
 import tempfile
+import time
+from urllib.error import URLError
 import urllib.request
 import zipfile
 
@@ -42,10 +44,16 @@ from substitute.infrastructure.comfy.nodepack_workspace_inspector import (
     tracked_source_files,
 )
 from substitute.shared.logging.logger import get_logger, log_info
+from substitute.shared.logging.logger import log_warning
+from sugarsubstitute_shared.startup_remote_access import (
+    is_startup_connectivity_failure,
+)
 from sugarsubstitute_shared.tls import SystemTrustTlsContext
 
 LogCallback = Callable[[str], None]
 _LOGGER = get_logger("infrastructure.comfy.pinned_nodepack_source")
+_DOWNLOAD_RETRY_DELAYS_SECONDS = (2.0, 5.0)
+_sleep = time.sleep
 
 
 class PinnedNodepackSourceInstaller:
@@ -76,6 +84,7 @@ class PinnedNodepackSourceInstaller:
             download_file(
                 archive_url=nodepack.fallback_archive_url,
                 target_path=archive_path,
+                on_log=on_log,
             )
             source_path = extract_single_root_zip(
                 archive_path=archive_path,
@@ -108,22 +117,61 @@ class PinnedNodepackSourceInstaller:
         )
 
 
-def download_file(*, archive_url: str, target_path: Path) -> None:
-    """Download one trusted source archive with an explicit timeout."""
+def download_file(
+    *,
+    archive_url: str,
+    target_path: Path,
+    on_log: LogCallback | None = None,
+) -> None:
+    """Download one trusted archive through bounded observable transport retries."""
 
     request = urllib.request.Request(
         archive_url,
         headers={"User-Agent": "SugarSubstitute"},
     )
-    with (
-        urllib.request.urlopen(  # noqa: S310 - manifest owns trusted HTTPS URLs.
-            request,
-            timeout=ARCHIVE_DOWNLOAD_TIMEOUT_SECONDS,
-            context=SystemTrustTlsContext.create(),
-        ) as response,
-        target_path.open("wb") as output,
-    ):
-        shutil.copyfileobj(response, output)
+    attempt_count = len(_DOWNLOAD_RETRY_DELAYS_SECONDS) + 1
+    for attempt in range(1, attempt_count + 1):
+        try:
+            with (
+                urllib.request.urlopen(  # noqa: S310 - trusted manifest URL.
+                    request,
+                    timeout=ARCHIVE_DOWNLOAD_TIMEOUT_SECONDS,
+                    context=SystemTrustTlsContext.create(),
+                ) as response,
+                target_path.open("wb") as output,
+            ):
+                shutil.copyfileobj(response, output)
+            return
+        except Exception as error:  # noqa: BLE001 - classify transport chain.
+            target_path.unlink(missing_ok=True)
+            if attempt >= attempt_count or not is_startup_connectivity_failure(error):
+                raise
+            retry_delay = _DOWNLOAD_RETRY_DELAYS_SECONDS[attempt - 1]
+            reason_type = _transport_reason_type(error)
+            retry_message = (
+                "[ComfyNodepacks] Source download was interrupted "
+                f"({reason_type}); retrying attempt {attempt + 1} of "
+                f"{attempt_count} in {retry_delay:g} seconds."
+            )
+            log_warning(
+                _LOGGER,
+                "Pinned nodepack source download interrupted; retrying",
+                attempt=attempt,
+                attempt_count=attempt_count,
+                reason_type=reason_type,
+                retry_delay_seconds=retry_delay,
+            )
+            if on_log is not None:
+                on_log(retry_message)
+            _sleep(retry_delay)
+
+
+def _transport_reason_type(error: BaseException) -> str:
+    """Return a diagnostic transport identity without exposing sensitive text."""
+
+    if isinstance(error, URLError) and isinstance(error.reason, BaseException):
+        return type(error.reason).__name__
+    return type(error).__name__
 
 
 def extract_single_root_zip(*, archive_path: Path, target_path: Path) -> Path:

--- a/tests/infrastructure/comfy/nodepacks/test_pinned_source.py
+++ b/tests/infrastructure/comfy/nodepacks/test_pinned_source.py
@@ -22,6 +22,7 @@ import io
 from pathlib import Path
 import shutil
 import ssl
+from urllib.error import URLError
 import zipfile
 
 import pytest
@@ -65,6 +66,143 @@ def test_pinned_archive_download_uses_system_trust_context(
 
     assert (tmp_path / "source.zip").read_bytes() == b"archive"
     assert observed == [tls_context]
+
+
+def test_pinned_archive_download_recovers_from_transient_transport_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Retry a bounded transport interruption and expose each retry to setup UI."""
+
+    attempts = 0
+    messages: list[str] = []
+    delays: list[float] = []
+
+    def flaky_urlopen(
+        _request: object,
+        *,
+        timeout: float,
+        context: ssl.SSLContext,
+    ) -> io.BytesIO:
+        """Fail twice like the release runner before returning the archive."""
+
+        del timeout, context
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise URLError(ConnectionResetError("simulated transport interruption"))
+        return io.BytesIO(b"archive")
+
+    monkeypatch.setattr("urllib.request.urlopen", flaky_urlopen)
+    monkeypatch.setattr(
+        pinned_nodepack_source,
+        "_DOWNLOAD_RETRY_DELAYS_SECONDS",
+        (0.25, 0.75),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        pinned_nodepack_source,
+        "_sleep",
+        delays.append,
+        raising=False,
+    )
+
+    pinned_nodepack_source.download_file(
+        archive_url="https://github.example/source.zip",
+        target_path=tmp_path / "source.zip",
+        on_log=messages.append,
+    )
+
+    assert attempts == 3
+    assert delays == [0.25, 0.75]
+    assert (tmp_path / "source.zip").read_bytes() == b"archive"
+    assert len(messages) == 2
+    assert all("retrying" in message.casefold() for message in messages)
+    assert "2 of 3" in messages[0]
+    assert "3 of 3" in messages[1]
+
+
+def test_pinned_archive_download_exhausts_a_bounded_retry_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Stop after the declared attempts and leave no partial archive behind."""
+
+    attempts = 0
+    messages: list[str] = []
+    delays: list[float] = []
+
+    def unavailable_urlopen(
+        _request: object,
+        *,
+        timeout: float,
+        context: ssl.SSLContext,
+    ) -> io.BytesIO:
+        """Represent a transport that remains unavailable for every attempt."""
+
+        del timeout, context
+        nonlocal attempts
+        attempts += 1
+        raise URLError(TimeoutError("simulated timeout"))
+
+    monkeypatch.setattr("urllib.request.urlopen", unavailable_urlopen)
+    monkeypatch.setattr(
+        pinned_nodepack_source,
+        "_DOWNLOAD_RETRY_DELAYS_SECONDS",
+        (0.25, 0.75),
+    )
+    monkeypatch.setattr(pinned_nodepack_source, "_sleep", delays.append)
+    target = tmp_path / "source.zip"
+
+    with pytest.raises(URLError):
+        pinned_nodepack_source.download_file(
+            archive_url="https://github.example/source.zip",
+            target_path=target,
+            on_log=messages.append,
+        )
+
+    assert attempts == 3
+    assert delays == [0.25, 0.75]
+    assert len(messages) == 2
+    assert not target.exists()
+
+
+def test_pinned_archive_download_does_not_retry_non_transport_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Propagate a local programming or filesystem failure without disguising it."""
+
+    attempts = 0
+    messages: list[str] = []
+    delays: list[float] = []
+
+    def invalid_urlopen(
+        _request: object,
+        *,
+        timeout: float,
+        context: ssl.SSLContext,
+    ) -> io.BytesIO:
+        """Raise a non-transport failure on the first request."""
+
+        del timeout, context
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("simulated local failure")
+
+    monkeypatch.setattr("urllib.request.urlopen", invalid_urlopen)
+    monkeypatch.setattr(pinned_nodepack_source, "_sleep", delays.append)
+
+    with pytest.raises(ValueError, match="simulated local failure"):
+        pinned_nodepack_source.download_file(
+            archive_url="https://github.example/source.zip",
+            target_path=tmp_path / "source.zip",
+            on_log=messages.append,
+        )
+
+    assert attempts == 1
+    assert delays == []
+    assert messages == []
 
 
 def test_fallback_install_is_registry_owned_and_preserves_mutable_data(

--- a/tests/shared/fluent_tooltips/test_persistence.py
+++ b/tests/shared/fluent_tooltips/test_persistence.py
@@ -260,7 +260,6 @@ def test_visible_tooltip_self_dismisses_when_leave_delivery_is_lost(
 
         wait_for_qt_condition(
             lambda: tooltip.hidden,
-            timeout_ms=500,
             description="tooltip self-dismissal after a lost leave event",
             state=lambda: {
                 "cursor": QCursor.pos(),
@@ -298,7 +297,6 @@ def test_real_tooltip_window_recovers_from_lost_leave_delivery_headlessly(
 
         wait_for_qt_condition(
             lambda: not tooltip.isVisible(),
-            timeout_ms=500,
             description="real QFluent tooltip self-dismissal",
         )
     finally:


### PR DESCRIPTION
## Outcome

- retries transient trusted core-nodepack archive interruptions with a bounded policy
- keeps setup visibly informed of retry attempt and delay
- preserves exact failure for non-transport errors and cleans partial archives

## Proven release failure

The 0.23.0.251 release qualified 29 jobs but the macOS 0.21.1 historical upgrade made one SugarCubes fallback request, received a transient URLError, retained the intentionally restored incompatible 0.11.0 copy, and terminated startup. This change guards that exact boundary.

## Verification

- full formatter
- full lint
- strict mypy
- architecture governance
- test governance
- full parallel tests
- all 93 isolated modules
- serial UI module
- direct real download and extraction of pinned SugarCubes 0.14.0