### PR TITLE
test(release): prove model downloads and updates survive restart

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -100,6 +100,24 @@ jobs:
           if-no-files-found: warn
           retention-days: 1
 
+      - name: Qualify model discovery and update lifecycle offscreen
+        shell: pwsh
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          .\.venv\Scripts\python.exe -m tools.qualify_empty_model_picker
+          .\.venv\Scripts\python.exe -m tools.qualify_model_update_lifecycle
+
+      - name: Upload model lifecycle qualification evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: model-lifecycle-qualification${{ inputs.artifact_suffix }}
+          path: |
+            build/qualification/empty-model-picker
+            build/qualification/model-update-lifecycle
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Upload Windows release inputs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/tests/qualification/release/workflow/test_packaging.py
+++ b/tests/qualification/release/workflow/test_packaging.py
@@ -272,6 +272,20 @@ def test_windows_release_build_qualifies_packaged_single_instance_behavior() -> 
     )
 
 
+def test_windows_release_build_qualifies_model_lifecycle() -> None:
+    """Block release inputs unless discovery and update lifecycles pass."""
+
+    build_text = workflow_text("release-build.yml")
+
+    assert "-m tools.qualify_empty_model_picker" in build_text
+    assert "-m tools.qualify_model_update_lifecycle" in build_text
+    assert "name: model-lifecycle-qualification${{ inputs.artifact_suffix }}" in (
+        build_text
+    )
+    assert "build/qualification/empty-model-picker" in build_text
+    assert "build/qualification/model-update-lifecycle" in build_text
+
+
 def test_linux_workflow_pins_appimagetool_and_builds_both_native_formats() -> None:
     """Linux packaging should verify its tool and publish AppImage plus Debian."""
 

--- a/tools/model_lifecycle_qualification/__init__.py
+++ b/tools/model_lifecycle_qualification/__init__.py
@@ -1,0 +1,33 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Expose synthetic boundaries shared by standalone model lifecycle probes."""
+
+from tools.model_lifecycle_qualification.catalog import (
+    FilesystemBackend,
+    new_filesystem_catalog,
+)
+from tools.model_lifecycle_qualification.runtime import (
+    runtime_evidence,
+    wait_until,
+)
+
+__all__ = [
+    "FilesystemBackend",
+    "new_filesystem_catalog",
+    "runtime_evidence",
+    "wait_until",
+]

--- a/tools/model_lifecycle_qualification/catalog.py
+++ b/tools/model_lifecycle_qualification/catalog.py
@@ -1,0 +1,170 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Project disposable model files through the production catalog service."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from substitute.application.model_metadata import ModelCatalogService
+from substitute.domain.model_metadata import (
+    BackendCapabilities,
+    BackendFingerprint,
+    BackendFingerprintJob,
+    BackendLocalPreview,
+    BackendModelCatalogEntry,
+    BackendModelFile,
+    BackendModelSource,
+    BackendSidecar,
+    FingerprintStatus,
+    JobStatus,
+    ModelMetadataCacheRecord,
+)
+
+
+class FilesystemBackend:
+    """Expose synthetic model files through the real catalog-service boundary."""
+
+    def __init__(self, model_root: Path) -> None:
+        """Bind backend discovery to one disposable model-kind folder."""
+
+        self._model_root = model_root
+        self.list_model_calls: list[tuple[tuple[str, ...], bool]] = []
+
+    def get_capabilities(self) -> BackendCapabilities | None:
+        """Return no optional capabilities for this catalog-only adapter."""
+
+        return None
+
+    def list_models(
+        self,
+        kinds: tuple[str, ...],
+        *,
+        refresh: bool = False,
+    ) -> tuple[BackendModelCatalogEntry, ...]:
+        """Project current synthetic files as Comfy-visible catalog entries."""
+
+        self.list_model_calls.append((kinds, refresh))
+        if "diffusion_models" not in kinds:
+            return ()
+        return tuple(
+            self._entry(path)
+            for path in sorted(self._model_root.rglob("*"))
+            if path.is_file()
+        )
+
+    def refresh_fingerprints(
+        self,
+        entries: tuple[BackendModelCatalogEntry, ...],
+    ) -> BackendFingerprintJob:
+        """Return a completed unused job for the catalog protocol."""
+
+        _ = entries
+        return BackendFingerprintJob(
+            job_id="unused",
+            status=JobStatus.COMPLETE,
+            entries=(),
+        )
+
+    def get_fingerprint_job(self, job_id: str) -> BackendFingerprintJob | None:
+        """Return no unused fingerprint job."""
+
+        _ = job_id
+        return None
+
+    def _entry(self, path: Path) -> BackendModelCatalogEntry:
+        """Build one exact backend catalog entry from a synthetic model file."""
+
+        relative_path = path.relative_to(self._model_root).as_posix()
+        payload = path.read_bytes()
+        digest = hashlib.sha256(payload).hexdigest()
+        return BackendModelCatalogEntry(
+            schema_version=1,
+            target_id=f"synthetic-{relative_path}",
+            kind="diffusion_models",
+            value=relative_path,
+            display_name=path.stem,
+            source=BackendModelSource(
+                root_id="synthetic-diffusion-models",
+                relative_path=relative_path,
+            ),
+            file=BackendModelFile(
+                extension=path.suffix,
+                size_bytes=len(payload),
+                modified_at="2026-09-13T00:00:00+00:00",
+                created_at=None,
+            ),
+            fingerprint=BackendFingerprint(
+                status=FingerprintStatus.READY,
+                sha256=digest,
+                source="synthetic-qualification",
+                computed_at="2026-09-13T00:00:00+00:00",
+                error=None,
+            ),
+            sidecar=BackendSidecar(
+                found=False,
+                model_id=None,
+                model_version_id=None,
+                sha256=None,
+                activation_text=None,
+                description=None,
+                base_model="Anima",
+                modified_at=None,
+            ),
+            local_preview=BackendLocalPreview(
+                available=False,
+                preview_id=None,
+                url=None,
+                source=None,
+                modified_at=None,
+                width=None,
+                height=None,
+            ),
+        )
+
+
+class _EmptyMetadataCatalog:
+    """Return no optional provider metadata around filesystem-backed models."""
+
+    def list_records(
+        self,
+        *,
+        kind: str | None = None,
+    ) -> tuple[ModelMetadataCacheRecord, ...]:
+        """Return an empty metadata projection for every model kind."""
+
+        _ = kind
+        return ()
+
+
+def new_filesystem_catalog(
+    model_root: Path,
+) -> tuple[ModelCatalogService, FilesystemBackend]:
+    """Construct fresh production catalog ownership for one synthetic root."""
+
+    backend = FilesystemBackend(model_root)
+    return (
+        ModelCatalogService(
+            backend=backend,
+            metadata_catalog=_EmptyMetadataCatalog(),
+        ),
+        backend,
+    )
+
+
+__all__ = ["FilesystemBackend", "new_filesystem_catalog"]

--- a/tools/model_lifecycle_qualification/runtime.py
+++ b/tools/model_lifecycle_qualification/runtime.py
@@ -1,0 +1,76 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Own shared runtime evidence and semantic waiting for model probes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+import sys
+
+from PySide6.QtCore import QEventLoop, QTimer
+from PySide6.QtWidgets import QApplication
+
+import substitute
+from substitute._version import __version__
+import sugarsubstitute_shared
+
+
+def runtime_evidence() -> dict[str, str]:
+    """Return exact runtime and source provenance for durable evidence."""
+
+    return {
+        "application_version": __version__,
+        "python_executable": str(Path(sys.executable).resolve()),
+        "substitute_source": str(Path(substitute.__file__ or "").resolve()),
+        "shared_source": str(Path(sugarsubstitute_shared.__file__ or "").resolve()),
+    }
+
+
+def wait_until(
+    application: QApplication,
+    condition: Callable[[], bool],
+    description: str,
+) -> None:
+    """Process Qt work until an observable condition or a hard deadline."""
+
+    if condition():
+        return
+    event_loop = QEventLoop()
+    probe = QTimer()
+    probe.setInterval(10)
+
+    def observe() -> None:
+        """Finish when the requested production state becomes observable."""
+
+        if condition():
+            event_loop.quit()
+
+    probe.timeout.connect(observe)
+    deadline = QTimer()
+    deadline.setSingleShot(True)
+    deadline.timeout.connect(event_loop.quit)
+    probe.start()
+    deadline.start(5_000)
+    event_loop.exec()
+    probe.stop()
+    if not condition():
+        raise TimeoutError(f"Timed out waiting for {description}.")
+    application.processEvents()
+
+
+__all__ = ["runtime_evidence", "wait_until"]

--- a/tools/qualify_empty_model_picker.py
+++ b/tools/qualify_empty_model_picker.py
@@ -26,12 +26,10 @@ from pathlib import Path
 import tempfile
 from typing import cast
 
-from PySide6.QtCore import QEventLoop, QTimer
 from PySide6.QtWidgets import QApplication, QPushButton, QVBoxLayout, QWidget
 
 from substitute.application.model_metadata import (
-    ModelCatalogItem,
-    ModelCatalogSnapshot,
+    ModelCatalogService,
     ModelChoiceCatalogIndex,
     RichChoiceResolver,
 )
@@ -75,41 +73,14 @@ from sugarsubstitute_shared.model_acquisition import (
     CancellationProbe,
 )
 from sugarsubstitute_shared.model_discovery import ModelArtifactKind
+from tools.model_lifecycle_qualification import (
+    new_filesystem_catalog,
+    runtime_evidence,
+    wait_until,
+)
 
 
 _PAYLOAD = b"synthetic model qualification payload"
-
-
-class _Catalog:
-    """Expose one authoritative warm empty catalog and record refreshes."""
-
-    def __init__(self) -> None:
-        """Initialize an empty catalog with observable refresh state."""
-
-        self.invalidated: list[str | None] = []
-        self.refreshed: list[str] = []
-
-    def cached_snapshot_nowait(self, kind: str) -> ModelCatalogSnapshot:
-        """Return a warm empty snapshot for the requested model kind."""
-
-        return ModelCatalogSnapshot(kind=kind, items=(), generation=1)
-
-    def invalidate(self, kind: str | None = None) -> None:
-        """Record exact catalog invalidation after acquisition."""
-
-        self.invalidated.append(kind)
-
-    def list_models(self, kind: str) -> tuple[ModelCatalogItem, ...]:
-        """Return the same authoritative empty catalog synchronously."""
-
-        _ = kind
-        return ()
-
-    def refresh_models(self, kind: str) -> tuple[ModelCatalogItem, ...]:
-        """Record the authoritative backend refresh before field selection."""
-
-        self.refreshed.append(kind)
-        return ()
 
 
 class _DestinationPolicy(ModelDestinationPolicy):
@@ -254,32 +225,41 @@ def main(argv: Sequence[str] | None = None) -> int:
     artifact_dir = Path("build/qualification/empty-model-picker").resolve()
     artifact_dir.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="SugarSubstitute-model-picker-") as root:
-        model_root = Path(root) / "models" / "diffusion_models"
+        model_root = Path(root) / "models"
+        public_root = model_root / "public" / "diffusion_models"
+        protected_root = model_root / "protected" / "diffusion_models"
         public = _qualify_flow(
             application,
-            destination=model_root,
+            destination=public_root,
             access=ModelSuggestionAccess.PUBLIC,
             file_name="public.safetensors",
             screenshot_path=artifact_dir / "empty-model-picker.png",
         )
         protected = _qualify_flow(
             application,
-            destination=model_root,
+            destination=protected_root,
             access=ModelSuggestionAccess.API_KEY_REQUIRED,
             file_name="protected.safetensors",
             screenshot_path=None,
         )
-        persisted = sorted(
-            path.relative_to(model_root).as_posix()
-            for path in model_root.rglob("*.safetensors")
-        )
-        if persisted != ["Anima/protected.safetensors", "Anima/public.safetensors"]:
-            raise AssertionError(f"Synthetic model persistence failed: {persisted}")
+        restarted = {
+            "public": _qualify_restart(
+                application,
+                destination=public_root,
+                expected_values=("Anima/public.safetensors",),
+            ),
+            "protected": _qualify_restart(
+                application,
+                destination=protected_root,
+                expected_values=("Anima/protected.safetensors",),
+            ),
+        }
     evidence = {
         "result": "passed",
         "public_flow": public,
         "protected_flow": protected,
-        "persisted_after_surface_teardown": persisted,
+        "persisted_after_application_restart": restarted,
+        "runtime": runtime_evidence(),
         "external_network_used": False,
     }
     report_path = artifact_dir / "empty-model-picker-qualification.json"
@@ -301,7 +281,9 @@ def _qualify_flow(
 ) -> dict[str, object]:
     """Drive one actual field, modal, credential decision, and catalog refresh."""
 
-    catalog = _Catalog()
+    catalog, backend = new_filesystem_catalog(destination)
+    if catalog.list_models("diffusion_models"):
+        raise AssertionError("Qualification model catalog was not initially empty.")
     credential = _CredentialHandler()
     provider = _SyntheticProvider(access=access, file_name=file_name)
     service = ModelSuggestionService(
@@ -326,7 +308,7 @@ def _qualify_flow(
     )
     layout.addWidget(picker)
     root.show()
-    _wait_until(application, picker.is_empty_action_visible, "empty action visibility")
+    wait_until(application, picker.is_empty_action_visible, "empty action visibility")
     button = picker.findChild(QPushButton, "modelPickerEmptyActionButton")
     if button is None or button.size() != picker.contentsRect().size():
         raise AssertionError(
@@ -342,7 +324,7 @@ def _qualify_flow(
     modal = root.findChild(ModelDiscoveryModal)
     if modal is None or not modal.isVisible():
         raise AssertionError("The empty-picker action did not open its modal.")
-    _wait_until(application, lambda: not controller.running, "suggestion plan")
+    wait_until(application, lambda: not controller.running, "suggestion plan")
     if credential.prompt_count != 0:
         raise AssertionError("Credentials were requested before explicit selection.")
     card = modal.findChild(ModelSuggestionCard)
@@ -351,7 +333,7 @@ def _qualify_flow(
     card.portrait.checkbox.click()
     modal.download_button.click()
     expected_value = f"Anima/{file_name}"
-    _wait_until(
+    wait_until(
         application,
         lambda: picker.currentText() == expected_value and not controller.running,
         "verified model selection",
@@ -359,15 +341,19 @@ def _qualify_flow(
     expected_prompts = 1 if access is ModelSuggestionAccess.API_KEY_REQUIRED else 0
     if credential.prompt_count != expected_prompts:
         raise AssertionError("Credential prompt policy disagreed with model access.")
-    if (
-        catalog.invalidated != ["diffusion_models"]
-        or not catalog.refreshed
-        or catalog.refreshed[-1] != "diffusion_models"
-    ):
+    discovered_values = tuple(
+        item.backend_value for item in catalog.list_models("diffusion_models")
+    )
+    if discovered_values != (expected_value,):
         raise AssertionError(
-            "Catalog was not refreshed before publishing selection: "
-            f"invalidated={catalog.invalidated}, refreshed={catalog.refreshed}."
+            "The refreshed production catalog did not expose the downloaded model: "
+            f"{discovered_values}."
         )
+    refresh_calls = tuple(
+        (kinds, refresh) for kinds, refresh in backend.list_model_calls if refresh
+    )
+    if refresh_calls != ((("diffusion_models",), True),):
+        raise AssertionError(f"Catalog refresh routing was not exact: {refresh_calls}.")
     if picker.is_empty_action_visible():
         raise AssertionError("Downloaded selection left the empty action visible.")
     controller.close()
@@ -379,16 +365,72 @@ def _qualify_flow(
         "credential_prompts_before_selection": 0,
         "credential_prompts_after_selection": credential.prompt_count,
         "selected_backend_value": expected_value,
-        "catalog_refresh": catalog.refreshed,
+        "catalog_values_after_refresh": discovered_values,
+        "backend_refresh_calls": refresh_calls,
         "same_size_action": True,
     }
+
+
+def _qualify_restart(
+    application: QApplication,
+    *,
+    destination: Path,
+    expected_values: tuple[str, ...],
+) -> dict[str, object]:
+    """Reconstruct catalog and picker owners and prove durable rediscovery."""
+
+    catalog, backend = new_filesystem_catalog(destination)
+    discovered_values = tuple(
+        item.backend_value for item in catalog.list_models("diffusion_models")
+    )
+    if discovered_values != expected_values:
+        raise AssertionError(
+            "A fresh production catalog did not rediscover downloaded models: "
+            f"expected={expected_values}, actual={discovered_values}."
+        )
+    root = QWidget()
+    root.resize(420, 72)
+    layout = QVBoxLayout(root)
+    picker = _build_empty_picker(
+        root,
+        catalog=catalog,
+        request=_reject_discovery_request,
+        current_value=expected_values[0],
+    )
+    layout.addWidget(picker)
+    root.show()
+    application.processEvents()
+    if picker.is_empty_action_visible():
+        raise AssertionError("A freshly reconstructed populated picker stayed empty.")
+    if picker.currentText() != expected_values[0]:
+        raise AssertionError("A freshly reconstructed picker lost its selected value.")
+    root.close()
+    root.deleteLater()
+    application.processEvents()
+    return {
+        "catalog_values": discovered_values,
+        "picker_value": expected_values[0],
+        "empty_action_visible": False,
+        "backend_load_calls": backend.list_model_calls,
+    }
+
+
+def _reject_discovery_request(
+    context: ModelSuggestionContext,
+    receiver: Callable[[str], None],
+) -> None:
+    """Fail if a reconstructed populated picker exposes empty discovery."""
+
+    _ = (context, receiver)
+    raise AssertionError("A populated picker exposed empty-model discovery.")
 
 
 def _build_empty_picker(
     parent: QWidget,
     *,
-    catalog: _Catalog,
+    catalog: ModelCatalogService,
     request: Callable[[ModelSuggestionContext, Callable[[str], None]], None],
+    current_value: str = "",
 ) -> ModelPickerField:
     """Build the production SimpleLoadAnima field from its real empty identity."""
 
@@ -403,7 +445,7 @@ def _build_empty_picker(
             field_behavior=FieldBehavior(field_key="diffusion_model"),
             node_name="models",
             key="diffusion_model",
-            value="",
+            value=current_value,
             node_type="SimpleSyrup.SimpleLoadAnima",
             field_type="LIST",
             field_info=[[], {}],
@@ -417,7 +459,7 @@ def _build_empty_picker(
             field_behavior=FieldBehavior(field_key="diffusion_model"),
             node_name="models",
             key="diffusion_model",
-            value="",
+            value=current_value,
             field_meta={},
             model_choice_snapshot=snapshot,
             empty_model_picker_action=request,
@@ -449,38 +491,6 @@ def _context() -> ModelSuggestionContext:
         artifact_kind=ModelArtifactKind.DIFFUSION_MODELS,
         family_id=ModelFamilyId.ANIMA,
     )
-
-
-def _wait_until(
-    application: QApplication,
-    condition: Callable[[], bool],
-    description: str,
-) -> None:
-    """Process Qt work until an observable condition or a hard deadline."""
-
-    if condition():
-        return
-    event_loop = QEventLoop()
-    probe = QTimer()
-    probe.setInterval(10)
-
-    def observe() -> None:
-        """Finish when the requested production state becomes observable."""
-
-        if condition():
-            event_loop.quit()
-
-    probe.timeout.connect(observe)
-    deadline = QTimer()
-    deadline.setSingleShot(True)
-    deadline.timeout.connect(event_loop.quit)
-    probe.start()
-    deadline.start(5_000)
-    event_loop.exec()
-    probe.stop()
-    if not condition():
-        raise TimeoutError(f"Timed out waiting for {description}.")
-    application.processEvents()
 
 
 if __name__ == "__main__":

--- a/tools/qualify_model_update_lifecycle.py
+++ b/tools/qualify_model_update_lifecycle.py
@@ -1,0 +1,341 @@
+#    SugarSubstitute - The desktop native Qt front-end for ComfyUI
+#    Copyright (C) 2026  Artificial Sweetener and contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Qualify installed model-update discovery and persistence without pytest."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+from typing import cast
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QApplication, QCheckBox, QWidget
+
+from substitute.infrastructure.model_updates import FileModelUsageRepository
+from substitute.presentation.model_updates import ModelUpdateModal
+from substitute.presentation.shell.model_update_notification_controller import (
+    ModelUpdateNotificationController,
+)
+from sugarsubstitute_shared.model_acquisition import ModelAcquisitionService
+from sugarsubstitute_shared.model_discovery import (
+    CivitaiDiscoveryClient,
+    ModelArtifactKind,
+)
+from sugarsubstitute_shared.model_updates import (
+    CivitaiCompatibleUpdateGateway,
+    ModelUpdateAcquisitionService,
+    ModelUpdatePreferences,
+    ModelUpdateProposal,
+    ModelUpdateService,
+)
+from tools.model_lifecycle_qualification import runtime_evidence, wait_until
+
+_CURRENT_PAYLOAD = b"synthetic current model"
+_UPDATE_PAYLOAD = b"synthetic compatible model update"
+_CURRENT_HASH = hashlib.sha256(_CURRENT_PAYLOAD).hexdigest()
+_UPDATE_HASH = hashlib.sha256(_UPDATE_PAYLOAD).hexdigest()
+_CLOCK = datetime(2026, 9, 13, tzinfo=UTC)
+
+
+class _Preferences:
+    """Expose explicit model-update consent to the production controller."""
+
+    def load_preferences(self) -> object:
+        """Return the enabled application preference aggregate."""
+
+        return SimpleNamespace(model_update_notifications_enabled=True)
+
+
+class _Stream:
+    """Expose a bounded in-memory response through the acquisition port."""
+
+    def __init__(self, payload: bytes) -> None:
+        """Store unread synthetic response bytes."""
+
+        self._payload = payload
+        self.content_length = len(payload)
+
+    def read(self, size: int) -> bytes:
+        """Read at most one requested response chunk."""
+
+        chunk, self._payload = self._payload[:size], self._payload[size:]
+        return chunk
+
+    def close(self) -> None:
+        """Release the synthetic stream."""
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run model usage, restart, review, acquisition, and rehydration proof."""
+
+    _ = argv
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    application = cast(QApplication, QApplication.instance() or QApplication([]))
+    artifact_dir = Path("build/qualification/model-update-lifecycle").resolve()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="SugarSubstitute-model-update-") as root:
+        evidence = _qualify_lifecycle(
+            application,
+            root=Path(root),
+            screenshot_path=artifact_dir / "model-update-modal.png",
+        )
+    report_path = artifact_dir / "model-update-lifecycle-qualification.json"
+    report_path.write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(report_path)
+    return 0
+
+
+def _qualify_lifecycle(
+    application: QApplication,
+    *,
+    root: Path,
+    screenshot_path: Path,
+) -> dict[str, object]:
+    """Exercise production owners across two explicit application restarts."""
+
+    model_root = root / "models"
+    settings_root = root / "settings"
+    current_path = model_root / "checkpoints" / "current.safetensors"
+    current_path.parent.mkdir(parents=True)
+    current_path.write_bytes(_CURRENT_PAYLOAD)
+
+    initial_repository = FileModelUsageRepository(settings_root)
+    _new_update_service(initial_repository).record_usage(
+        sha256=_CURRENT_HASH,
+        path=current_path,
+        artifact_kind=ModelArtifactKind.CHECKPOINTS,
+        model_id=314,
+        version_id=10,
+        base_model="SDXL 1.0",
+    )
+    initial_records = initial_repository.load()
+    if len(initial_records) != 1 or initial_records[0].usage_count != 1:
+        raise AssertionError("Generate-derived model usage was not persisted.")
+
+    restarted_repository = FileModelUsageRepository(settings_root)
+    restarted_service = _new_update_service(restarted_repository)
+    restarted_proposals = restarted_service.check_updates(
+        ModelUpdatePreferences(enabled=True)
+    )
+    if len(restarted_proposals) != 1:
+        raise AssertionError(
+            "A fresh update service did not rediscover the compatible update."
+        )
+    proposal = restarted_proposals[0]
+    if proposal.current.path != current_path or proposal.candidate.version_id != 20:
+        raise AssertionError(
+            "Restarted update identity disagreed with persisted usage."
+        )
+
+    modal_evidence: dict[str, object] = {}
+
+    def choose_update(
+        proposals: Sequence[ModelUpdateProposal],
+        destination: Path,
+        parent: QWidget,
+    ) -> tuple[str, ...]:
+        """Drive the production modal from unchecked review to explicit consent."""
+
+        modal = ModelUpdateModal(
+            proposals=proposals,
+            model_root=destination,
+            parent=parent,
+        )
+        checks = modal.findChildren(QCheckBox)
+        if len(checks) != 1 or checks[0].isChecked():
+            raise AssertionError(
+                "Update review did not begin with one unchecked model."
+            )
+        modal_evidence["initially_unchecked"] = True
+
+        def accept_selected() -> None:
+            """Capture the visible modal and explicitly select its update."""
+
+            if not modal.grab().save(str(screenshot_path), "PNG"):
+                raise OSError(
+                    f"Could not save update modal evidence: {screenshot_path}"
+                )
+            checks[0].setChecked(True)
+            if not modal.download_button.isEnabled():
+                raise AssertionError("Explicit selection did not enable download.")
+            modal.download_button.click()
+
+        QTimer.singleShot(0, accept_selected)
+        try:
+            selected = modal.choose_updates()
+        finally:
+            modal.deleteLater()
+        if len(selected) != 1:
+            raise AssertionError(
+                "Production update review did not return one selection."
+            )
+        modal_evidence["explicit_selection_count"] = len(selected)
+        return selected
+
+    feedback: list[tuple[str, str]] = []
+    parent = QWidget()
+    controller = ModelUpdateNotificationController(
+        parent_widget=parent,
+        preferences=_Preferences(),
+        updates=restarted_service,
+        model_root=model_root,
+        acquisition=ModelUpdateAcquisitionService(
+            model_root=model_root,
+            acquisition=ModelAcquisitionService(
+                allowed_roots=(model_root,),
+                stream_opener=lambda _url, _headers, _timeout: _Stream(_UPDATE_PAYLOAD),
+            ),
+        ),
+        chooser=choose_update,
+        feedback=lambda severity, message: feedback.append((severity, message)),
+    )
+    if not controller.check_on_focus():
+        raise AssertionError("Enabled update notification check did not start.")
+    wait_until(
+        application,
+        lambda: not controller.running and bool(feedback),
+        "model update acquisition",
+    )
+    controller.close()
+    parent.deleteLater()
+    application.processEvents()
+    if feedback[-1][0] != "success":
+        raise AssertionError(f"Update acquisition did not report success: {feedback}.")
+
+    updated_path = model_root / "checkpoints" / "updated.safetensors"
+    if current_path.read_bytes() != _CURRENT_PAYLOAD:
+        raise AssertionError("Side-by-side update modified the current model.")
+    if updated_path.read_bytes() != _UPDATE_PAYLOAD:
+        raise AssertionError("Downloaded update bytes failed verification.")
+
+    second_restart_repository = FileModelUsageRepository(settings_root)
+    second_restart_records = second_restart_repository.load()
+    if second_restart_records != initial_records:
+        raise AssertionError("Update acquisition changed authoritative usage state.")
+    second_restart_proposals = _new_update_service(
+        second_restart_repository
+    ).check_updates(ModelUpdatePreferences(enabled=True))
+    if len(second_restart_proposals) != 1:
+        raise AssertionError("Update availability disappeared after a second restart.")
+
+    return {
+        "result": "passed",
+        "external_network_used": False,
+        "usage_persisted_before_restart": True,
+        "update_available_after_first_restart": True,
+        "update_available_after_second_restart": True,
+        "current_model_preserved": True,
+        "updated_model_installed_beside_current": True,
+        "current_sha256": hashlib.sha256(current_path.read_bytes()).hexdigest(),
+        "updated_sha256": hashlib.sha256(updated_path.read_bytes()).hexdigest(),
+        "candidate_version_id": proposal.candidate.version_id,
+        "modal": modal_evidence,
+        "feedback_severity": feedback[-1][0],
+        "runtime": runtime_evidence(),
+    }
+
+
+def _new_update_service(repository: FileModelUsageRepository) -> ModelUpdateService:
+    """Construct fresh production update ownership over persisted usage."""
+
+    return ModelUpdateService(
+        usage=repository,
+        updates=CivitaiCompatibleUpdateGateway(
+            CivitaiDiscoveryClient(fetch_json=_fetch_update_payload)
+        ),
+        clock=lambda: _CLOCK,
+    )
+
+
+def _fetch_update_payload(
+    url: str,
+    *,
+    headers: object | None = None,
+    timeout: float = 0.0,
+) -> dict[str, object]:
+    """Return a deterministic provider response without external network access."""
+
+    _ = (url, headers, timeout)
+    return {
+        "id": 314,
+        "name": "Synthetic Update Model",
+        "type": "Checkpoint",
+        "nsfw": False,
+        "creator": {"username": "Synthetic"},
+        "modelVersions": [
+            _provider_version(
+                version_id=20,
+                name="Updated",
+                file_name="updated.safetensors",
+                sha256=_UPDATE_HASH,
+                size_bytes=len(_UPDATE_PAYLOAD),
+            ),
+            _provider_version(
+                version_id=10,
+                name="Current",
+                file_name="current.safetensors",
+                sha256=_CURRENT_HASH,
+                size_bytes=len(_CURRENT_PAYLOAD),
+            ),
+        ],
+    }
+
+
+def _provider_version(
+    *,
+    version_id: int,
+    name: str,
+    file_name: str,
+    sha256: str,
+    size_bytes: int,
+) -> dict[str, object]:
+    """Build one public compatible SafeTensor provider version."""
+
+    return {
+        "id": version_id,
+        "name": name,
+        "baseModel": "SDXL 1.0",
+        "availability": "Public",
+        "images": [],
+        "files": [
+            {
+                "name": file_name,
+                "downloadUrl": (
+                    f"https://civitai.com/api/download/models/{version_id}"
+                ),
+                "sizeKB": size_bytes / 1024,
+                "primary": True,
+                "metadata": {"format": "SafeTensor"},
+                "hashes": {"SHA256": sha256},
+                "pickleScanResult": "Success",
+                "virusScanResult": "Success",
+            }
+        ],
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Outcome
- release builds now exercise the production empty-model picker, verified acquisition, catalog refresh, and fresh-instance rediscovery
- release builds now exercise persisted model usage, update review, side-by-side verified acquisition, and update availability across fresh instances
- qualification reports include exact application, Python, and packaged-source provenance

## Local verification
- full format, lint, and strict typing gates
- architecture and test-governance gates
- full parallel suite
- all 93 isolated test modules
- serial test module
- both standalone qualifiers against the public 0.23.0.252 Canary installation